### PR TITLE
:mag: Temporary debug log for /api/auth/me/ always-401

### DIFF
--- a/kippo/projects/views.py
+++ b/kippo/projects/views.py
@@ -546,6 +546,27 @@ class CurrentUserView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    def initial(self, request: Request, *args, **kwargs) -> None:
+        # TODO: remove after diagnosing /api/auth/me/ always-401 (see PR fix/auth-me-redirect-loop).
+        # Logs whether the session cookie arrived at Lambda and whether Django's
+        # AuthenticationMiddleware resolved it to an authenticated user.
+        django_request = request._request  # noqa: SLF001
+        django_user = django_request.user
+        cookie_keys = sorted(django_request.COOKIES.keys())
+        logger.warning(
+            "auth-me-debug django_user_authenticated=%s django_user=%s sessionid_present=%s "
+            "session_key_set=%s authorization_header_present=%s cookie_keys=%s origin=%s referer=%s",
+            django_user.is_authenticated,
+            getattr(django_user, "username", None) or str(django_user),
+            "sessionid" in django_request.COOKIES,
+            bool(django_request.session.session_key),
+            "HTTP_AUTHORIZATION" in django_request.META,
+            cookie_keys,
+            django_request.META.get("HTTP_ORIGIN", ""),
+            django_request.META.get("HTTP_REFERER", ""),
+        )
+        super().initial(request, *args, **kwargs)
+
     @extend_schema(
         tags=["auth"],
         summary="Get current user",


### PR DESCRIPTION
## Summary

Diagnostic PR — adds a temporary `logger.warning` in `CurrentUserView.initial()` to pin down why `/api/auth/me/` returns 401 for users who are logged into kippo admin.

## Context

Every `/api/auth/me/` request in `/aws/lambda/kippo-prod` over the past 7 days has returned 401, across multiple users and business hours. Companion client-side fix is in kippo-ui [PR #50](https://github.com/monkut/kippo-ui/pull/50) — that PR stops the SPA from hard-redirecting to a broken `/login` URL on a 401 here, but it doesn't fix the 401 itself. This PR captures the data needed to decide where the 401 comes from.

## What gets logged

Per `/api/auth/me/` request, one WARNING line with:

- `django_user_authenticated` — did `AuthenticationMiddleware` resolve the request to a real user before DRF runs?
- `django_user` — username, or `AnonymousUser`
- `sessionid_present` — did the session cookie reach Lambda at all?
- `session_key_set` — did SessionMiddleware load a session from the DB?
- `authorization_header_present` — JWT path indicator
- `cookie_keys` / `origin` / `referer` — request context

No cookie values or session keys are logged — only whether they're present.

## Expected diagnosis branches

| `sessionid_present` | `django_user_authenticated` | Likely cause |
|---|---|---|
| false | false | Cookie not sent — SameSite / API Gateway / cookie-path issue |
| true | false | Cookie arrived but session lookup missed — expired / different cache / wrong DB |
| true | true | Something downstream of AuthMiddleware is still 401-ing (DRF auth class returning None) |

## Rollback

Ephemeral diagnostic — TODO in the commit to revert once we have the data. Ruff/format clean, 42 tests in \`projects.tests.test_api_rest\` pass.

## Test plan

- [ ] Deploy to prod
- [ ] Click "サイトを表示" from kippo \`/admin/\` as a real user (one hit is enough)
- [ ] Grep \`/aws/lambda/kippo-prod\` for \`auth-me-debug\`
- [ ] Decide the real fix based on which branch of the table above hits
- [ ] Revert this PR