### PR TITLE
:sparkles: Add Close Project admin action with optional upsell flow

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -48,6 +48,7 @@ from .functions import (
     get_user_session_organization,
 )
 from .models import (
+    UPSELL_CATEGORY_VALUES,
     ActiveKippoProject,
     CollectIssuesAction,
     KippoMilestone,
@@ -62,6 +63,8 @@ from .models import (
     ProjectMonthlyCost,
     ProjectWeeklyEffort,
 )
+
+CLOSE_PROJECT_NO_UPSELL_VALUE = "__no_upsell__"
 
 logger = logging.getLogger(__name__)
 
@@ -389,6 +392,84 @@ def collect_project_github_repositories_action(modeladmin: admin.ModelAdmin, req
 collect_project_github_repositories_action.short_description = _("Collect Project Repositories")  # noqa: E305
 
 
+class CloseProjectActionForm(forms.Form):
+    CATEGORY_CHOICES = (
+        ("upsell-improvement", _("(Upsell) 追加改善・拡張")),
+        ("upsell-new-proposal", _("(Upsell) 新規提案")),
+        ("upsell-new-department", _("(Upsell) 別部署紹介")),
+        (CLOSE_PROJECT_NO_UPSELL_VALUE, _("upsellなし")),
+    )
+
+    category = forms.ChoiceField(
+        label=_("Category"),
+        widget=forms.RadioSelect,
+        choices=CATEGORY_CHOICES,
+    )
+    close_comment = forms.CharField(
+        label=_("Close Comment"),
+        widget=forms.Textarea(attrs={"rows": 4, "cols": 60}),
+        required=False,
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        category = cleaned_data.get("category")
+        close_comment = cleaned_data.get("close_comment", "").strip()
+        if category == CLOSE_PROJECT_NO_UPSELL_VALUE and not close_comment:
+            raise ValidationError({"close_comment": _("Close Comment is required when upsellなし is selected.")})
+        return cleaned_data
+
+
+def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoRequest, queryset: models.QuerySet):
+    """Close a KippoProject with an optional upsell follow-up project."""
+    if queryset.count() != 1:
+        modeladmin.message_user(request, _("Select exactly one project to close."), level=messages.ERROR)
+        return None
+
+    project: KippoProject = queryset.first()
+    if project.is_closed:
+        modeladmin.message_user(
+            request,
+            _("Project is already closed; re-open the project before closing again."),
+            level=messages.ERROR,
+        )
+        return None
+
+    if request.POST.get("post") == "yes":
+        form = CloseProjectActionForm(request.POST)
+        if form.is_valid():
+            selected_category = form.cleaned_data["category"]
+            project.close_comment = form.cleaned_data["close_comment"]
+            project.is_closed = True
+            project.actual_date = timezone.now().date()
+            project.display_as_active = False
+            project.display_in_project_report = False
+            project.updated_by = request.user
+            project.save()
+
+            modeladmin.message_user(request, _("Project '%s' closed.") % project.name, level=messages.INFO)
+
+            if selected_category in UPSELL_CATEGORY_VALUES:
+                params = urllib.parse.urlencode({"category": selected_category, "parent_project": str(project.id)})
+                return HttpResponseRedirect(f"{settings.URL_PREFIX}/admin/projects/kippoproject/add/?{params}")
+            return HttpResponseRedirect(f"{settings.URL_PREFIX}/admin/projects/kippoproject/")
+    else:
+        form = CloseProjectActionForm()
+
+    context = {
+        **modeladmin.admin_site.each_context(request),
+        "title": _("Close Project"),
+        "project": project,
+        "form": form,
+        "action": "close_kippoproject_action",
+        "opts": modeladmin.model._meta,
+    }
+    return TemplateResponse(request, "admin/projects/close_project_action.html", context)
+
+
+close_kippoproject_action.short_description = _("Close Project")  # noqa: E305
+
+
 @admin.register(KippoProject)
 class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     list_display = (
@@ -415,9 +496,11 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         create_github_organizational_project_action,
         create_github_repository_milestones_action,
         collect_project_github_repositories_action,
+        close_kippoproject_action,
         "export_project_kippotaskstatus_csv",
         "export_kippoprojectstatus_comments_csv",
     ]
+    exclude = ("is_closed", "actual_date", "display_as_active", "display_in_project_report")
     inlines = [
         # Milestones not used atm, commenting out.
         # KippoMilestoneReadOnlyInline,
@@ -629,7 +712,30 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             form.base_fields[fieldname].widget.can_change_related = False
             form.base_fields[fieldname].widget.can_delete_related = False
 
+        # parent_project: hidden on add form (preserves GET prefill); readonly on change form (handled in get_readonly_fields)
+        if obj is None and "parent_project" in form.base_fields:
+            form.base_fields["parent_project"].widget = forms.HiddenInput()
+            parent_project_id = request.GET.get("parent_project")
+            if parent_project_id:
+                form.base_fields["parent_project"].initial = parent_project_id
         return form
+
+    def get_readonly_fields(self, request: DjangoRequest, obj: KippoProject | None = None) -> tuple[str, ...]:
+        readonly_fields = tuple(super().get_readonly_fields(request, obj))
+        # show parent_project as readonly on the change form so admins can see the upsell parent
+        if obj is not None and "parent_project" not in readonly_fields:
+            readonly_fields = (*readonly_fields, "parent_project")
+        return readonly_fields
+
+    def get_changeform_initial_data(self, request: DjangoRequest) -> dict:
+        initial = super().get_changeform_initial_data(request)
+        category = request.GET.get("category")
+        if category:
+            initial["category"] = category
+        parent_project_id = request.GET.get("parent_project")
+        if parent_project_id:
+            initial["parent_project"] = parent_project_id
+        return initial
 
     def save_model(self, request: DjangoRequest, obj: KippoProject, form: Form, change: bool):
         if obj.pk is None:

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -36,7 +36,7 @@ from rangefilter.filters import DateRangeFilterBuilder
 from tasks.models import KippoTaskStatus
 from tasks.periodic.tasks import collect_github_project_issues
 
-from .definitions import ProjectProgressStatus
+from .definitions import UPSELL_CATEGORY_VALUES, ProjectProgressStatus
 from .exceptions import GithubMilestoneAlreadyExistsError
 from .functions import (
     generate_kippoprojectusermonthlystatisfaction_csv,
@@ -48,7 +48,6 @@ from .functions import (
     get_user_session_organization,
 )
 from .models import (
-    UPSELL_CATEGORY_VALUES,
     ActiveKippoProject,
     CollectIssuesAction,
     KippoMilestone,

--- a/kippo/projects/definitions.py
+++ b/kippo/projects/definitions.py
@@ -3,6 +3,7 @@ import datetime
 from typing import TYPE_CHECKING
 
 from commons.definitions import StringEnumWithChoices
+from django.utils.translation import gettext_lazy as _
 
 if TYPE_CHECKING:
     from .models import KippoProject
@@ -10,6 +11,22 @@ if TYPE_CHECKING:
 
 # Minimum effort percentage required for a user to be included in survey tracking
 SURVEY_EFFORT_THRESHOLD_PERCENTAGE = 3
+
+KIPPOPROJECT_CATEGORY_CHOICES = (
+    ("new-proposal", _("新規提案")),
+    ("maintenance", _("保守")),
+    ("poc", "poc"),
+    ("instructor", _("講師")),
+    ("r-and-d", "R&D"),
+    ("PAO", "PAO"),
+    ("upsell-improvement", _("(Upsell) 追加改善・拡張")),
+    ("upsell-new-proposal", _("(Upsell) 新規提案")),
+    ("upsell-new-department", _("(Upsell) 別部署紹介")),
+    ("other", _("その他")),
+)
+UPSELL_CATEGORY_VALUES = ("upsell-improvement", "upsell-new-proposal", "upsell-new-department")
+KIPPOPROJECT_CATEGORY_MAX_LENGTH = 32
+VALID_KIPPOPROJECT_CATEGORY_VALUES = tuple(choice[0] for choice in KIPPOPROJECT_CATEGORY_CHOICES)
 
 
 class ProjectRoles(StringEnumWithChoices):

--- a/kippo/projects/migrations/0031_kippoproject_category_choices_close_fields.py
+++ b/kippo/projects/migrations/0031_kippoproject_category_choices_close_fields.py
@@ -1,0 +1,62 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+NEW_CATEGORY_CHOICES = (
+    ("new-proposal", "新規提案"),
+    ("maintenance", "保守"),
+    ("poc", "poc"),
+    ("instructor", "講師"),
+    ("r-and-d", "R&D"),
+    ("PAO", "PAO"),
+    ("upsell-improvement", "(Upsell) 追加改善・拡張"),
+    ("upsell-new-proposal", "(Upsell) 新規提案"),
+    ("upsell-new-department", "(Upsell) 別部署紹介"),
+    ("other", "その他"),
+)
+NEW_CATEGORY_VALUES = tuple(value for value, _label in NEW_CATEGORY_CHOICES)
+
+
+def map_invalid_categories_to_other(apps, schema_editor):
+    KippoProject = apps.get_model("projects", "KippoProject")  # noqa: N806
+    KippoProject.objects.exclude(category__in=NEW_CATEGORY_VALUES).update(category="other")
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("projects", "0030_issue9_project_external_resources"),
+    ]
+
+    operations = [
+        # Map invalid existing category values to "other" BEFORE narrowing max_length to avoid truncation
+        migrations.RunPython(map_invalid_categories_to_other, noop_reverse),
+        migrations.AddField(
+            model_name="kippoproject",
+            name="close_comment",
+            field=models.TextField(blank=True, default="", verbose_name="Close Comment"),
+        ),
+        migrations.AddField(
+            model_name="kippoproject",
+            name="parent_project",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Original (parent) project for upsell projects",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="upsell_children",
+                to="projects.kippoproject",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="kippoproject",
+            name="category",
+            field=models.CharField(
+                choices=NEW_CATEGORY_CHOICES,
+                default="poc",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -22,7 +22,14 @@ from django.utils.translation import gettext_lazy as _
 from ghorgs.managers import GithubOrganizationManager
 from tasks.models import KippoTaskStatus
 
-from .definitions import ProjectProgressStatus, ProjectRoles, ValidCurrencies, ValidServices
+from .definitions import (
+    KIPPOPROJECT_CATEGORY_CHOICES,
+    KIPPOPROJECT_CATEGORY_MAX_LENGTH,
+    ProjectProgressStatus,
+    ProjectRoles,
+    ValidCurrencies,
+    ValidServices,
+)
 from .exceptions import ProjectColumnSetError
 from .functions import previous_week_startdate
 
@@ -150,22 +157,6 @@ VALID_PROJECT_PHASES = (
     ("project-proposal", "Project Proposal Preparation"),
     ("project-development", "Project Development"),
 )
-
-KIPPOPROJECT_CATEGORY_CHOICES = (
-    ("new-proposal", _("新規提案")),
-    ("maintenance", _("保守")),
-    ("poc", "poc"),
-    ("instructor", _("講師")),
-    ("r-and-d", "R&D"),
-    ("PAO", "PAO"),
-    ("upsell-improvement", _("(Upsell) 追加改善・拡張")),
-    ("upsell-new-proposal", _("(Upsell) 新規提案")),
-    ("upsell-new-department", _("(Upsell) 別部署紹介")),
-    ("other", _("その他")),
-)
-UPSELL_CATEGORY_VALUES = ("upsell-improvement", "upsell-new-proposal", "upsell-new-department")
-KIPPOPROJECT_CATEGORY_MAX_LENGTH = 32
-VALID_KIPPOPROJECT_CATEGORY_VALUES = tuple(choice[0] for choice in KIPPOPROJECT_CATEGORY_CHOICES)
 
 
 @reversion.register()

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -151,6 +151,22 @@ VALID_PROJECT_PHASES = (
     ("project-development", "Project Development"),
 )
 
+KIPPOPROJECT_CATEGORY_CHOICES = (
+    ("new-proposal", _("新規提案")),
+    ("maintenance", _("保守")),
+    ("poc", "poc"),
+    ("instructor", _("講師")),
+    ("r-and-d", "R&D"),
+    ("PAO", "PAO"),
+    ("upsell-improvement", _("(Upsell) 追加改善・拡張")),
+    ("upsell-new-proposal", _("(Upsell) 新規提案")),
+    ("upsell-new-department", _("(Upsell) 別部署紹介")),
+    ("other", _("その他")),
+)
+UPSELL_CATEGORY_VALUES = ("upsell-improvement", "upsell-new-proposal", "upsell-new-department")
+KIPPOPROJECT_CATEGORY_MAX_LENGTH = 32
+VALID_KIPPOPROJECT_CATEGORY_VALUES = tuple(choice[0] for choice in KIPPOPROJECT_CATEGORY_CHOICES)
+
 
 @reversion.register()
 class KippoProject(UserCreatedBaseModel):
@@ -169,7 +185,11 @@ class KippoProject(UserCreatedBaseModel):
         validators=(MaxValueValidator(100), MinValueValidator(0)),
         help_text=_("0-100, Confidence level of the project proceeding to the next phase"),
     )
-    category = models.CharField(max_length=256, default=settings.DEFAULT_KIPPOPROJECT_CATEGORY)
+    category = models.CharField(
+        max_length=KIPPOPROJECT_CATEGORY_MAX_LENGTH,
+        choices=KIPPOPROJECT_CATEGORY_CHOICES,
+        default=settings.DEFAULT_KIPPOPROJECT_CATEGORY,
+    )
     slack_channel_name = models.CharField(
         max_length=80,
         blank=True,
@@ -197,7 +217,16 @@ class KippoProject(UserCreatedBaseModel):
         blank=True,
         help_text=_("Project Manager assigned to the project"),
     )
+    parent_project = models.ForeignKey(
+        "self",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="upsell_children",
+        help_text=_("Original (parent) project for upsell projects"),
+    )
     is_closed = models.BooleanField(_("Project is Closed"), default=False, help_text=_("Manually set when project is complete"))
+    close_comment = models.TextField(_("Close Comment"), blank=True, default="")
     display_as_active = models.BooleanField(
         _("Display as Active"),
         default=True,

--- a/kippo/projects/templates/admin/projects/close_project_action.html
+++ b/kippo/projects/templates/admin/projects/close_project_action.html
@@ -1,0 +1,41 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+  &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+  &rsaquo; {% trans 'Close Project' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+  <h1>{% trans "Close Project" %}: {{ project.name }}</h1>
+  <form method="post">{% csrf_token %}
+    <input type="hidden" name="action" value="close_kippoproject_action">
+    <input type="hidden" name="post" value="yes">
+    <input type="hidden" name="_selected_action" value="{{ project.id }}">
+    <fieldset class="module aligned">
+      {% if form.non_field_errors %}
+        <p class="errornote">{{ form.non_field_errors }}</p>
+      {% endif %}
+      <div class="form-row{% if form.category.errors %} errors{% endif %}">
+        {% if form.category.errors %}{{ form.category.errors }}{% endif %}
+        <label class="required">{{ form.category.label }}:</label>
+        {{ form.category }}
+      </div>
+      <div class="form-row{% if form.close_comment.errors %} errors{% endif %}">
+        {% if form.close_comment.errors %}{{ form.close_comment.errors }}{% endif %}
+        <label for="{{ form.close_comment.id_for_label }}">{{ form.close_comment.label }}:</label>
+        {{ form.close_comment }}
+      </div>
+    </fieldset>
+    <div class="submit-row">
+      <input type="submit" class="default" value="{% trans 'OK' %}">
+      <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link">{% trans 'Cancel' %}</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1,8 +1,10 @@
 from http import HTTPStatus
 from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
 
 from accounts.models import KippoUser, OrganizationMembership
 from commons.tests import DEFAULT_COLUMNSET_PK, DEFAULT_FIXTURES, IsStaffModelAdminTestCaseBase
+from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.urls import reverse
 from django.utils import timezone
 
@@ -213,3 +215,194 @@ class ProjectsAdminViewTestCase(IsStaffModelAdminTestCaseBase):
         # response = self.client.get(url)
         # self.assertEqual(response.status_code, HTTPStatus.OK)
         # self.assertTemplateUsed(response, "admin/change_list.html")
+
+
+class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        super().setUp()
+        columnset = ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK)
+        self.current_date = timezone.now().date()
+        # add organization membership for the superuser to satisfy has_add_permission
+        OrganizationMembership.objects.create(
+            user=self.superuser_no_org,
+            organization=self.organization,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.project1 = KippoProject.objects.create(
+            organization=self.organization,
+            name="project1",
+            category="poc",
+            columnset=columnset,
+            start_date=self.current_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.project2 = KippoProject.objects.create(
+            organization=self.organization,
+            name="project2",
+            category="poc",
+            columnset=columnset,
+            start_date=self.current_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.changelist_url = reverse("admin:projects_kippoproject_changelist")
+        self.client.force_login(self.superuser_no_org)
+
+    def test_multiple_projects_selected_rejected(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id), str(self.project2.id)],
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.project1.refresh_from_db()
+        self.project2.refresh_from_db()
+        self.assertFalse(self.project1.is_closed)
+        self.assertFalse(self.project2.is_closed)
+        # ensure error message displayed
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("exactly one" in m.lower() for m in messages_list), messages_list)
+
+    def test_already_closed_rejected(self):
+        self.project1.is_closed = True
+        self.project1.save()
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("re-open" in m.lower() for m in messages_list), messages_list)
+
+    def test_no_upsell_requires_close_comment(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                "post": "yes",
+                "category": "__no_upsell__",
+                "close_comment": "",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        # form was redisplayed with errors; project not closed
+        self.project1.refresh_from_db()
+        self.assertFalse(self.project1.is_closed)
+        # form should have errors attribute
+        form = response.context.get("form")
+        self.assertIsNotNone(form)
+        self.assertIn("close_comment", form.errors)
+
+    def test_no_upsell_flow_closes_project(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                "post": "yes",
+                "category": "__no_upsell__",
+                "close_comment": "Project completed successfully.",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertIn("/admin/projects/kippoproject/", response["Location"])
+        # ensure no add page is requested for upsell-none
+        self.assertNotIn("/add/", response["Location"])
+
+        self.project1.refresh_from_db()
+        self.assertTrue(self.project1.is_closed)
+        self.assertEqual(self.project1.actual_date, timezone.now().date())
+        self.assertFalse(self.project1.display_as_active)
+        self.assertFalse(self.project1.display_in_project_report)
+        self.assertEqual(self.project1.close_comment, "Project completed successfully.")
+        self.assertIsNotNone(self.project1.closed_datetime)
+
+        # confirm no new project was created
+        self.assertEqual(KippoProject.objects.count(), 2)
+
+    def test_upsell_flow_closes_and_redirects(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                "post": "yes",
+                "category": "upsell-improvement",
+                "close_comment": "",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertIn("/admin/projects/kippoproject/add/", response["Location"])
+        parsed = urlparse(response["Location"])
+        params = parse_qs(parsed.query)
+        self.assertEqual(params.get("category"), ["upsell-improvement"])
+        self.assertEqual(params.get("parent_project"), [str(self.project1.id)])
+
+        self.project1.refresh_from_db()
+        self.assertTrue(self.project1.is_closed)
+        self.assertFalse(self.project1.display_as_active)
+        self.assertFalse(self.project1.display_in_project_report)
+        # category on the closing project is unchanged
+        self.assertEqual(self.project1.category, "poc")
+
+    def test_intermediate_form_get(self):
+        """Without 'post=yes', the action displays the intermediate form."""
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertTemplateUsed(response, "admin/projects/close_project_action.html")
+        self.assertContains(response, "project1")
+
+    def test_add_form_prefills_from_get_params(self):
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url, {"category": "upsell-improvement", "parent_project": str(self.project1.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        adminform = response.context["adminform"]
+        self.assertEqual(adminform.form.initial.get("category"), "upsell-improvement")
+        self.assertEqual(adminform.form.initial.get("parent_project"), str(self.project1.id))
+        # parent_project widget should be hidden on add form
+        self.assertEqual(adminform.form.fields["parent_project"].widget.input_type, "hidden")
+
+    def test_close_related_fields_hidden_from_change_form(self):
+        url = reverse("admin:projects_kippoproject_change", args=[self.project1.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.content.decode()
+        for field_name in ("is_closed", "actual_date", "display_as_active", "display_in_project_report"):
+            self.assertNotIn(f'name="{field_name}"', content, f"{field_name} should not be in form")
+
+    def test_change_form_shows_parent_project_readonly(self):
+        child = KippoProject.objects.create(
+            organization=self.organization,
+            name="upsell-child",
+            category="upsell-improvement",
+            columnset=ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK),
+            parent_project=self.project1,
+            start_date=self.current_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        url = reverse("admin:projects_kippoproject_change", args=[child.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        # parent_project should appear as readonly (no input element with that name)
+        self.assertNotIn('name="parent_project"', response.content.decode())
+        self.assertContains(response, self.project1.name)

--- a/kippo/projects/tests/test_migrations.py
+++ b/kippo/projects/tests/test_migrations.py
@@ -1,0 +1,62 @@
+import importlib
+
+from django.test import TestCase
+
+migration_module = importlib.import_module("projects.migrations.0031_kippoproject_category_choices_close_fields")
+map_invalid_categories_to_other = migration_module.map_invalid_categories_to_other
+
+
+class FakeQuerySet:
+    def __init__(self, projects: list[dict]) -> None:
+        self._projects = projects
+
+    def exclude(self, **kwargs):
+        valid_values = kwargs["category__in"]
+        return FakeQuerySet([p for p in self._projects if p["category"] not in valid_values])
+
+    def update(self, **kwargs):
+        for project in self._projects:
+            for key, value in kwargs.items():
+                project[key] = value
+        return len(self._projects)
+
+
+class FakeManager:
+    def __init__(self, projects: list[dict]) -> None:
+        self._projects = projects
+
+    def exclude(self, **kwargs):
+        return FakeQuerySet(self._projects).exclude(**kwargs)
+
+
+class FakeKippoProject:
+    def __init__(self, projects: list[dict]) -> None:
+        self.objects = FakeManager(projects)
+
+
+class FakeApps:
+    def __init__(self, projects: list[dict]) -> None:
+        self._model = FakeKippoProject(projects)
+
+    def get_model(self, app_label: str, model_name: str):
+        assert app_label == "projects"
+        assert model_name == "KippoProject"
+        return self._model
+
+
+class CategoryDataMigrationTestCase(TestCase):
+    def test_invalid_category_values_mapped_to_other(self):
+        projects = [
+            {"name": "p1", "category": "testing"},
+            {"name": "p2", "category": "foo"},
+            {"name": "p3", "category": "poc"},
+            {"name": "p4", "category": "new-proposal"},
+            {"name": "p5", "category": "upsell-improvement"},
+        ]
+        apps = FakeApps(projects)
+        map_invalid_categories_to_other(apps, schema_editor=None)
+        self.assertEqual(projects[0]["category"], "other")
+        self.assertEqual(projects[1]["category"], "other")
+        self.assertEqual(projects[2]["category"], "poc")
+        self.assertEqual(projects[3]["category"], "new-proposal")
+        self.assertEqual(projects[4]["category"], "upsell-improvement")

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -8,13 +8,12 @@ from django.test import TestCase
 from django.utils import timezone
 from tasks.models import KippoTask, KippoTaskStatus
 
-from projects.models import (
+from projects.definitions import (
     KIPPOPROJECT_CATEGORY_CHOICES,
     UPSELL_CATEGORY_VALUES,
     VALID_KIPPOPROJECT_CATEGORY_VALUES,
-    KippoMilestone,
-    KippoProject,
 )
+from projects.models import KippoMilestone, KippoProject
 
 
 class KippoProjectMethodsTestCase(TestCase):

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -3,11 +3,18 @@ import datetime
 from accounts.models import Country, KippoUser, OrganizationMembership, PersonalHoliday, PublicHoliday
 from commons.definitions import SATURDAY, SUNDAY
 from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 from tasks.models import KippoTask, KippoTaskStatus
 
-from projects.models import KippoMilestone, KippoProject
+from projects.models import (
+    KIPPOPROJECT_CATEGORY_CHOICES,
+    UPSELL_CATEGORY_VALUES,
+    VALID_KIPPOPROJECT_CATEGORY_VALUES,
+    KippoMilestone,
+    KippoProject,
+)
 
 
 class KippoProjectMethodsTestCase(TestCase):
@@ -602,3 +609,32 @@ class KippoMilestoneMethodsTestCase(TestCase):
         self.assertEqual(len(actual), expected_assignee_count)
         self.assertIn(self.task1.assignee, actual)
         self.assertIn(self.task2.assignee, actual)
+
+
+class KippoProjectCategoryChoicesTestCase(TestCase):
+    fixtures = DEFAULT_FIXTURES
+
+    def test_category_field_choices_match_module_constant(self):
+        choices = KippoProject._meta.get_field("category").choices
+        self.assertEqual(tuple(choices), KIPPOPROJECT_CATEGORY_CHOICES)
+
+    def test_category_field_default_is_poc(self):
+        default = KippoProject._meta.get_field("category").default
+        self.assertEqual(default, settings.DEFAULT_KIPPOPROJECT_CATEGORY)
+        self.assertEqual(default, "poc")
+        self.assertIn(default, VALID_KIPPOPROJECT_CATEGORY_VALUES)
+
+    def test_upsell_category_values_subset_of_choices(self):
+        for value in UPSELL_CATEGORY_VALUES:
+            self.assertIn(value, VALID_KIPPOPROJECT_CATEGORY_VALUES)
+
+    def test_close_comment_field_defaults(self):
+        field = KippoProject._meta.get_field("close_comment")
+        self.assertTrue(field.blank)
+        self.assertEqual(field.default, "")
+
+    def test_parent_project_field_is_self_fk_with_set_null(self):
+        field = KippoProject._meta.get_field("parent_project")
+        self.assertTrue(field.null)
+        self.assertTrue(field.blank)
+        self.assertEqual(field.related_model, KippoProject)


### PR DESCRIPTION
## Summary

Implements the Close Project admin action with optional upsell flow per kiconiaworks/kippo#7.

- `KippoProject`: `category` → fixed choice list (10 values incl. `other`, default `poc`, max_length 32); add `close_comment` (TextField), `parent_project` (self FK, `SET_NULL`).
- Migration `0031`: `RunPython` maps out-of-set categories → `other` BEFORE narrowing `max_length` to avoid truncation.
- Admin: `close_kippoproject_action` with intermediate form (3 upsell options + `upsellなし`); guards on multi-row + already-closed; close action sets `is_closed`, `actual_date`, `display_as_active`, `display_in_project_report`, `close_comment`, then either redirects back to changelist (`upsellなし`) or to the add-form with `category` + `parent_project` GET-prefilled (`upsell-*`).
- Hide `is_closed`, `actual_date`, `display_as_active`, `display_in_project_report` from the change form (admin UI only — non-admin paths intentionally unchanged).
- `parent_project` rendered as `HiddenInput` on the add form (preserves GET prefill); read-only on the change form.
- Template `admin/projects/close_project_action.html` for the wizard step.

## Key flows

- **upsellなし path**: validate `close_comment` is non-empty → mutate close fields → save → redirect to changelist.
- **upsell-\* path**: same close mutation → redirect to `KippoProject` add form with `?category=<selected>&parent_project=<id>`. Existing add-form auto-population (`organization`, `columnset`, `project_manager` defaults via `KippoProjectAdmin.get_form`) continues to apply.
- **Re-close guard**: if selected project has `is_closed=True`, action errors with a "must be re-opened first" message. Re-open is out of scope.

## Test plan

- [x] `uv run python kippo/manage.py test projects.tests.test_models projects.tests.test_admin projects.tests.test_migrations` — 36 tests pass locally.
- [x] `uv run poe check` (ruff) — clean.
- [ ] Reviewer: run full project test suite.
- [ ] Reviewer: apply migration on a copy of prod data; verify out-of-set category values get remapped to `other` and existing rows aren't truncated.
- [ ] Reviewer: manual exercise of the close action end-to-end (both `upsellなし` and one `upsell-*` flow).

## Out of scope (per issue)

- kippo-ui UI updates for new category labels.
- Re-open-project admin path.
- Restricting non-admin code paths from setting `is_closed` (API/serializer/programmatic remain writable).

Closes kiconiaworks/kippo#7