### PR TITLE
:sparkles: add "id" to project admin search.

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -268,7 +268,7 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         "updated_datetime",
     )
     list_display_links = ("id", "name")
-    search_fields = ("name", "phase", "category", "problem_definition")
+    search_fields = ("id", "name", "phase", "category", "problem_definition")
     ordering = ("organization", "-display_as_active", "-confidence", "phase", "name")
     actions = [
         create_github_organizational_project_action,


### PR DESCRIPTION
Need to be able to look up project ids as they are being used for cost measurement.