### PR TITLE
:lipstick: Collapse KippoProject GithubRepository inline and cap at 5

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -244,13 +244,15 @@ class GithubRepositoryProjectInlineFormSet(BaseInlineFormSet):
             obj.save(update_fields=["project"])
 
 
-class GithubRepositoryProjectInline(AllowIsStaffAdminMixin, admin.TabularInline):
+class GithubRepositoryProjectInline(AllowIsStaffAdminMixin, admin.StackedInline):
     model = GithubRepository
     fk_name = "project"
     form = GithubRepositoryProjectInlineForm
     formset = GithubRepositoryProjectInlineFormSet
-    extra = 1
+    extra = 0
+    max_num = 5
     fields = ("html_url",)
+    classes = ("collapse",)
     verbose_name = _("Github Repository")
     verbose_name_plural = _("Github Repositories")
 


### PR DESCRIPTION
## Summary
- Switch `GithubRepositoryProjectInline` from `TabularInline` to `StackedInline` for cleaner collapse rendering
- Auto-fold the inline closed via `classes = ("collapse",)`
- Cap inline rows at `max_num = 5`
- Set `extra = 0` so empty form rows aren't rendered by default

## Test plan
- [ ] Open a `KippoProject` change page in Django admin
- [ ] Confirm the "Github Repositories" inline section is collapsed by default
- [ ] Confirm the section expands on click
- [ ] Confirm no more than 5 GithubRepository rows can be added (UI prevents add beyond 5)
- [ ] Confirm existing repositories on a project still render and remain editable