### PR TITLE
Lock closed KippoProjects in admin + add Re-open action

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -68,7 +68,26 @@ CLOSE_PROJECT_NO_UPSELL_VALUE = "__no_upsell__"
 logger = logging.getLogger(__name__)
 
 
-class ProjectAssignmentRateInline(AllowIsStaffAdminMixin, admin.TabularInline):
+class LockWhenProjectClosedInlineMixin:
+    """Inline mixin that disables add/change/delete when the parent KippoProject is closed."""
+
+    def has_add_permission(self, request: DjangoRequest, obj: models.Model | None = None):
+        if getattr(obj, "is_closed", False):
+            return False
+        return super().has_add_permission(request, obj)
+
+    def has_change_permission(self, request: DjangoRequest, obj: models.Model | None = None):
+        if getattr(obj, "is_closed", False):
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_delete_permission(self, request: DjangoRequest, obj: models.Model | None = None):
+        if getattr(obj, "is_closed", False):
+            return False
+        return super().has_delete_permission(request, obj)
+
+
+class ProjectAssignmentRateInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, admin.TabularInline):
     model = ProjectAssignmentRate
     extra = 0
     fields = ("role", "rate_per_day")
@@ -120,7 +139,7 @@ class ProjectWeeklyEffortReadOnlyInine(AllowIsStaffAdminMixin, admin.TabularInli
         return qs
 
 
-class ProjectWeeklyEffortAdminInline(AllowIsStaffAdminMixin, admin.TabularInline):
+class ProjectWeeklyEffortAdminInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, admin.TabularInline):
     model = ProjectWeeklyEffort
     extra = 1
     fields = ("week_start", "user", "hours")
@@ -162,7 +181,7 @@ class KippoProjectStatusReadOnlyInine(AllowIsStaffAdminMixin, admin.TabularInlin
         return qs
 
 
-class KippoProjectStatusAdminInline(AllowIsStaffAdminMixin, admin.TabularInline):
+class KippoProjectStatusAdminInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, admin.TabularInline):
     model = KippoProjectStatus
     extra = 1
     fields = ("comment",)
@@ -246,7 +265,7 @@ class GithubRepositoryProjectInlineFormSet(BaseInlineFormSet):
             obj.save(update_fields=["project"])
 
 
-class GithubRepositoryProjectInline(AllowIsStaffAdminMixin, admin.StackedInline):
+class GithubRepositoryProjectInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, admin.StackedInline):
     model = GithubRepository
     fk_name = "project"
     form = GithubRepositoryProjectInlineForm
@@ -469,6 +488,43 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
 close_kippoproject_action.short_description = _("Close Project")  # noqa: E305
 
 
+def reopen_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoRequest, queryset: models.QuerySet):
+    """Re-open one or more closed KippoProjects and record a status comment."""
+    selected = list(queryset)
+    closed_projects = [p for p in selected if p.is_closed]
+    skipped_count = len(selected) - len(closed_projects)
+    if skipped_count:
+        modeladmin.message_user(
+            request,
+            _("%(count)d project(s) were not closed and were skipped.") % {"count": skipped_count},
+            level=messages.WARNING,
+        )
+    if not closed_projects:
+        modeladmin.message_user(request, _("No closed projects selected to re-open."), level=messages.ERROR)
+        return
+
+    reopen_comment = _("re-opened by %(username)s") % {"username": request.user.username}
+    for project in closed_projects:
+        project.is_closed = False
+        project.actual_date = None
+        project.updated_by = request.user
+        project.save()
+        KippoProjectStatus.objects.create(
+            project=project,
+            comment=reopen_comment,
+            created_by=request.user,
+            updated_by=request.user,
+        )
+    modeladmin.message_user(
+        request,
+        _("Re-opened %(count)d project(s).") % {"count": len(closed_projects)},
+        level=messages.INFO,
+    )
+
+
+reopen_kippoproject_action.short_description = _("Re-open Project(s)")  # noqa: E305
+
+
 @admin.register(KippoProject)
 class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     list_display = (
@@ -496,6 +552,7 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         create_github_repository_milestones_action,
         collect_project_github_repositories_action,
         close_kippoproject_action,
+        reopen_kippoproject_action,
         "export_project_kippotaskstatus_csv",
         "export_kippoprojectstatus_comments_csv",
     ]
@@ -689,6 +746,9 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         """Set defaults based on request user"""
         # update user field with logged user as default
         form = super().get_form(request, obj, **kwargs)
+        # closed projects: every field is readonly, so base_fields is empty — skip the editable-form tweaks
+        if obj is not None and obj.is_closed:
+            return form
         form.base_fields["project_manager"].initial = request.user.id
         try:
             user_initial_organization, user_organizations = get_user_session_organization(request)
@@ -724,6 +784,15 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # show parent_project as readonly on the change form so admins can see the upsell parent
         if obj is not None and "parent_project" not in readonly_fields:
             readonly_fields = (*readonly_fields, "parent_project")
+        # closed projects: lock every editable field — use the re-open action to edit
+        if obj is not None and obj.is_closed:
+            excluded = set(self.exclude or ())
+            locked = tuple(
+                f.name
+                for f in self.model._meta.get_fields()
+                if getattr(f, "editable", False) and not f.auto_created and f.name not in excluded and f.name not in readonly_fields
+            )
+            readonly_fields = (*readonly_fields, *locked)
         return readonly_fields
 
     def get_changeform_initial_data(self, request: DjangoRequest) -> dict:
@@ -770,6 +839,7 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
     # Override parent ordering to match UI: confidence desc, target_date asc, name asc
     ordering = ("-confidence", "target_date", "name")
 
+    # is_closed/actual_date/display_as_active/display_in_project_report are excluded by KippoProjectAdmin and must not appear here
     fieldsets = [
         (
             None,
@@ -788,7 +858,6 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
                 "fields": (
                     "start_date",
                     "target_date",
-                    "actual_date",
                     "allocated_staff_days",
                 ),
             },
@@ -804,9 +873,6 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
                     "slack_channel_name",
                     "slack_notification_channel_name",
                     "columnset",
-                    "is_closed",
-                    "display_as_active",
-                    "display_in_project_report",
                     "enable_cost_report",
                     "document_folder_url",
                     "github_project_html_url",

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1,3 +1,4 @@
+from datetime import date
 from http import HTTPStatus
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
@@ -9,7 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from projects.admin import KippoMilestoneAdmin, KippoProjectAdmin, ProjectWeeklyEffortAdminInline
-from projects.models import KippoMilestone, KippoProject, ProjectColumnSet
+from projects.models import KippoMilestone, KippoProject, KippoProjectStatus, ProjectColumnSet
 
 
 class MockRequest:
@@ -406,3 +407,171 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         # parent_project should appear as readonly (no input element with that name)
         self.assertNotIn('name="parent_project"', response.content.decode())
         self.assertContains(response, self.project1.name)
+
+
+class KippoProjectAdminFixtureTestCaseBase(IsStaffModelAdminTestCaseBase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        super().setUp()
+        self.columnset = ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK)
+        self.current_date = timezone.now().date()
+        OrganizationMembership.objects.create(
+            user=self.superuser_no_org,
+            organization=self.organization,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.client.force_login(self.superuser_no_org)
+
+    def make_project(self, name: str, *, is_closed: bool = False, actual_date: date | None = None) -> KippoProject:
+        project = KippoProject.objects.create(
+            organization=self.organization,
+            name=name,
+            category="poc",
+            columnset=self.columnset,
+            start_date=self.current_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        if is_closed:
+            project.is_closed = True
+            project.actual_date = actual_date
+            project.save()
+        return project
+
+
+class ActiveKippoProjectChangeViewTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """Regression: ActiveKippoProject.fieldsets must not reference fields excluded by the parent admin."""
+
+    def setUp(self):
+        super().setUp()
+        self.active_project = self.make_project("active-project")
+
+    def test_change_view_renders_without_keyerror(self):
+        url = reverse("admin:projects_activekippoproject_change", args=[self.active_project.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    def test_fieldsets_do_not_reference_excluded_fields(self):
+        from projects.admin import ActiveKippoProjectAdmin
+
+        excluded = set(ActiveKippoProjectAdmin.exclude or ())
+        for _label, opts in ActiveKippoProjectAdmin.fieldsets:
+            overlap = [f for f in opts["fields"] if f in excluded]
+            self.assertFalse(overlap, f"fieldset references excluded fields: {overlap}")
+
+
+class ClosedProjectReadonlyTestCase(KippoProjectAdminFixtureTestCaseBase):
+    def setUp(self):
+        super().setUp()
+        self.open_project = self.make_project("open-project")
+        self.closed_project = self.make_project("closed-project", is_closed=True)
+
+    def test_closed_project_change_form_locks_all_editable_fields(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        readonly = set(modeladmin.get_readonly_fields(self.super_user_request, self.closed_project))
+        excluded = set(modeladmin.exclude or ())
+        expected_locked = {
+            f.name for f in KippoProject._meta.get_fields() if getattr(f, "editable", False) and not f.auto_created and f.name not in excluded
+        }
+        missing = expected_locked - readonly
+        self.assertFalse(missing, f"expected fields locked but were not: {missing}")
+
+    def test_open_project_change_form_keeps_fields_editable(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        readonly = set(modeladmin.get_readonly_fields(self.super_user_request, self.open_project))
+        editable_field_names = {
+            f.name for f in KippoProject._meta.get_fields() if getattr(f, "editable", False) and not f.auto_created and f.name != "parent_project"
+        }
+        self.assertFalse(editable_field_names & readonly, f"editable fields unexpectedly locked: {editable_field_names & readonly}")
+
+    def test_closed_project_change_form_renders_no_editable_inputs_for_model_fields(self):
+        url = reverse("admin:projects_kippoproject_change", args=[self.closed_project.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.content.decode()
+        for field_name in ("name", "phase", "category", "confidence", "project_manager"):
+            self.assertNotIn(f'name="{field_name}"', content, f"{field_name} should be readonly on closed project")
+
+
+class ReopenProjectActionTestCase(KippoProjectAdminFixtureTestCaseBase):
+    def setUp(self):
+        super().setUp()
+        self.closed_project_a = self.make_project("closed-a", is_closed=True, actual_date=self.current_date)
+        self.closed_project_b = self.make_project("closed-b", is_closed=True, actual_date=self.current_date)
+        self.open_project = self.make_project("still-open")
+        self.changelist_url = reverse("admin:projects_kippoproject_changelist")
+
+    def test_reopen_action_reopens_single_project_and_creates_status_comment(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "reopen_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.closed_project_a.id)],
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.closed_project_a.refresh_from_db()
+        self.assertFalse(self.closed_project_a.is_closed)
+        self.assertIsNone(self.closed_project_a.closed_datetime)
+        self.assertIsNone(self.closed_project_a.actual_date)
+        self.assertEqual(self.closed_project_a.updated_by, self.superuser_no_org)
+
+        statuses = KippoProjectStatus.objects.filter(project=self.closed_project_a)
+        self.assertEqual(statuses.count(), 1)
+        status = statuses.get()
+        self.assertEqual(status.comment, f"re-opened by {self.superuser_no_org.username}")
+        self.assertEqual(status.created_by, self.superuser_no_org)
+
+    def test_reopen_action_supports_multiple_projects(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "reopen_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.closed_project_a.id), str(self.closed_project_b.id)],
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.closed_project_a.refresh_from_db()
+        self.closed_project_b.refresh_from_db()
+        self.assertFalse(self.closed_project_a.is_closed)
+        self.assertFalse(self.closed_project_b.is_closed)
+        self.assertEqual(KippoProjectStatus.objects.filter(project=self.closed_project_a).count(), 1)
+        self.assertEqual(KippoProjectStatus.objects.filter(project=self.closed_project_b).count(), 1)
+
+    def test_reopen_action_skips_already_open_projects(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "reopen_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.closed_project_a.id), str(self.open_project.id)],
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.closed_project_a.refresh_from_db()
+        self.open_project.refresh_from_db()
+        self.assertFalse(self.closed_project_a.is_closed)
+        self.assertFalse(self.open_project.is_closed)
+        # only the originally-closed project should have a re-open status comment
+        self.assertEqual(KippoProjectStatus.objects.filter(project=self.closed_project_a).count(), 1)
+        self.assertEqual(KippoProjectStatus.objects.filter(project=self.open_project).count(), 0)
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("skipped" in m.lower() for m in messages_list), messages_list)
+
+    def test_reopen_action_rejects_when_no_closed_projects_selected(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "reopen_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.open_project.id)],
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(KippoProjectStatus.objects.filter(project=self.open_project).count(), 0)
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("no closed projects" in m.lower() for m in messages_list), messages_list)


### PR DESCRIPTION
## Summary

- **Closed KippoProjects are now read-only in the admin.** `get_readonly_fields` locks every editable field when `is_closed=True`, and `get_form` short-circuits the editable-form setup. The four editable inlines (weekly effort, status, repository, assignment rate) get the same treatment via a new `LockWhenProjectClosedInlineMixin`.
- **New \"Re-open Project(s)\" admin action.** Multi-select capable. Flips `is_closed=False` (which clears `closed_datetime` and `actual_date`) and writes a `KippoProjectStatus` row \"re-opened by {username}\" attributed to the acting user. Already-open selections are skipped with a warning; an all-open selection returns an error.
- **Bug fix: 500 on `ActiveKippoProject` change view.** `ActiveKippoProjectAdmin.fieldsets` referenced `is_closed`, `actual_date`, `display_as_active`, `display_in_project_report` — all four are removed by `KippoProjectAdmin.exclude`, causing `KeyError: 'actual_date'` on form render. Dropped them from the fieldsets and added a regression test that asserts no fieldset references an excluded field.

## Test plan

- [x] `uv run poe test projects.tests.test_admin` — 22/22 passing locally
- [x] `uv run ruff check` + `ruff format --check` clean on touched files
- [ ] Reviewer: open a closed project's admin change page — confirm all fields render readonly, inlines show no add/edit controls
- [ ] Reviewer: select one or more closed projects → \"Re-open Project(s)\" → confirm `is_closed=False`, `actual_date` cleared, and a status comment \"re-opened by {your username}\" appears
- [ ] Reviewer: open the previously-broken URL `/admin/projects/activekippoproject/<id>/change/` — confirm 200