### PR TITLE
Add "Non-Project" Phase 

### DIFF
--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -134,6 +134,7 @@ class ProjectColumn(models.Model):
 
 DEFAULT_PROJECT_PHASE = "lead-evaluation"
 VALID_PROJECT_PHASES = (
+    ("non-project", "Non-Project"),
     ("lead-evaluation", "Lead Evaluation"),
     ("project-proposal", "Project Proposal Preparation"),
     ("project-development", "Project Development"),


### PR DESCRIPTION
All set 'phases' are intended to be the phase of a project.

However, for work effort tracking some work is not project related, and we currently use KippoProject models to track effort.

This PR adds a 'Non-Project' phase to make it easy to group these projects.