### PR TITLE
:pencil: add weekly effort display

### DIFF
--- a/kippo/common/templates/admin/base.html
+++ b/kippo/common/templates/admin/base.html
@@ -1,0 +1,9 @@
+{% extends "admin/base.html" %}
+{% load i18n admin_urls %}
+
+{% block welcome-msg %}
+    <strong>{% firstof user.get_short_name user.get_username %}</strong>
+    {% if USER_WEEKLYEFFORT_HOURS_TOTAL >= 0 %}
+<span title="Last week's effort hours CURRENT/EXPECTED">( {{ USER_WEEKLYEFFORT_HOURS_TOTAL }}/{{ USER_WEEKLYEFFORT_HOURS_EXPECTED }} {{ USER_WEEKLYEFFORT_HOURS_PERCENTAGE }}% )</span>
+    {% endif %}
+{% endblock %}

--- a/kippo/kippo/context_processors.py
+++ b/kippo/kippo/context_processors.py
@@ -1,6 +1,8 @@
 from typing import Dict
-from django.http.request import HttpRequest
+
 from django.conf import settings
+from django.db.models import Sum
+from django.http.request import HttpRequest
 
 
 def global_view_additional_context(request: HttpRequest) -> Dict:
@@ -10,9 +12,32 @@ def global_view_additional_context(request: HttpRequest) -> Dict:
     :param request:
     :return:
     """
+    user_weeklyeffort_hours_sum = None
+    user_weeklyeffort_expected_total = None
+    user_weeklyeffort_percentage = None
+    if request.user and request.user.is_authenticated:
+        from projects.models import ProjectWeeklyEffort
+        from projects.functions import previous_week_startdate
+
+        # NOTE: uses first org (may not be expected result
+        user_first_org = request.user.organizations.first()
+        if user_first_org:
+            org_membership = request.user.get_membership(organization=user_first_org)
+            org_commiteddays = org_membership.committed_days
+            user_weeklyeffort_expected_total = org_commiteddays * user_first_org.day_workhours
+            week_startdate = previous_week_startdate()
+            user_weeklyeffort_hours_result = ProjectWeeklyEffort.objects.filter(user=request.user, week_start=week_startdate).aggregate(Sum("hours"))
+            if user_weeklyeffort_hours_result and "hours__sum" in user_weeklyeffort_hours_result:
+                user_weeklyeffort_hours_sum = user_weeklyeffort_hours_result["hours__sum"]
+                if user_weeklyeffort_hours_sum and user_weeklyeffort_hours_sum >= 0 and user_weeklyeffort_expected_total > 0:
+                    user_weeklyeffort_percentage = int((user_weeklyeffort_hours_sum / user_weeklyeffort_expected_total) * 100)
+
     context = {
-        'URL_PREFIX': settings.URL_PREFIX,
-        'STATIC_URL': settings.STATIC_URL,
-        'DISPLAY_ADMIN_AUTH_FOR_MODELBACKEND': settings.DISPLAY_ADMIN_AUTH_FOR_MODELBACKEND,
+        "URL_PREFIX": settings.URL_PREFIX,
+        "STATIC_URL": settings.STATIC_URL,
+        "DISPLAY_ADMIN_AUTH_FOR_MODELBACKEND": settings.DISPLAY_ADMIN_AUTH_FOR_MODELBACKEND,
+        "USER_WEEKLYEFFORT_HOURS_TOTAL": user_weeklyeffort_hours_sum,
+        "USER_WEEKLYEFFORT_HOURS_EXPECTED": user_weeklyeffort_expected_total,
+        "USER_WEEKLYEFFORT_HOURS_PERCENTAGE": user_weeklyeffort_percentage,
     }
     return context


### PR DESCRIPTION
Adding the 'last week's entered project weekly effort hours' display in admin title.

It was difficult to *know* how much time you've added so far.
This feature allows you to easily know how much time you've submitted so you can make adjustments so that the values are more accurate.