### PR TITLE
Fix project display past target_date

### DIFF
--- a/kippo/tasks/functions.py
+++ b/kippo/tasks/functions.py
@@ -251,7 +251,9 @@ def get_projects_load(organization: KippoOrganization, schedule_start_date: date
         is_closed=False).order_by('target_date')
     )
     if not projects:
-        raise ProjectConfigurationError('No projects found! Project(s) Not properly configured! (Check that 1 or more project has a start_date and target_date defined)')
+        raise ProjectConfigurationError(
+            'No projects found! Project(s) Not properly configured! (Check that 1 or more project has a start_date and target_date defined)'
+        )
 
     # prepare absolute priority
     project_active_state_priority = {

--- a/kippo/tasks/functions.py
+++ b/kippo/tasks/functions.py
@@ -244,13 +244,14 @@ def get_projects_load(organization: KippoOrganization, schedule_start_date: date
     elif isinstance(schedule_start_date, datetime.datetime):
         schedule_start_date = schedule_start_date.date()
 
-    projects = list(KippoProject.objects.filter(target_date__gt=schedule_start_date,
-                                                organization=organization,
-                                                start_date__isnull=False,
-                                                target_date__isnull=False,
-                                                is_closed=False).order_by('target_date'))
+    projects = list(KippoProject.objects.filter(
+        organization=organization,
+        start_date__isnull=False,
+        target_date__isnull=False,
+        is_closed=False).order_by('target_date')
+    )
     if not projects:
-        raise ProjectConfigurationError('Project(s) Not properly configured! (Check that 1 or more project has a start_date and target_date defined)')
+        raise ProjectConfigurationError('No projects found! Project(s) Not properly configured! (Check that 1 or more project has a start_date and target_date defined)')
 
     # prepare absolute priority
     project_active_state_priority = {

--- a/kippo/tasks/periodic/tasks.py
+++ b/kippo/tasks/periodic/tasks.py
@@ -327,13 +327,13 @@ def get_existing_kippo_project(github_project: GithubOrganizationProject, existi
 def collect_github_project_issues(action_tracker_id: int,
                                   kippo_organization_id: str,
                                   status_effort_date_iso8601: Optional[str] = None,
-                                  github_project_html_urls: List[str] = None) -> tuple:
+                                  github_project_html_urls: List[str] = None) -> None:
     """
     1. Collect issues from attached github projects
     2. If related KippoTask does not exist, create one
     3. If KippoTask exists create KippoTaskStatus
 
-    :param action_tracker_id:
+    :param action_tracker_id: specific caller defined id to clearly identify the action value stored in the relatedd CollectIssuesProjectResult.action_id
     :param kippo_organization_id: KippoOrganization ID
     :param status_effort_date_iso8601: Date to get tasks from for testing, estimation purposes
     :param github_project_html_urls: If only specific projects are desired, the related github_project_html_urls may be provided


### PR DESCRIPTION
- Update to allow viewing of projects that are NOT closed passed the target date.
- add 'Collect Repositories' action command for projects
- refactor `get_user_session_organization()` move to functions, and use in projects admin to determine user's orgs.

addresses:
https://github.com/monkut/kippo/issues/60