### PR TITLE
Point KippoProject view-on-site to /ui/weekly-effort (#202)

### DIFF
--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -266,7 +266,7 @@ class KippoProject(UserCreatedBaseModel):
         return f"{settings.URL_PREFIX}/admin/projects/kippoproject/{self.id}/change"
 
     def get_absolute_url(self):
-        return f"{settings.URL_PREFIX}/projects/?slug={self.slug}"
+        return f"{settings.URL_PREFIX}/ui/weekly-effort"
 
     def get_column_names(self) -> list[str]:
         """

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -3,11 +3,12 @@ import datetime
 from accounts.models import Country, KippoUser, OrganizationMembership, PersonalHoliday, PublicHoliday
 from commons.definitions import SATURDAY, SUNDAY
 from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 from tasks.models import KippoTask, KippoTaskStatus
 
-from projects.models import KippoMilestone, KippoProject
+from projects.models import ActiveKippoProject, KippoMilestone, KippoProject
 
 
 class KippoProjectMethodsTestCase(TestCase):
@@ -107,6 +108,15 @@ class KippoProjectMethodsTestCase(TestCase):
             updated_by=self.github_manager,
         )
         self.task3_status1.save()
+
+    def test_get_absolute_url__points_to_weekly_effort_ui(self):
+        expected = f"{settings.URL_PREFIX}/ui/weekly-effort"
+        self.assertEqual(self.project.get_absolute_url(), expected)
+
+    def test_get_absolute_url__active_project_proxy_points_to_weekly_effort_ui(self):
+        active_project = ActiveKippoProject.objects.get(pk=self.project.pk)
+        expected = f"{settings.URL_PREFIX}/ui/weekly-effort"
+        self.assertEqual(active_project.get_absolute_url(), expected)
 
     def test_get_active_taskstatus__no_max_date(self):
         results, has_estimates = self.project.get_active_taskstatus()


### PR DESCRIPTION
## Summary
- Update `KippoProject.get_absolute_url()` to return `${URL_PREFIX}/ui/weekly-effort` so the Django admin "View on site" link (and any template using `project.get_absolute_url`) opens the weekly effort UI in kippo-ui.
- Add unit tests covering both `KippoProject` and the `ActiveKippoProject` proxy.

## Notes on related models
- `ActiveKippoProject` is a proxy model and inherits the new behavior automatically — verified by test.
- `KippoTask` does not define `get_absolute_url()` / use `view_on_site`, so it is intentionally left unchanged.
- `KippoMilestone.get_absolute_url()` already points at the admin change page and is out of scope for this issue.

Closes #202

## Test plan
- [x] `uv run python manage.py test projects.tests.test_models.KippoProjectMethodsTestCase`
- [x] `uv run python manage.py test projects.tests.test_admin`
- [x] `uv run ruff check` / `ruff format --check` on touched files
- [ ] Manual: open Django admin, click "View on site" on a KippoProject and confirm it lands on `/ui/weekly-effort`