### PR TITLE
:lipstick: Modernize Close Project wizard + conditional required indicator

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -481,6 +481,7 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
         "form": form,
         "action": "close_kippoproject_action",
         "opts": modeladmin.model._meta,
+        "no_upsell_value": CLOSE_PROJECT_NO_UPSELL_VALUE,
     }
     return TemplateResponse(request, "admin/projects/close_project_action.html", context)
 

--- a/kippo/projects/templates/admin/projects/close_project_action.html
+++ b/kippo/projects/templates/admin/projects/close_project_action.html
@@ -1,6 +1,26 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls %}
 
+{% block extrastyle %}
+  {{ block.super }}
+  <style>
+    .required-indicator {
+      display: none;
+      margin-left: 6px;
+      color: #ba2121;
+      font-weight: bold;
+    }
+    .required-indicator.is-visible {
+      display: inline;
+    }
+    .form-row textarea {
+      vertical-align: top;
+    }
+  </style>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} close-project-confirmation{% endblock %}
+
 {% block breadcrumbs %}
 <div class="breadcrumbs">
   <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
@@ -28,14 +48,48 @@
       </div>
       <div class="form-row{% if form.close_comment.errors %} errors{% endif %}">
         {% if form.close_comment.errors %}{{ form.close_comment.errors }}{% endif %}
-        <label for="{{ form.close_comment.id_for_label }}">{{ form.close_comment.label }}:</label>
+        <label for="{{ form.close_comment.id_for_label }}">
+          {{ form.close_comment.label }}:
+          <span id="close-comment-required-indicator"
+                class="required-indicator"
+                data-no-upsell-value="{{ no_upsell_value }}"
+                data-comment-target="{{ form.close_comment.id_for_label }}"
+                aria-live="polite">{% trans "(required)" %}</span>
+        </label>
         {{ form.close_comment }}
       </div>
     </fieldset>
     <div class="submit-row">
       <input type="submit" class="default" value="{% trans 'OK' %}">
-      <a href="{% url opts|admin_urlname:'changelist' %}" class="button cancel-link">{% trans 'Cancel' %}</a>
+      <a href="{% url opts|admin_urlname:'changelist' %}" class="closelink">{% trans 'Cancel' %}</a>
     </div>
   </form>
 </div>
+<script>
+  (function () {
+    var indicator = document.getElementById("close-comment-required-indicator");
+    if (!indicator) { return; }
+    var noUpsellValue = indicator.getAttribute("data-no-upsell-value");
+    var commentInput = document.getElementById(indicator.getAttribute("data-comment-target"));
+    var radios = document.querySelectorAll('input[type="radio"][name="category"]');
+    function update() {
+      var checked = document.querySelector('input[type="radio"][name="category"]:checked');
+      var isRequired = !!(checked && checked.value === noUpsellValue);
+      indicator.classList.toggle("is-visible", isRequired);
+      if (commentInput) {
+        if (isRequired) {
+          commentInput.setAttribute("required", "required");
+          commentInput.setAttribute("aria-required", "true");
+        } else {
+          commentInput.removeAttribute("required");
+          commentInput.removeAttribute("aria-required");
+        }
+      }
+    }
+    for (var i = 0; i < radios.length; i++) {
+      radios[i].addEventListener("change", update);
+    }
+    update();
+  })();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace mismatched `<a class="button cancel-link">` with `<a class="closelink">` so the Cancel button matches the OK submit-button size (Django admin already styles `.submit-row a.closelink` with the same `padding: 10px 15px; height: 15px;` metrics as `.submit-row input.default`). Zero re-implementation of admin CSS.
- Add a `(required)` indicator next to the **Close Comment** label that appears only when the **upsellなし** category is selected — matching the server-side validation rule in `CloseProjectActionForm.clean()` where `close_comment` becomes required for `__no_upsell__`.
- The script also flips the textarea's `required` / `aria-required` attributes so the browser blocks empty submission before the server-side validator does. Server validation remains the source of truth.
- Pass `CLOSE_PROJECT_NO_UPSELL_VALUE` and the comment input id to the template via `data-*` attributes (no hardcoded constants in JS).
- Adopt the standard admin `bodyclass` / `extrastyle` block structure used elsewhere in `django.contrib.admin`.

## Test plan
- [x] `uv run poe test projects.tests.test_admin.CloseProjectActionTestCase` — 9/9 pass (no test changes required).
- [x] `uv run poe check` — ruff clean.
- [ ] Manually verify in admin: the Cancel and OK buttons render at matching sizes; selecting **upsellなし** reveals a red `(required)` next to the Close Comment label and adds the HTML `required` attribute to the textarea; selecting any other category hides it.
- [ ] Verify the form-validation-error redisplay path (POST `__no_upsell__` with empty comment) still shows the indicator on initial render.