### PR TITLE
Point admin サイトを表示 link to /ui/weekly-effort (#202)

### DIFF
--- a/kippo/commons/admin.py
+++ b/kippo/commons/admin.py
@@ -129,7 +129,7 @@ class KippoAdminSite(admin.AdminSite):
     # update displayed header/title
     site_header = settings.SITE_HEADER
     site_title = settings.SITE_TITLE
-    site_url = f"{settings.URL_PREFIX}/ui/"
+    site_url = f"{settings.URL_PREFIX}/ui/weekly-effort"
 
 
 admin_site = KippoAdminSite(name="kippoadmin")

--- a/kippo/commons/tests/test_admin.py
+++ b/kippo/commons/tests/test_admin.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+from django.test import TestCase
+
+from commons.admin import KippoAdminSite
+
+
+class KippoAdminSiteTestCase(TestCase):
+    def test_site_url_points_to_weekly_effort(self):
+        expected = f"{settings.URL_PREFIX}/ui/weekly-effort"
+        self.assertEqual(KippoAdminSite.site_url, expected)


### PR DESCRIPTION
Refs #202

## Summary
- Updates `KippoAdminSite.site_url` (kippo/commons/admin.py) so the Django admin header **サイトを表示** ("View site") link opens `/ui/weekly-effort` instead of the generic `/ui/` landing page.
- Adds a unit test asserting `KippoAdminSite.site_url` resolves to `{URL_PREFIX}/ui/weekly-effort`.

## Notes
- Re-lands the intent of #203 against `main` (the original PR landed on the stale `master` branch). The correct Django attribute for the header link is `AdminSite.site_url`, not per-object `get_absolute_url()`, so the fix now targets `commons/admin.py` rather than `projects/models.py`.
- `KippoProject.get_absolute_url()` is intentionally left unchanged.

## Test plan
- [x] `uv run poe test commons.tests.test_admin` passes
- [x] `uv run poe check` passes
- [ ] Manual: in Django admin, header "サイトを表示" link opens `/prod/ui/weekly-effort`