### PR TITLE
:wrench: update to ignore "OLD" closed projects when generating projectid_mapping 

### DIFF
--- a/kippo/kippo/settings/base.py
+++ b/kippo/kippo/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 import logging
 import os
+from distutils.util import strtobool
 from pathlib import PurePath
 
 from django.conf.locale.en import formats as en_formats
@@ -220,3 +221,7 @@ logger.info(f"AWS_SERVICE_ENDPOINTS: {AWS_SERVICE_ENDPOINTS}")
 
 DEFAULT_FALLBACK_ESTIMATE_DAYS = "3"
 FALLBACK_ESTIMATE_DAYS = int(os.getenv("FALLBACK_ESTIMATE_DAYS", DEFAULT_FALLBACK_ESTIMATE_DAYS))
+
+TWO_YEARS_IN_DAYS = 365 * 2
+DEFAULT_PROJECTID_MAPPING_CLOSED_IGNORED_DAYS = str(TWO_YEARS_IN_DAYS)
+PROJECTID_MAPPING_CLOSED_IGNORED_DAYS = int(os.getenv("PROJECTID_MAPPING_CLOSED_IGNORED_DAYS", DEFAULT_PROJECTID_MAPPING_CLOSED_IGNORED_DAYS))

--- a/kippo/kippo/settings/base.py
+++ b/kippo/kippo/settings/base.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 import logging
 import os
-from distutils.util import strtobool
 from pathlib import PurePath
 
 from django.conf.locale.en import formats as en_formats

--- a/kippo/projects/handlers/functions.py
+++ b/kippo/projects/handlers/functions.py
@@ -12,10 +12,16 @@ from ..models import KippoProject
 logger = logging.getLogger(__name__)
 
 
+def _get_projectid_mapping_ignore_date() -> timezone.datetime:
+    lte_ignore_datetime = timezone.now() - timezone.timedelta(days=settings.PROJECTID_MAPPING_CLOSED_IGNORED_DAYS)
+    return lte_ignore_datetime
+
+
 def _prepare_mapping() -> dict:
     now = timezone.now().replace(microsecond=0)
     mapping = {"last_updated": now.isoformat()}
-    for project in KippoProject.objects.all():
+    lte_ignore_datetime = _get_projectid_mapping_ignore_date()
+    for project in KippoProject.objects.exclude(closed_datetime__lte=lte_ignore_datetime):
         mapping[str(project.pk)] = project.name
     return mapping
 

--- a/kippo/projects/tests/test_handlers_functions.py
+++ b/kippo/projects/tests/test_handlers_functions.py
@@ -3,9 +3,10 @@ from io import BytesIO
 
 from common.tests import DEFAULT_FIXTURES, setup_basic_project
 from django.test import TestCase
+from django.utils import timezone
 from kippo.aws import S3_CLIENT, S3_RESOURCE, parse_s3_uri, s3_key_exists
-from projects.handlers.functions import _prepare_mapping, write_projectid_json
-from projects.models import ActiveKippoProject
+from projects.handlers.functions import _get_projectid_mapping_ignore_date, _prepare_mapping, write_projectid_json
+from projects.models import ActiveKippoProject, KippoProject
 
 
 class ProjectsHandlersFunctionsTestCase(TestCase):
@@ -19,18 +20,52 @@ class ProjectsHandlersFunctionsTestCase(TestCase):
         created_objects = setup_basic_project()
 
         # get active column state names
+        self.user = created_objects["KippoUser"]
         self.project = created_objects["KippoProject"]
+        self.project2 = created_objects["KippoProject2"]
+        self.organization = created_objects["KippoOrganization"]
 
         self.test_s3uri = f"s3://{self.test_bucket}/test/mapping.json"
 
     def test__prepare_mapping(self):
         assert ActiveKippoProject.objects.count() == 2, ActiveKippoProject.objects.count()
-        expected = {str(p.pk): p.name for p in ActiveKippoProject.objects.all()}
+
+        # change active project to closed project
+        closed_but_not_old_pk = self.project2.pk
+        self.project2.is_closed = True
+
+        self.project2.save()
+
+        # add closed project
+        old_kippo_project_api_id = "1234568"
+        old_closed_project_name = "old-closed-project"
+        lte_ignore_datetime = _get_projectid_mapping_ignore_date()
+        old_actual_closed_date = lte_ignore_datetime - timezone.timedelta(days=1)
+        old_kippo_project = KippoProject(
+            organization=self.organization,
+            name=old_closed_project_name,
+            github_project_html_url=f"https://github.com/orgs/{self.organization.github_organization_name}/projects/3",
+            github_project_api_url=f"https://api.github.com/projects/{old_kippo_project_api_id}",
+            columnset=self.project.columnset,
+            created_by=self.user,
+            updated_by=self.user,
+            is_closed=True,
+            closed_datetime=old_actual_closed_date,
+        )
+        old_kippo_project.save()
+        assert KippoProject.objects.filter(is_closed=True).count() == 2
+        assert KippoProject.objects.filter(is_closed=False).count() == 1
+
+        expected = {str(p.pk): p.name for p in KippoProject.objects.exclude(closed_datetime__lte=lte_ignore_datetime)}
+        assert len(expected) == 2, len(expected)
         mapping = _prepare_mapping()
         self.assertIn("last_updated", mapping)
         # remove "last_updated"
         del mapping["last_updated"]
         self.assertDictEqual(mapping, expected)
+
+        expected = {str(closed_but_not_old_pk), str(self.project.pk)}
+        self.assertEqual(set(mapping.keys()), expected)
 
     def test_write_projectid_json(self):
         assert ActiveKippoProject.objects.count() == 2, ActiveKippoProject.objects.count()


### PR DESCRIPTION
Needed to prevent infinite increase in output mapping file.

> "OLD" defined by "PROJECTID_MAPPING_CLOSED_IGNORED_DAYS" envar in settings