### PR TITLE
:wrench: change from using `get_kippoprojectuserstatisfactionresult_c…

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -260,7 +260,7 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         "get_latest_kippoprojectstatus_comment",
         "start_date",
         "target_date",
-        "get_kippoprojectuserstatisfactionresult_count",
+        "get_kippoprojectuserstatisfactionresult_usernames",
         "get_projectsurvey_display_url",
         "show_github_project_html_url",
         "display_as_active",
@@ -308,13 +308,19 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     get_confidence_display.admin_order_field = "confidence"
     get_confidence_display.short_description = "confidence"
 
-    def get_kippoprojectuserstatisfactionresult_count(self, obj: Optional[KippoProject] = None) -> int:
-        result = 0
+    def get_kippoprojectuserstatisfactionresult_usernames(self, obj: Optional[KippoProject] = None) -> str:
+        result = ""
         if obj:
-            result = KippoProjectUserStatisfactionResult.objects.filter(project=obj).count()
+            result = format_html(
+                "<br>".join(
+                    KippoProjectUserStatisfactionResult.objects.filter(project=obj)
+                    .order_by("created_by__username")
+                    .values_list("created_by__username", flat=True)
+                )
+            )
         return result
 
-    get_kippoprojectuserstatisfactionresult_count.short_description = f"{KippoProjectUserStatisfactionResult._meta.verbose_name} Count"
+    get_kippoprojectuserstatisfactionresult_usernames.short_description = f"{KippoProjectUserStatisfactionResult._meta.verbose_name} Submitted Users"
 
     def get_projectsurvey_display_url(self, obj):
         url = obj.get_projectsurvey_url()
@@ -466,7 +472,7 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
         "get_latest_kippoprojectstatus_comment",
         "start_date",
         "target_date",
-        "get_kippoprojectuserstatisfactionresult_count",
+        "get_kippoprojectuserstatisfactionresult_usernames",
         "get_projectsurvey_display_url",
         "show_github_project_html_url",
         "get_updated_by_display",


### PR DESCRIPTION
…ount` to `get_kippoprojectuserstatisfactionresult_usernames` to make it easier to know who has submitted a result.