### PR TITLE
:bug: Normalize KippoProject.slack_channel_name on save (refs #208)

### DIFF
--- a/kippo/projects/migrations/0029_normalize_kippoproject_slack_channel_name.py
+++ b/kippo/projects/migrations/0029_normalize_kippoproject_slack_channel_name.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def normalize_slack_channel_names(apps, schema_editor):
+    KippoProject = apps.get_model("projects", "KippoProject")
+    for project in KippoProject.objects.exclude(slack_channel_name="").iterator():
+        normalized = project.slack_channel_name.strip().lstrip("#")
+        if normalized != project.slack_channel_name:
+            project.slack_channel_name = normalized
+            project.save(update_fields=["slack_channel_name"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("projects", "0028_rename_github_project_api_url_to_nodeid"),
+    ]
+
+    operations = [
+        migrations.RunPython(normalize_slack_channel_names, migrations.RunPython.noop),
+    ]

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -517,6 +517,13 @@ class KippoProject(UserCreatedBaseModel):
             # perform initial creation tasks
             self.slug = slugify(self.name, allow_unicode=True)
 
+        # Slack's slash-command payload sends "channel_name" without a leading "#",
+        # so the slash-command project lookup ("...subcommands/projectstatus.py") does
+        # an exact string match on the bare name. Store the canonical bare form here
+        # so users entering "#proj-foo" or "  proj-foo  " in admin still resolve.
+        if self.slack_channel_name:
+            self.slack_channel_name = self.slack_channel_name.strip().lstrip("#")
+
         super().save(*args, **kwargs)
 
     def __str__(self) -> str:

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -185,6 +185,36 @@ class KippoProjectMethodsTestCase(TestCase):
         actual = list(self.project.related_github_repositories())
         self.assertEqual(actual, expected)
 
+    def test_save_strips_leading_hash_from_slack_channel_name(self):
+        self.project.slack_channel_name = "#proj-foo"
+        self.project.save()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.slack_channel_name, "proj-foo")
+
+    def test_save_strips_surrounding_whitespace_from_slack_channel_name(self):
+        self.project.slack_channel_name = "  proj-foo  "
+        self.project.save()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.slack_channel_name, "proj-foo")
+
+    def test_save_strips_whitespace_then_leading_hash(self):
+        self.project.slack_channel_name = "  #proj-foo "
+        self.project.save()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.slack_channel_name, "proj-foo")
+
+    def test_save_preserves_already_normalized_slack_channel_name(self):
+        self.project.slack_channel_name = "proj-foo"
+        self.project.save()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.slack_channel_name, "proj-foo")
+
+    def test_save_leaves_empty_slack_channel_name_empty(self):
+        self.project.slack_channel_name = ""
+        self.project.save()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.slack_channel_name, "")
+
 
 class KippoMilestoneMethodsTestCase(TestCase):
     fixtures = DEFAULT_FIXTURES


### PR DESCRIPTION
Refs #208.

## Summary

`KippoProject.slack_channel_name` was stored as entered. Slack's slash-command payload sends `channel_name` *without* a leading `#`, while admins commonly enter the channel as `#proj-foo` — the slash-command lookup `ActiveKippoProject.objects.filter(...slack_channel_name=source_channel).first()` silently missed those projects. Cost reports tolerated both forms, so the bug shipped invisibly.

## Changes

- `kippo/projects/models.py` — `KippoProject.save()` now strips surrounding whitespace then a single leading `#` before persisting. All future saves store the canonical bare form. Inline comment explains *why* (slash-command payload contract).
- `kippo/projects/migrations/0029_normalize_kippoproject_slack_channel_name.py` — one-shot data migration that applies the same normalization to existing rows. Reverse is `noop` (the bare form is also valid input, so reversing wouldn't change behavior).
- `kippo/projects/tests/test_models.py` — 5 new tests in `KippoProjectMethodsTestCase`:
  - leading `#` only
  - surrounding whitespace only
  - whitespace + leading `#`
  - already-normalized passthrough
  - empty-string passthrough

## Out of scope

- No uniqueness enforcement (two projects sharing a channel still possible — `.first()` arbitrarily picks)
- No full Slack channel-name validation (lowercase / character set)

## Test plan

- [x] `uv run poe check` clean
- [x] `uv run python manage.py test projects.tests.test_models` — 17/17 pass (5 new)
- [x] `uv run python manage.py makemigrations --check` — no missing migrations from this app
- [ ] Deploy and confirm a project previously saved as `#some-channel` now resolves slash commands invoked from `#some-channel`