### PR TITLE
Fix support for ignorecase regex in webhook url

### DIFF
--- a/kippo/octocat/urls.py
+++ b/kippo/octocat/urls.py
@@ -4,7 +4,12 @@ from . import views
 
 urlpatterns = [
     url(
-        '(?i)webhook/(?P<organization_id>[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12})/$',
+        'webhook/(?P<organization_id>[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12})/$',
+        views.webhook,
+        name='octocat_webhook'
+    ),
+    url(
+        'webhook/(?P<organization_id>[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89aAbB][A-F0-9]{3}-[A-F0-9]{12})/$',
         views.webhook,
         name='octocat_webhook'
     ),


### PR DESCRIPTION
- remove problem '(?i)' component from url regex
- adding alternative regex to handle ignore case case
See:
https://stackoverflow.com/questions/10570463/django-url-reverse-non-reversible-reg-exp-portion