### PR TITLE
Add/effort slack command

### DIFF
--- a/kippo/accounts/tests/subcommands/test_attendancecancel.py
+++ b/kippo/accounts/tests/subcommands/test_attendancecancel.py
@@ -150,3 +150,10 @@ class AttendanceCancelSubCommandTestCase(IsStaffModelAdminTestCaseBase):
 
             # delete for next category test
             AttendanceRecord.objects.all().delete()
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        from commons.slackcommand import get_all_subcommands
+
+        available_subcommands = get_all_subcommands()
+        self.assertIn(AttendanceCancelSubCommand, available_subcommands)

--- a/kippo/accounts/tests/subcommands/test_breakend.py
+++ b/kippo/accounts/tests/subcommands/test_breakend.py
@@ -233,3 +233,10 @@ class ClockInSubCommandTestCase(IsStaffModelAdminTestCaseBase):
             self.assertEqual(end_attendance_record.entry_datetime, expected_entry_datetime.astimezone(datetime.UTC))
 
             AttendanceRecord.objects.filter(category=AttendanceRecordCategory.BREAK_END).delete()
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        from commons.slackcommand import get_all_subcommands
+
+        available_subcommands = get_all_subcommands()
+        self.assertIn(BreakEndSubCommand, available_subcommands)

--- a/kippo/accounts/tests/subcommands/test_breakstart.py
+++ b/kippo/accounts/tests/subcommands/test_breakstart.py
@@ -231,3 +231,10 @@ class ClockInSubCommandTestCase(IsStaffModelAdminTestCaseBase):
             self.assertEqual(end_attendance_record.entry_datetime, expected_entry_datetime.astimezone(datetime.UTC))
 
             AttendanceRecord.objects.filter(category=AttendanceRecordCategory.BREAK_START).delete()
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        from commons.slackcommand import get_all_subcommands
+
+        available_subcommands = get_all_subcommands()
+        self.assertIn(BreakStartSubCommand, available_subcommands)

--- a/kippo/accounts/tests/subcommands/test_clockin.py
+++ b/kippo/accounts/tests/subcommands/test_clockin.py
@@ -192,3 +192,10 @@ class ClockInSubCommandTestCase(IsStaffModelAdminTestCaseBase):
             self.assertEqual(end_attendance_record.entry_datetime, expected_entry_datetime.astimezone(datetime.UTC))
 
             AttendanceRecord.objects.all().delete()
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        from commons.slackcommand import get_all_subcommands
+
+        available_subcommands = get_all_subcommands()
+        self.assertIn(ClockInSubCommand, available_subcommands)

--- a/kippo/accounts/tests/subcommands/test_clockout.py
+++ b/kippo/accounts/tests/subcommands/test_clockout.py
@@ -262,3 +262,10 @@ class ClockOutSubCommandTestCase(IsStaffModelAdminTestCaseBase):
             self.assertEqual(end_attendance_record.entry_datetime, expected_entry_datetime)
 
             AttendanceRecord.objects.filter(category=AttendanceRecordCategory.END).delete()
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        from commons.slackcommand import get_all_subcommands
+
+        available_subcommands = get_all_subcommands()
+        self.assertIn(ClockOutSubCommand, available_subcommands)

--- a/kippo/accounts/tests/subcommands/test_listusers.py
+++ b/kippo/accounts/tests/subcommands/test_listusers.py
@@ -244,3 +244,10 @@ class ListUsersSubCommandTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(self.membership.slack_image_url, SLACK_RESPONSE_IMAGE_URL)
         today = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         self.assertGreaterEqual(self.membership.updated_datetime, today)
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        from commons.slackcommand import get_all_subcommands
+
+        available_subcommands = get_all_subcommands()
+        self.assertIn(ListUsersSubCommand, available_subcommands)

--- a/kippo/accounts/tests/subcommands/test_setholiday.py
+++ b/kippo/accounts/tests/subcommands/test_setholiday.py
@@ -222,3 +222,10 @@ class SetHolidaySubCommandTestCase(IsStaffModelAdminTestCaseBase):
             self.assertTrue(personalholiday.is_half)
 
             personalholiday.delete()  # delete for next loop
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        from commons.slackcommand import get_all_subcommands
+
+        available_subcommands = get_all_subcommands()
+        self.assertIn(SetHolidaySubCommand, available_subcommands)

--- a/kippo/commons/context_processors.py
+++ b/kippo/commons/context_processors.py
@@ -64,7 +64,7 @@ def global_view_additional_context(request: HttpRequest) -> dict:
             )
             if request.user.holiday_country:
                 public_holidays = public_holidays.filter(country=request.user.holiday_country)
-            elif org_membership and org_membership.default_holiday_country:
+            elif org_membership and org_membership.organization.default_holiday_country:
                 public_holidays = public_holidays.filter(country=org_membership.default_holiday_country)
 
             public_holiday_days = public_holidays.count()

--- a/kippo/commons/slackcommand/__init__.py
+++ b/kippo/commons/slackcommand/__init__.py
@@ -1,9 +1,5 @@
 def get_all_subcommands() -> tuple:
-    """
-    Import and list all subcommands.
-
-    NOTE: using @lazy decorator to avoid circular import issues.
-    """
+    """Import and list all subcommands."""
     from accounts.slackcommand.subcommands.clockin import ClockInSubCommand
     from accounts.slackcommand.subcommands.clockout import ClockOutSubCommand
     from accounts.slackcommand.subcommands.setholiday import SetHolidaySubCommand
@@ -13,6 +9,8 @@ def get_all_subcommands() -> tuple:
     from accounts.slackcommand.subcommands.attendancecancel import AttendanceCancelSubCommand
     from projects.slackcommand.subcommands.projectstatus import ProjectStatusSubCommand
     from projects.slackcommand.subcommands.listprojectstatus import ListProjectStatusSubCommand
+    from projects.slackcommand.subcommands.projecteffort import ProjectEffortSubCommand
+    from projects.slackcommand.subcommands.listprojecteffort import ListProjectEffortSubCommand
 
     from .subcommands.listcommands import ListCommandsSubCommand
 
@@ -28,4 +26,6 @@ def get_all_subcommands() -> tuple:
         ProjectStatusSubCommand,
         ListProjectStatusSubCommand,
         ListCommandsSubCommand,
+        ProjectEffortSubCommand,
+        ListProjectEffortSubCommand,
     )

--- a/kippo/projects/slackcommand/subcommands/listprojecteffort.py
+++ b/kippo/projects/slackcommand/subcommands/listprojecteffort.py
@@ -1,0 +1,109 @@
+import datetime
+import logging
+
+from accounts.models import SlackCommand
+from commons.definitions import SlackResponseTypes
+from commons.slackcommand.base import SubCommandBase
+from django.db.models.query import QuerySet
+from slack_sdk.web import SlackResponse
+from slack_sdk.webhook import WebhookClient, WebhookResponse
+
+from ...functions import previous_week_startdate
+from ...models import ProjectWeeklyEffort
+
+logger = logging.getLogger(__name__)
+
+
+class ListProjectEffortSubCommand(SubCommandBase):
+    """Command to list all registered effort for th latest week for the user"""
+
+    DISPLAY_COMMAND_NAME: str = "list-project-effort"
+    DESCRIPTION: str = "実行中プロジェクトの現状週間ステータスを表示します。例） `COMMAND list-project-status`"
+    ALIASES: set = {
+        "list-project-effort",
+        "listprojecteffort",
+        "list-effort",
+        "listeffort",
+    }
+
+    @classmethod
+    def _get_project_effort_blocks(cls, related_effort_entries: QuerySet[ProjectWeeklyEffort], week_start: datetime.date) -> list[dict]:
+        project_effort_blocks = []
+        display_week_start_date = week_start.strftime("%-m月%-d日")
+        project_effort_block = {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"{display_week_start_date}週のプロジェクト稼働時間",
+            },
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": "*プロジェクト名*",
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*稼働時間*",
+                },
+            ],
+        }
+
+        slack_max_fields = 10
+        total = 0
+        for effort in related_effort_entries:
+            project_name = effort.project.name
+            hours = effort.hours
+            project_effort_block["fields"].append({"type": "plain_text", "text": project_name})
+            project_effort_block["fields"].append({"type": "plain_text", "text": str(hours)})
+
+            if len(project_effort_block["fields"]) >= slack_max_fields:
+                # If we have 10 fields, we need to create a new block
+                project_effort_blocks.append(project_effort_block)
+                project_effort_block = {"type": "section", "fields": []}
+
+            total += hours
+        project_effort_block["fields"].append({"type": "mrkdwn", "text": "_合計_"})
+        project_effort_block["fields"].append({"type": "mrkdwn", "text": f"_{str(total)}_"})
+        project_effort_blocks.append(project_effort_block)
+        return project_effort_blocks
+
+    @classmethod
+    def handle(cls, command: SlackCommand) -> tuple[list[dict], SlackResponse | None, WebhookResponse | None]:
+        """Report current taotal project effort for the user"""
+        assert cls._is_valid_subcommand_alias(command.sub_command)
+        web_send_response = None
+
+        # this is extra text provided by the user
+        text_without_subcommand = command.get_text_without_subcommand()
+
+        # check if datetime is given in 'text'
+        logger.debug(f"text_without_subcommand={text_without_subcommand}")
+        week_start = previous_week_startdate()
+        related_effort_entries = ProjectWeeklyEffort.objects.filter(
+            project__organization=command.organization, user=command.user, week_start=week_start
+        ).order_by("hours")
+        if not related_effort_entries:
+            display_week_start_date = week_start.strftime("%-m月%-d日")
+            command_response_blocks = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (f":warning: ({display_week_start_date}週) プロジェクト稼働時間が見つかりませんでした。\n"),
+                    },
+                }
+            ]
+        else:
+            effort_status_blocks = cls._get_project_effort_blocks(related_effort_entries, week_start)
+            command_response_blocks = effort_status_blocks
+            command.is_valid = True
+            command.save()
+
+        webhook_send_response = None
+        if command_response_blocks:
+            # Notify user that notification was sent to the registered channel
+            webhook_client = WebhookClient(command.response_url)
+            webhook_send_response = webhook_client.send(blocks=command_response_blocks, response_type=SlackResponseTypes.EPHEMERAL)
+        else:
+            logger.warning(f"command_response_blocks is empty, no response sent to {command.user.username}.")
+        return command_response_blocks, web_send_response, webhook_send_response

--- a/kippo/projects/slackcommand/subcommands/listprojectstatus.py
+++ b/kippo/projects/slackcommand/subcommands/listprojectstatus.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class ListProjectStatusSubCommand(SubCommandBase):
-    """Command to clock out a user."""
+    """Command to list all project status for the current week"""
 
     DISPLAY_COMMAND_NAME: str = "list-project-status"
     DESCRIPTION: str = "実行中プロジェクトの現状週間ステータスを表示します。例） `COMMAND list-project-status`"

--- a/kippo/projects/slackcommand/subcommands/projecteffort.py
+++ b/kippo/projects/slackcommand/subcommands/projecteffort.py
@@ -102,6 +102,8 @@ class ProjectEffortSubCommand(SubCommandBase):
                             week_start=week_start_date,
                             user=command.user,
                             hours=hours,
+                            created_by=command.user,
+                            updated_by=command.user,
                         )
                         effort.save()
                         logger.info(
@@ -114,7 +116,7 @@ class ProjectEffortSubCommand(SubCommandBase):
                                 "type": "section",
                                 "text": {
                                     "type": "mrkdwn",
-                                    "text": (f"({display_week_start_date}週) {related_project.name}に '{hours}' 稼働時間を登録しました。\n"),
+                                    "text": (f"({display_week_start_date}週) *{related_project.name}* に `{hours}` の稼働時間を登録しました。"),
                                 },
                             }
                         ]
@@ -133,7 +135,7 @@ class ProjectEffortSubCommand(SubCommandBase):
                                     "type": "mrkdwn",
                                     "text": (
                                         f"> {text_without_subcommand}\n"
-                                        f"({display_week_start_date}週) {related_project.name} ({existing_effort.hours}) "
+                                        f"({display_week_start_date}週) *{related_project.name}* に `{existing_effort.hours}h` の"
                                         f"稼働時間はすでに登録されています。"
                                     ),
                                 },

--- a/kippo/projects/slackcommand/subcommands/projecteffort.py
+++ b/kippo/projects/slackcommand/subcommands/projecteffort.py
@@ -1,0 +1,168 @@
+import logging
+import re
+
+from accounts.models import SlackCommand
+from commons.definitions import SlackResponseTypes
+from commons.slackcommand.base import SubCommandBase
+from django.utils.text import gettext_lazy as _
+from slack_sdk.web import SlackResponse
+from slack_sdk.webhook import WebhookClient, WebhookResponse
+
+from ...functions import previous_week_startdate
+from ...models import ActiveKippoProject, ProjectWeeklyEffort
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectEffortSubCommand(SubCommandBase):
+    """Command to add ProjectWeeklyEffort to related KippoProject."""
+
+    DISPLAY_COMMAND_NAME: str = "project-effort"
+    DESCRIPTION: str = _("チャンネルのプロジェクトへ稼働時間を登録。例) `COMMAND project-effort {HOURS}`")
+    ALIASES: set = {
+        "project-effort",
+        "effort",
+        "稼働",
+    }
+
+    @classmethod
+    def handle(cls, command: SlackCommand) -> tuple[list[dict], SlackResponse | None, WebhookResponse]:
+        """Handle the project-effort command."""
+        web_send_response = None
+        assert cls._is_valid_subcommand_alias(command.sub_command)
+
+        # this is extra text provided by the user
+        text_without_subcommand = command.get_text_without_subcommand()
+
+        # check if datetime is given in 'text'
+        logger.debug(f"text_without_subcommand={text_without_subcommand}")
+
+        source_channel = command.payload.get("channel_name", None)
+        # ActiveKippoProject includes filters:
+        # > is_closed=False
+        # > display_as_active=True
+        related_project = ActiveKippoProject.objects.filter(organization=command.organization, slack_channel_name=source_channel).first()
+        if not related_project:
+            logger.error(f"{command.organization.name} Project not found for source_channel: {source_channel}")
+            command_response_blocks = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"プロジェクトが見つかりませんでした。:warning: `{source_channel}`チャンネルは、プロジェクトに関連付けられていません。\n"
+                            f"（閉じている可能性があります）\n"
+                            f"プロジェクトの`slack_channel_name`設定を確認してください。"
+                        ),
+                    },
+                }
+            ]
+        else:
+            # check for valid hours input
+            pattern = r"^(?P<hours>\d+)(\s.+|)$"  # Matches integers or decimals
+            match = re.match(pattern, text_without_subcommand)
+            if match:
+                max_weekly_effort_hours = 7 * 24  # 7 days * 24 hours
+
+                # valid input, extract hours
+                hours = int(match.groupdict()["hours"])
+                logger.debug(f"Extracted hours: {hours} from text_without_subcommand: {text_without_subcommand}")
+                if not (0 < hours <= max_weekly_effort_hours):
+                    # invalid hours input, return error message
+                    organization_slack_command = command.organization.slack_command_name
+                    command_response_blocks = [
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": (
+                                    f"> {text_without_subcommand}\n"
+                                    f"稼働時間を取得できませんでした。 `/{organization_slack_command} {cls.DISPLAY_COMMAND_NAME} HOURS` "
+                                    f"(0 < x < {max_weekly_effort_hours})整数で稼働時間を指定してください。"
+                                ),
+                            },
+                        }
+                    ]
+
+                else:
+                    week_start_date = previous_week_startdate()
+                    # check for existing ProjectWeeklyEffort for the project/user/week_start
+                    existing_effort = ProjectWeeklyEffort.objects.filter(
+                        project=related_project, user=command.user, week_start=week_start_date
+                    ).first()
+                    display_week_start_date = week_start_date.strftime("%-m月%-d日")
+                    if not existing_effort:
+                        # create new ProjectWeeklyEffort)
+                        logger.info(
+                            f"{command.organization.name} linked project('{related_project.name}') found, and hours({hours}) detected, "
+                            f"creating ProjectWeeklyEffort ({week_start_date}) ..."
+                        )
+                        effort = ProjectWeeklyEffort(
+                            project=related_project,
+                            week_start=week_start_date,
+                            user=command.user,
+                            hours=hours,
+                        )
+                        effort.save()
+                        logger.info(
+                            f"{command.organization.name} linked project('{related_project.name}') found, and hours({hours}) detected, "
+                            f"creating ProjectWeeklyEffort ({week_start_date}) ... DONE"
+                        )
+
+                        command_response_blocks = [
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": (f"({display_week_start_date}週) {related_project.name}に '{hours}' 稼働時間を登録しました。\n"),
+                                },
+                            }
+                        ]
+                        command.is_valid = True
+                        command.save()
+                    else:
+                        logger.warning(
+                            f"ProjectWeeklyEffort already exists for project '{related_project.name}', "
+                            f"user '{command.user.username}', week_start '{week_start_date}'"
+                        )
+                        # ProjectWeeklyEffort already exists, return error message
+                        command_response_blocks = [
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": (
+                                        f"> {text_without_subcommand}\n"
+                                        f"({display_week_start_date}週) {related_project.name} ({existing_effort.hours}) "
+                                        f"稼働時間はすでに登録されています。"
+                                    ),
+                                },
+                            }
+                        ]
+
+            else:
+                logger.warning(f"Unable to extract hours from text with pattern ({pattern}): {text_without_subcommand}")
+                # unable to extract hours from 'text_without_subcommand', return error message
+                organization_slack_command = command.organization.slack_command_name
+                command_response_blocks = [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": (
+                                f"> {text_without_subcommand}\n"
+                                f"稼働時間を取得できませんでした。 "
+                                f"`/{organization_slack_command} {cls.DISPLAY_COMMAND_NAME} HOURS` 整数で稼働時間を指定してください。"
+                            ),
+                        },
+                    }
+                ]
+
+        webhook_send_response = None
+        if command_response_blocks:
+            # Notify user that notification was sent to the registered channel
+            webhook_client = WebhookClient(command.response_url)
+            webhook_send_response = webhook_client.send(blocks=command_response_blocks, response_type=SlackResponseTypes.EPHEMERAL)
+        else:
+            logger.warning(f"command_response_blocks is empty, no response sent to {command.user.username}.")
+        return command_response_blocks, web_send_response, webhook_send_response

--- a/kippo/projects/slackcommand/subcommands/projectstatus.py
+++ b/kippo/projects/slackcommand/subcommands/projectstatus.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class ProjectStatusSubCommand(SubCommandBase):
-    """Command to clock out a user."""
+    """Command to add project status for a related slack channel for a a user."""
 
     DISPLAY_COMMAND_NAME: str = "project-status"
     DESCRIPTION: str = _("チャンネルのプロジェクトへステータスを当露光。例) `COMMAND project-status {STATUS COMMENT}`")
@@ -25,7 +25,7 @@ class ProjectStatusSubCommand(SubCommandBase):
 
     @classmethod
     def handle(cls, command: SlackCommand) -> tuple[list[dict], SlackResponse | None, WebhookResponse]:
-        """Handle the check-in command."""
+        """Handle the project-status command."""
         web_send_response = None
 
         assert cls._is_valid_subcommand_alias(command.sub_command)

--- a/kippo/projects/tests/subcommands/test_listprojecteffort.py
+++ b/kippo/projects/tests/subcommands/test_listprojecteffort.py
@@ -1,0 +1,106 @@
+from unittest import mock
+
+from accounts.models import OrganizationMembership, SlackCommand
+from commons.slackcommand import get_all_subcommands
+from commons.tests import IsStaffModelAdminTestCaseBase, setup_basic_project
+from commons.tests.utils import webhook_response_factory
+
+from projects.functions import previous_week_startdate
+from projects.models import ProjectWeeklyEffort
+from projects.slackcommand.subcommands.listprojecteffort import ListProjectEffortSubCommand
+
+
+class ListProjectEffortSubCommandTestCase(IsStaffModelAdminTestCaseBase):
+    def setUp(self):
+        super().setUp()
+
+        # populate slack related settings
+        self.organization.slack_api_token = "xoxb-1234567890-1234567890123-1234567890123-abcde"  # noqa: S105
+        self.organization.slack_signing_secret = "1234567890123"  # noqa: S105
+        self.organization.slack_command_name = "kippo"
+        self.organization.slack_attendance_report_channel = "#kippo"
+        self.organization.enable_slack_channel_reporting = True
+        self.organization.save()
+
+        # update slack user id
+        self.staffuser_with_org_slack_id = "U12345678"
+        self.staffuser_with_org_slack_username = "testuser"
+
+        membership = OrganizationMembership.objects.get(organization=self.organization, user=self.staffuser_with_org)
+        membership.slack_user_id = self.staffuser_with_org_slack_id
+        membership.slack_username = self.staffuser_with_org_slack_username
+        membership.save()
+
+        created = setup_basic_project(organization=self.organization)
+        self.project = created["KippoProject"]
+
+        self.project_slack_channel_name = "test_channel"
+
+    @mock.patch("projects.slackcommand.subcommands.listprojecteffort.WebhookClient.send", return_value=webhook_response_factory())
+    def test_no_related_effort(self, *_):
+        expected_slackcommand_count = 0
+        assert SlackCommand.objects.count() == expected_slackcommand_count
+        expected_projectweeklyeffort_count = 0
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        assert project_weekly_effort_count == expected_projectweeklyeffort_count
+
+        subcommand_text = ListProjectEffortSubCommand.DISPLAY_COMMAND_NAME
+        command = SlackCommand(
+            organization=self.organization,
+            user=self.staffuser_with_org,
+            sub_command=ListProjectEffortSubCommand.DISPLAY_COMMAND_NAME,
+            text=subcommand_text,
+            response_url="https://example.com/response_url",
+            payload={"channel_name": "unlinked_channel"},
+        )
+        command.save()
+
+        blocks, web_response, webhook_response = ListProjectEffortSubCommand.handle(command)
+        self.assertTrue(blocks)
+        self.assertFalse(web_response)
+        self.assertTrue(webhook_response)
+
+        expected_block_count = 1  # response content only
+        self.assertEqual(len(blocks), expected_block_count)
+
+    @mock.patch("projects.slackcommand.subcommands.listprojectstatus.WebhookClient.send", return_value=webhook_response_factory())
+    def test_related_project__with_projectweeklyeffort(self, *_):
+        expected_slackcommand_count = 0
+        assert SlackCommand.objects.count() == expected_slackcommand_count
+        expected_projectweeklyeffort_count = 0
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        assert project_weekly_effort_count == expected_projectweeklyeffort_count
+
+        # create a ProjectWeeklyEffort for the project
+        ProjectWeeklyEffort.objects.create(
+            project=self.project,
+            hours=10,
+            user=self.staffuser_with_org,
+            created_by=self.staffuser_with_org,
+            updated_by=self.staffuser_with_org,
+            week_start=previous_week_startdate(),
+        )
+
+        subcommand_text = ListProjectEffortSubCommand.DISPLAY_COMMAND_NAME
+        command = SlackCommand(
+            organization=self.organization,
+            user=self.staffuser_with_org,
+            sub_command=ListProjectEffortSubCommand.DISPLAY_COMMAND_NAME,
+            text=subcommand_text,
+            response_url="https://example.com/response_url",
+            payload={"channel_name": "unlinked_channel"},
+        )
+        command.save()
+
+        blocks, web_response, webhook_response = ListProjectEffortSubCommand.handle(command)
+        self.assertTrue(blocks)
+        self.assertFalse(web_response)
+        self.assertTrue(webhook_response)
+
+        expected_block_count = 1
+        self.assertEqual(len(blocks), expected_block_count)
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        available_subcommands = get_all_subcommands()
+        self.assertIn(ListProjectEffortSubCommand, available_subcommands)

--- a/kippo/projects/tests/subcommands/test_listprojectstatus.py
+++ b/kippo/projects/tests/subcommands/test_listprojectstatus.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from accounts.models import OrganizationMembership, SlackCommand
+from commons.slackcommand import get_all_subcommands
 from commons.tests import IsStaffModelAdminTestCaseBase, setup_basic_project
 from commons.tests.utils import webhook_response_factory
 from django.utils import timezone
@@ -194,3 +195,8 @@ class ProjectStatusSubCommandTestCase(IsStaffModelAdminTestCaseBase):
 
         expected_type = "divider"
         self.assertEqual(divider_block_2["type"], expected_type)
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        available_subcommands = get_all_subcommands()
+        self.assertIn(ListProjectStatusSubCommand, available_subcommands)

--- a/kippo/projects/tests/subcommands/test_projecteffort.py
+++ b/kippo/projects/tests/subcommands/test_projecteffort.py
@@ -1,0 +1,198 @@
+from unittest import mock
+
+from accounts.models import OrganizationMembership, SlackCommand
+from commons.slackcommand import get_all_subcommands
+from commons.tests import IsStaffModelAdminTestCaseBase, setup_basic_project
+from commons.tests.utils import webhook_response_factory
+
+from projects.models import KippoProjectStatus, ProjectWeeklyEffort
+from projects.slackcommand.subcommands.projecteffort import ProjectEffortSubCommand
+
+
+class ProjectStatusSubCommandTestCase(IsStaffModelAdminTestCaseBase):
+    def setUp(self):
+        super().setUp()
+
+        # populate slack related settings
+        self.organization.slack_api_token = "xoxb-1234567890-1234567890123-1234567890123-abcde"  # noqa: S105
+        self.organization.slack_signing_secret = "1234567890123"  # noqa: S105
+        self.organization.slack_command_name = "kippo"
+        self.organization.slack_attendance_report_channel = "#kippo"
+        self.organization.save()
+
+        # update slack user id
+        self.staffuser_with_org_slack_id = "U12345678"
+        self.staffuser_with_org_slack_username = "testuser"
+
+        membership = OrganizationMembership.objects.get(organization=self.organization, user=self.staffuser_with_org)
+        membership.slack_user_id = self.staffuser_with_org_slack_id
+        membership.slack_username = self.staffuser_with_org_slack_username
+        membership.save()
+
+        created = setup_basic_project(organization=self.organization)
+        self.project = created["KippoProject"]
+
+        self.project_slack_channel_name = "test_channel"
+        KippoProjectStatus.objects.all().delete()
+
+    @mock.patch("projects.slackcommand.subcommands.projectstatus.WebhookClient.send", return_value=webhook_response_factory())
+    def test_no_linkied_project(self, *_):
+        """Confirm that a *new* KippoProojectStatus is NOT created when a project with related slack channel is not found."""
+        expected_slackcommand_count = 0
+        assert SlackCommand.objects.count() == expected_slackcommand_count
+        expected_projectweeklyeffort_count = 0
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        assert project_weekly_effort_count == expected_projectweeklyeffort_count
+
+        valid_subcommand_text = f"{ProjectEffortSubCommand.DISPLAY_COMMAND_NAME} 10"
+        command = SlackCommand(
+            organization=self.organization,
+            user=self.staffuser_with_org,
+            sub_command=ProjectEffortSubCommand.DISPLAY_COMMAND_NAME,
+            text=valid_subcommand_text,
+            response_url="https://example.com/response_url",
+            payload={"channel_name": self.project_slack_channel_name},
+        )
+        command.save()
+
+        blocks, web_response, webhook_response = ProjectEffortSubCommand.handle(command)
+        self.assertTrue(blocks)
+        self.assertFalse(web_response)
+        self.assertTrue(webhook_response)
+
+        expected_weekly_effort_count = 0
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        self.assertEqual(project_weekly_effort_count, expected_weekly_effort_count)
+
+    def test_valid_with_subcommand_aliases(self):
+        expected_slackcommand_count = 0
+        assert SlackCommand.objects.count() == expected_slackcommand_count
+        expected_projectweeklyeffort_count = 0
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        assert project_weekly_effort_count == expected_projectweeklyeffort_count
+
+        # link project with slack_channel_name
+        self.project.slack_channel_name = self.project_slack_channel_name
+        self.project.is_closed = False
+        self.project.save()
+
+        weekly_effort_hours = 10
+        for alias in ProjectEffortSubCommand.ALIASES:
+            valid_subcommand_text = f"{alias} {weekly_effort_hours}"
+            command = SlackCommand(
+                organization=self.organization,
+                user=self.staffuser_with_org,
+                sub_command=alias,
+                text=valid_subcommand_text,
+                response_url="https://example.com/response_url",
+                payload={"channel_name": self.project_slack_channel_name},
+            )
+            command.save()
+
+            blocks, web_response, webhook_response = ProjectEffortSubCommand.handle(command)
+            self.assertTrue(blocks)
+            self.assertFalse(web_response)
+            self.assertTrue(webhook_response)
+
+            expected_weekly_effort_count = 1
+            project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+            self.assertEqual(project_weekly_effort_count, expected_weekly_effort_count)
+
+            project_weekly_effort = ProjectWeeklyEffort.objects.first()
+            self.assertTrue(project_weekly_effort)
+
+            self.assertEqual(project_weekly_effort.hours, weekly_effort_hours)
+
+            # delete the created record for the next test iteration
+            project_weekly_effort.delete()
+
+    def test_invalid_hours_input(self):
+        expected_slackcommand_count = 0
+        assert SlackCommand.objects.count() == expected_slackcommand_count
+        expected_projectweeklyeffort_count = 0
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        assert project_weekly_effort_count == expected_projectweeklyeffort_count
+
+        # link project with slack_channel_name
+        self.project.slack_channel_name = self.project_slack_channel_name
+        self.project.is_closed = False
+        self.project.save()
+
+        exceed_max = 7 * 24 + 1  # 7 days * 24 hours + 1 hour
+        for invalid_weekly_effort_values in (" XX other", "XXY", str(exceed_max)):
+            invalid_subcommand_text = f"{ProjectEffortSubCommand.DISPLAY_COMMAND_NAME}{invalid_weekly_effort_values}"
+            command = SlackCommand(
+                organization=self.organization,
+                user=self.staffuser_with_org,
+                sub_command=ProjectEffortSubCommand.DISPLAY_COMMAND_NAME,
+                text=invalid_subcommand_text,
+                response_url="https://example.com/response_url",
+                payload={"channel_name": self.project_slack_channel_name},
+            )
+            command.save()
+
+            blocks, web_response, webhook_response = ProjectEffortSubCommand.handle(command)
+            self.assertTrue(blocks)
+            self.assertFalse(web_response)
+            self.assertTrue(webhook_response)
+
+            expected_weekly_effort_count = 0
+            project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+            self.assertEqual(project_weekly_effort_count, expected_weekly_effort_count)
+
+    def test_entry_already_exists(self):
+        expected_slackcommand_count = 0
+        assert SlackCommand.objects.count() == expected_slackcommand_count
+        expected_projectweeklyeffort_count = 0
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        assert project_weekly_effort_count == expected_projectweeklyeffort_count
+
+        # link project with slack_channel_name
+        self.project.slack_channel_name = self.project_slack_channel_name
+        self.project.is_closed = False
+        self.project.save()
+
+        valid_effort_hours = 10
+        valid_subcommand_text = f"{ProjectEffortSubCommand.DISPLAY_COMMAND_NAME} {valid_effort_hours}"
+        command = SlackCommand(
+            organization=self.organization,
+            user=self.staffuser_with_org,
+            sub_command=ProjectEffortSubCommand.DISPLAY_COMMAND_NAME,
+            text=valid_subcommand_text,
+            response_url="https://example.com/response_url",
+            payload={"channel_name": self.project_slack_channel_name},
+        )
+        command.save()
+
+        blocks, web_response, webhook_response = ProjectEffortSubCommand.handle(command)
+        self.assertTrue(blocks)
+        self.assertFalse(web_response)
+        self.assertTrue(webhook_response)
+
+        expected_weekly_effort_count = 1
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        assert project_weekly_effort_count == expected_weekly_effort_count
+
+        # try to create the same entry again
+        command = SlackCommand(
+            organization=self.organization,
+            user=self.staffuser_with_org,
+            sub_command=ProjectEffortSubCommand.DISPLAY_COMMAND_NAME,
+            text=valid_subcommand_text,
+            response_url="https://example.com/response_url",
+            payload={"channel_name": self.project_slack_channel_name},
+        )
+        command.save()
+        blocks, web_response, webhook_response = ProjectEffortSubCommand.handle(command)
+        self.assertTrue(blocks)
+        self.assertFalse(web_response)
+        self.assertTrue(webhook_response)
+
+        expected_weekly_effort_count = 1
+        project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
+        self.assertEqual(project_weekly_effort_count, expected_weekly_effort_count)
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        available_subcommands = get_all_subcommands()
+        self.assertIn(ProjectEffortSubCommand, available_subcommands)

--- a/kippo/projects/tests/subcommands/test_projecteffort.py
+++ b/kippo/projects/tests/subcommands/test_projecteffort.py
@@ -35,7 +35,7 @@ class ProjectStatusSubCommandTestCase(IsStaffModelAdminTestCaseBase):
         self.project_slack_channel_name = "test_channel"
         KippoProjectStatus.objects.all().delete()
 
-    @mock.patch("projects.slackcommand.subcommands.projectstatus.WebhookClient.send", return_value=webhook_response_factory())
+    @mock.patch("projects.slackcommand.subcommands.projecteffort.WebhookClient.send", return_value=webhook_response_factory())
     def test_no_linkied_project(self, *_):
         """Confirm that a *new* KippoProojectStatus is NOT created when a project with related slack channel is not found."""
         expected_slackcommand_count = 0
@@ -64,7 +64,8 @@ class ProjectStatusSubCommandTestCase(IsStaffModelAdminTestCaseBase):
         project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
         self.assertEqual(project_weekly_effort_count, expected_weekly_effort_count)
 
-    def test_valid_with_subcommand_aliases(self):
+    @mock.patch("projects.slackcommand.subcommands.projecteffort.WebhookClient.send", return_value=webhook_response_factory())
+    def test_valid_with_subcommand_aliases(self, *_):
         expected_slackcommand_count = 0
         assert SlackCommand.objects.count() == expected_slackcommand_count
         expected_projectweeklyeffort_count = 0
@@ -106,7 +107,8 @@ class ProjectStatusSubCommandTestCase(IsStaffModelAdminTestCaseBase):
             # delete the created record for the next test iteration
             project_weekly_effort.delete()
 
-    def test_invalid_hours_input(self):
+    @mock.patch("projects.slackcommand.subcommands.projecteffort.WebhookClient.send", return_value=webhook_response_factory())
+    def test_invalid_hours_input(self, *_):
         expected_slackcommand_count = 0
         assert SlackCommand.objects.count() == expected_slackcommand_count
         expected_projectweeklyeffort_count = 0
@@ -140,7 +142,8 @@ class ProjectStatusSubCommandTestCase(IsStaffModelAdminTestCaseBase):
             project_weekly_effort_count = ProjectWeeklyEffort.objects.filter(project=self.project).count()
             self.assertEqual(project_weekly_effort_count, expected_weekly_effort_count)
 
-    def test_entry_already_exists(self):
+    @mock.patch("projects.slackcommand.subcommands.projecteffort.WebhookClient.send", return_value=webhook_response_factory())
+    def test_entry_already_exists(self, *_):
         expected_slackcommand_count = 0
         assert SlackCommand.objects.count() == expected_slackcommand_count
         expected_projectweeklyeffort_count = 0

--- a/kippo/projects/tests/subcommands/test_projectstatus.py
+++ b/kippo/projects/tests/subcommands/test_projectstatus.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from accounts.models import OrganizationMembership, SlackCommand
+from commons.slackcommand import get_all_subcommands
 from commons.tests import IsStaffModelAdminTestCaseBase, setup_basic_project
 from commons.tests.utils import webhook_response_factory
 
@@ -140,3 +141,8 @@ class ProjectStatusSubCommandTestCase(IsStaffModelAdminTestCaseBase):
 
             # delete the created record for the next test iteration
             kippoprojectstatus.delete()
+
+    def test_subcommand_registered(self):
+        """Confirm that the subcommand is registered."""
+        available_subcommands = get_all_subcommands()
+        self.assertIn(ProjectStatusSubCommand, available_subcommands)


### PR DESCRIPTION
- :sparkles: Add `project-effort HOURS` command
- :sparkles: Add `list-project-effort` command
- :wrench: move `context_processors.py` to commons
- :bug: fix `context_processors.py` missing user filter for PersonalHolidays