### PR TITLE
Update projects status display to accept varying KippoTaskStatus.effort_dates per task

### DIFF
--- a/kippo/common/tests.py
+++ b/kippo/common/tests.py
@@ -105,7 +105,7 @@ def setup_basic_project(organization=None, repository_name='Hello-World'):
 
     github_repo = GithubRepository(
         organization=organization,
-        name='Hello-World',
+        name=repository_name,
         api_url=f'https://api.github.com/repos/{organization.github_organization_name}/{repository_name}',
         html_url=f'https://github.com/repos/{organization.github_organization_name}/{repository_name}',
         created_by=user,

--- a/kippo/projects/tests/test_views.py
+++ b/kippo/projects/tests/test_views.py
@@ -2,9 +2,12 @@ from http import HTTPStatus
 
 from django.test import Client, TestCase
 from django.conf import settings
+from django.utils import timezone
 
 from common.tests import DEFAULT_FIXTURES, setup_basic_project
 from accounts.models import KippoUser, KippoOrganization, OrganizationMembership
+from tasks.models import KippoTask, KippoTaskStatus
+from ..views import _get_active_taskstatus_from_projects
 
 
 class SetOrganizationTestCase(TestCase):
@@ -79,3 +82,158 @@ class SetOrganizationTestCase(TestCase):
 
         actual = self.client.session.get('organization_id', None)
         self.assertTrue(actual is None)
+
+
+class ViewsHelperFunctionsTestCase(TestCase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created['KippoOrganization']
+        self.user = created['KippoUser']
+        self.project = created['KippoProject']
+        self.repository = created['GithubRepository']
+        self.task1 = created['KippoTask']
+        self.github_manager = KippoUser.objects.get(username='github-manager')
+
+        # default columnset done name
+        self.done_column_name = 'done'
+
+        # create task2
+        self.task2 = KippoTask(
+            title='task2',
+            category='test category',
+            project=self.project,
+            assignee=self.user,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+            github_issue_html_url=f'https://github.com/repos/{self.organization.github_organization_name}/{self.repository.name}/issues/2',
+            github_issue_api_url=f"https://api.github.com/repos/{self.organization.github_organization_name}/{self.repository.name}/issues/2",
+        )
+        self.task2.save()
+
+        # create task3
+        self.task3 = KippoTask(
+            title='task3',
+            category='test category',
+            project=self.project,
+            assignee=self.user,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+            github_issue_html_url=f'https://github.com/repos/{self.organization.github_organization_name}/{self.repository.name}/issues/3',
+            github_issue_api_url=f"https://api.github.com/repos/{self.organization.github_organization_name}/{self.repository.name}/issues/3",
+        )
+        self.task3.save()
+
+        self.firstdate = timezone.datetime(2019, 8, 14).date()
+        # create KippoTaskStatus objects
+        # create existing taskstatus
+        self.task1_status1 = KippoTaskStatus(
+            task=self.task1,
+            state='open',
+            effort_date=self.firstdate,
+            estimate_days=3,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.task1_status1.save()
+
+        self.task1_seconddate = timezone.datetime(2019, 8, 17).date()
+        self.task1_status2 = KippoTaskStatus(
+            task=self.task1,
+            state='open',
+            effort_date=self.task1_seconddate,
+            estimate_days=3,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.task1_status2.save()
+
+        self.task2_status1 = KippoTaskStatus(
+            task=self.task2,
+            state='open',
+            effort_date=self.firstdate,
+            estimate_days=3,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.task2_status1.save()
+
+        self.task2_seconddate = timezone.datetime(2019, 8, 19).date()
+        self.task2_status2 = KippoTaskStatus(
+            task=self.task2,
+            state='open',
+            effort_date=self.task2_seconddate,
+            estimate_days=3,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.task2_status2.save()
+
+        # task3 taskstatus
+        self.task3_status1 = KippoTaskStatus(
+            task=self.task3,
+            state=self.done_column_name,
+            effort_date=self.firstdate,
+            estimate_days=3,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.task3_status1.save()
+
+    def test__get_active_taskstatus_from_projects__without_max_effort_date(self):
+        projects = [self.project]
+        results, has_estimates = _get_active_taskstatus_from_projects(
+            projects=projects,
+        )
+        self.assertTrue(len(results) == 2)
+
+        actual_tasks = [s.task for s in results]
+        self.assertTrue(
+            self.task3 not in actual_tasks,
+            f'done task({self.task3}) should not be returned but is: {results}'
+        )
+
+        expected_tasks = [self.task1, self.task2]
+        self.assertTrue(all(t in expected_tasks for t in actual_tasks))
+        self.assertTrue(all(t in actual_tasks for t in expected_tasks))
+
+        task1_tested = False
+        task2_tested = False
+        for taskstatus in results:
+            if taskstatus.task == self.task1:
+                self.assertTrue(taskstatus.effort_date == self.task1_seconddate)
+                task1_tested = True
+            elif taskstatus.task == self.task2:
+                self.assertTrue(taskstatus.effort_date == self.task2_seconddate)
+                task2_tested = True
+        self.assertTrue(all([task1_tested, task2_tested]))
+
+    def test__get_active_taskstatus_from_projects__with_max_effort_date(self):
+        projects = [self.project]
+        max_effort_date = timezone.datetime(2019, 8, 15).date()
+        results, has_estimates = _get_active_taskstatus_from_projects(
+            projects=projects,
+            max_effort_date=max_effort_date
+        )
+        self.assertTrue(len(results) == 2)
+        actual_tasks = [s.task for s in results]
+        self.assertTrue(
+            self.task3 not in actual_tasks,
+            f'done task({self.task3}) should not be returned but is: {results}'
+        )
+
+        expected_tasks = [self.task1, self.task2]
+        self.assertTrue(all(t in expected_tasks for t in actual_tasks))
+        self.assertTrue(all(t in actual_tasks for t in expected_tasks))
+
+        task1_tested = False
+        task2_tested = False
+        for taskstatus in results:
+            if taskstatus.task == self.task1:
+                self.assertTrue(taskstatus.effort_date == self.firstdate)
+                task1_tested = True
+            elif taskstatus.task == self.task2:
+                self.assertTrue(taskstatus.effort_date == self.firstdate)
+                task2_tested = True
+        self.assertTrue(all([task1_tested, task2_tested]))

--- a/kippo/projects/views.py
+++ b/kippo/projects/views.py
@@ -96,7 +96,9 @@ def view_inprogress_projects_overview(request: HttpRequest) -> HttpResponse:
     return render(request, 'projects/view_inprogress_projects_status_overview.html', context)
 
 
-def _get_active_taskstatus_from_projects(projects: List[KippoProject], max_effort_date: Optional[timezone.datetime.date] = None) -> Tuple[List[KippoTaskStatus], bool]:
+def _get_active_taskstatus_from_projects(
+        projects: List[KippoProject],
+        max_effort_date: Optional[timezone.datetime.date] = None) -> Tuple[List[KippoTaskStatus], bool]:
     active_taskstatus = []
     has_estimates = False
     for project in projects:

--- a/kippo/projects/views.py
+++ b/kippo/projects/views.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from collections import Counter, defaultdict
 
 from django.shortcuts import render, get_object_or_404
@@ -96,16 +96,23 @@ def view_inprogress_projects_overview(request: HttpRequest) -> HttpResponse:
     return render(request, 'projects/view_inprogress_projects_status_overview.html', context)
 
 
-def _get_active_taskstatus_from_projects(projects: List[KippoProject], active_effort_date: timezone.datetime.date) -> Tuple[List[KippoTaskStatus], bool]:
+def _get_active_taskstatus_from_projects(projects: List[KippoProject], max_effort_date: Optional[timezone.datetime.date] = None) -> Tuple[List[KippoTaskStatus], bool]:
     active_taskstatus = []
     has_estimates = False
     for project in projects:
         done_column_names = project.columnset.get_done_column_names()
-        results = KippoTaskStatus.objects.filter(
-            effort_date__gte=active_effort_date,
+        qs = KippoTaskStatus.objects.filter(
             task__github_issue_api_url__isnull=False,  # filter out non-linked tasks
             task__project=project
-        ).exclude(state__in=done_column_names)
+        ).exclude(
+            state__in=done_column_names
+        )
+        if max_effort_date:
+            qs = qs.filter(
+                effort_date__lte=max_effort_date,
+            )
+        results = qs.order_by('task__github_issue_api_url', '-effort_date').distinct('task__github_issue_api_url')
+
         taskstatus_results = list(results)
         if any(status.estimate_days for status in taskstatus_results):
             has_estimates = True
@@ -140,10 +147,8 @@ def view_inprogress_projects_status(request: HttpRequest) -> HttpResponse:
         projects = KippoProject.objects.filter(is_closed=False, organization=selected_organization)
     active_projects = KippoProject.objects.filter(is_closed=False, organization=selected_organization).order_by('name')
 
-    # Collect tasks with TaskStatus updated this last 2 weeks
-    two_weeks_ago = timezone.timedelta(days=14)
-    active_taskstatus_startdate = (timezone.now() - two_weeks_ago).date()
-    active_taskstatus, has_estimates = _get_active_taskstatus_from_projects(projects, active_taskstatus_startdate)
+    # Collect KippoTaskStatus for projects
+    active_taskstatus, has_estimates = _get_active_taskstatus_from_projects(projects)
 
     if not has_estimates:
         msg = f'No Estimates defined in tasks (Expect "estimate labels")'


### PR DESCRIPTION
- fixing setup_basic_project repo to use optionally defined 'repository_name'
- updating `project.views._get_active_taskstatus_from_projects()` to use the _latest_ kippotaskstatus.effort_date for each task (in order to support webhookevent updates where all effort_dates will NOT be the same as initially implemented here)
- change `project.views._get_active_taskstatus_from_projects()` argument, "active_effort_date" -> "max_effort_date" to allow display of the effort at a specific date in time. (previously used to filter kippotaskstatus for *only* dates matching the given "active_effort_date")
- adding testcase for `project.views._get_active_taskstatus_from_projects()`