### PR TITLE
:sparkles: Close Project wizard: dropdown + auto-populate upsell child fields

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1,6 +1,8 @@
 import csv
+import datetime
 import json
 import logging
+import re
 import urllib.parse
 from collections import Counter, defaultdict
 from collections.abc import Iterable
@@ -420,8 +422,9 @@ class CloseProjectActionForm(forms.Form):
 
     category = forms.ChoiceField(
         label=_("Category"),
-        widget=forms.RadioSelect,
+        widget=forms.Select,
         choices=CATEGORY_CHOICES,
+        initial=CLOSE_PROJECT_NO_UPSELL_VALUE,
     )
     close_comment = forms.CharField(
         label=_("Close Comment"),
@@ -436,6 +439,36 @@ class CloseProjectActionForm(forms.Form):
         if category == CLOSE_PROJECT_NO_UPSELL_VALUE and not close_comment:
             raise ValidationError({"close_comment": _("Close Comment is required when upsellなし is selected.")})
         return cleaned_data
+
+
+def _next_upsell_project_name(name: str) -> str:
+    match = re.match(r"(.*) Phase (\d+)$", name)
+    if match:
+        return f"{match.group(1)} Phase {int(match.group(2)) + 1}"
+    return f"{name} Phase 2"
+
+
+def _start_of_next_month(today: datetime.date) -> datetime.date:
+    return (today.replace(day=1) + datetime.timedelta(days=32)).replace(day=1)
+
+
+def _build_upsell_prefill_params(project: KippoProject, selected_category: str) -> dict[str, str]:
+    today = timezone.now().date()
+    params = {
+        "category": selected_category,
+        "parent_project": str(project.id),
+        "name": _next_upsell_project_name(project.name),
+        "start_date": _start_of_next_month(today).isoformat(),
+        "slack_channel_name": project.slack_channel_name,
+        "slack_notification_channel_name": project.slack_notification_channel_name,
+        "document_folder_url": project.document_folder_url,
+        "github_project_html_url": project.github_project_html_url,
+        "github_project_api_nodeid": project.github_project_api_nodeid,
+        "docbase_tag": project.docbase_tag,
+    }
+    if project.columnset_id:
+        params["columnset"] = str(project.columnset_id)
+    return {k: v for k, v in params.items() if v}
 
 
 def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoRequest, queryset: models.QuerySet):
@@ -468,7 +501,7 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
             modeladmin.message_user(request, _("Project '%s' closed.") % project.name, level=messages.INFO)
 
             if selected_category in UPSELL_CATEGORY_VALUES:
-                params = urllib.parse.urlencode({"category": selected_category, "parent_project": str(project.id)})
+                params = urllib.parse.urlencode(_build_upsell_prefill_params(project, selected_category))
                 return HttpResponseRedirect(f"{settings.URL_PREFIX}/admin/projects/kippoproject/add/?{params}")
             return HttpResponseRedirect(f"{settings.URL_PREFIX}/admin/projects/kippoproject/")
     else:
@@ -574,6 +607,12 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # check if user has organization memberships
         # - if not can't add new projects
         return request.user.memberships.exists()
+
+    def get_exclude(self, request: DjangoRequest, obj: KippoProject | None = None):
+        excluded = list(super().get_exclude(request, obj) or ())
+        if obj is None and "close_comment" not in excluded:
+            excluded.append("close_comment")
+        return tuple(excluded)
 
     def get_updated_by_display(self, obj: KippoProject) -> str:
         result = ""

--- a/kippo/projects/templates/admin/projects/close_project_action.html
+++ b/kippo/projects/templates/admin/projects/close_project_action.html
@@ -4,6 +4,16 @@
 {% block extrastyle %}
   {{ block.super }}
   <style>
+    .form-row.close-comment-row label {
+      display: block;
+      float: none;
+      width: auto;
+      margin-bottom: 6px;
+    }
+    .form-row.close-comment-row textarea {
+      display: block;
+      vertical-align: top;
+    }
     .required-indicator {
       display: none;
       margin-left: 6px;
@@ -12,9 +22,6 @@
     }
     .required-indicator.is-visible {
       display: inline;
-    }
-    .form-row textarea {
-      vertical-align: top;
     }
   </style>
 {% endblock %}
@@ -43,10 +50,9 @@
       {% endif %}
       <div class="form-row{% if form.category.errors %} errors{% endif %}">
         {% if form.category.errors %}{{ form.category.errors }}{% endif %}
-        <label class="required">{{ form.category.label }}:</label>
         {{ form.category }}
       </div>
-      <div class="form-row{% if form.close_comment.errors %} errors{% endif %}">
+      <div class="form-row close-comment-row{% if form.close_comment.errors %} errors{% endif %}">
         {% if form.close_comment.errors %}{{ form.close_comment.errors }}{% endif %}
         <label for="{{ form.close_comment.id_for_label }}">
           {{ form.close_comment.label }}:
@@ -71,10 +77,9 @@
     if (!indicator) { return; }
     var noUpsellValue = indicator.getAttribute("data-no-upsell-value");
     var commentInput = document.getElementById(indicator.getAttribute("data-comment-target"));
-    var radios = document.querySelectorAll('input[type="radio"][name="category"]');
+    var categorySelect = document.querySelector('select[name="category"]');
     function update() {
-      var checked = document.querySelector('input[type="radio"][name="category"]:checked');
-      var isRequired = !!(checked && checked.value === noUpsellValue);
+      var isRequired = !!(categorySelect && categorySelect.value === noUpsellValue);
       indicator.classList.toggle("is-visible", isRequired);
       if (commentInput) {
         if (isRequired) {
@@ -86,8 +91,8 @@
         }
       }
     }
-    for (var i = 0; i < radios.length; i++) {
-      radios[i].addEventListener("change", update);
+    if (categorySelect) {
+      categorySelect.addEventListener("change", update);
     }
     update();
   })();

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1,5 +1,7 @@
+import datetime
 from datetime import date
 from http import HTTPStatus
+from unittest import TestCase
 from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlparse
 
@@ -9,7 +11,13 @@ from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.urls import reverse
 from django.utils import timezone
 
-from projects.admin import KippoMilestoneAdmin, KippoProjectAdmin, ProjectWeeklyEffortAdminInline
+from projects.admin import (
+    KippoMilestoneAdmin,
+    KippoProjectAdmin,
+    ProjectWeeklyEffortAdminInline,
+    _next_upsell_project_name,
+    _start_of_next_month,
+)
 from projects.models import KippoMilestone, KippoProject, KippoProjectStatus, ProjectColumnSet
 
 
@@ -359,6 +367,84 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         # category on the closing project is unchanged
         self.assertEqual(self.project1.category, "poc")
 
+    def test_upsell_redirect_prefills_new_project_fields(self):
+        # populate source-project fields that should propagate to the upsell child
+        self.project1.slack_channel_name = "proj1"
+        self.project1.slack_notification_channel_name = "proj1-notify"
+        self.project1.document_folder_url = "https://docs.example.com/proj1"
+        self.project1.github_project_html_url = "https://github.com/orgs/example/projects/42"
+        self.project1.github_project_api_nodeid = "PVT_kwDO_NODE_ID"
+        self.project1.docbase_tag = "proj1-tag"
+        self.project1.save()
+
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                "post": "yes",
+                "category": "upsell-new-proposal",
+                "close_comment": "",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        params = parse_qs(urlparse(response["Location"]).query)
+        self.assertEqual(params.get("name"), ["project1 Phase 2"])
+        self.assertEqual(params.get("slack_channel_name"), ["proj1"])
+        self.assertEqual(params.get("slack_notification_channel_name"), ["proj1-notify"])
+        self.assertEqual(params.get("document_folder_url"), ["https://docs.example.com/proj1"])
+        self.assertEqual(params.get("github_project_html_url"), ["https://github.com/orgs/example/projects/42"])
+        self.assertEqual(params.get("github_project_api_nodeid"), ["PVT_kwDO_NODE_ID"])
+        self.assertEqual(params.get("columnset"), [str(self.project1.columnset_id)])
+        self.assertEqual(params.get("docbase_tag"), ["proj1-tag"])
+        # start_date should be the first day of the month following today
+        today = timezone.now().date()
+        expected_start = (today.replace(day=1) + datetime.timedelta(days=32)).replace(day=1)
+        self.assertEqual(params.get("start_date"), [expected_start.isoformat()])
+
+    def test_upsell_redirect_omits_blank_source_fields(self):
+        # leave optional source fields blank: prefill params should not include empty values
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                "post": "yes",
+                "category": "upsell-improvement",
+                "close_comment": "",
+            },
+        )
+        params = parse_qs(urlparse(response["Location"]).query)
+        for blank_field in (
+            "slack_channel_name",
+            "slack_notification_channel_name",
+            "document_folder_url",
+            "github_project_html_url",
+            "github_project_api_nodeid",
+            "docbase_tag",
+        ):
+            with self.subTest(field=blank_field):
+                self.assertNotIn(blank_field, params)
+
+    def test_close_form_category_dropdown_default_is_no_upsell(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        form = response.context["form"]
+        self.assertEqual(form.fields["category"].widget.__class__.__name__, "Select")
+        self.assertEqual(form.fields["category"].initial, "__no_upsell__")
+
+    def test_add_form_hides_close_comment_field(self):
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertNotIn('name="close_comment"', response.content.decode())
+
     def test_intermediate_form_get(self):
         """Without 'post=yes', the action displays the intermediate form."""
         response = self.client.post(
@@ -407,6 +493,23 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         # parent_project should appear as readonly (no input element with that name)
         self.assertNotIn('name="parent_project"', response.content.decode())
         self.assertContains(response, self.project1.name)
+
+
+class UpsellPrefillHelpersTestCase(TestCase):
+    def test_next_upsell_project_name_appends_phase_2_when_no_existing_suffix(self):
+        self.assertEqual(_next_upsell_project_name("Foo"), "Foo Phase 2")
+        self.assertEqual(_next_upsell_project_name("Foo Bar"), "Foo Bar Phase 2")
+
+    def test_next_upsell_project_name_increments_existing_phase_number(self):
+        self.assertEqual(_next_upsell_project_name("Foo Phase 2"), "Foo Phase 3")
+        self.assertEqual(_next_upsell_project_name("Foo Phase 9"), "Foo Phase 10")
+        self.assertEqual(_next_upsell_project_name("Foo Bar Phase 11"), "Foo Bar Phase 12")
+
+    def test_start_of_next_month(self):
+        self.assertEqual(_start_of_next_month(datetime.date(2026, 1, 15)), datetime.date(2026, 2, 1))
+        self.assertEqual(_start_of_next_month(datetime.date(2026, 12, 31)), datetime.date(2027, 1, 1))
+        # boundary: first of month
+        self.assertEqual(_start_of_next_month(datetime.date(2026, 4, 1)), datetime.date(2026, 5, 1))
 
 
 class KippoProjectAdminFixtureTestCaseBase(IsStaffModelAdminTestCaseBase):


### PR DESCRIPTION
Builds on #214. Tightens the Close Project wizard UX and makes the upsell-redirect path useful by prefilling the new project's fields from the parent.

## Summary

**Wizard form**
- Category: `RadioSelect` → `Select` (dropdown). Default value is `__no_upsell__` (upsellなし).
- Removed the redundant "Category:" label.
- Close-comment label and textarea now stack vertically (`form-row.close-comment-row label { display: block; }`) so the textarea no longer shifts when the `(required)` indicator toggles on/off — this was visible movement in the previous round.

**Upsell redirect: prefill new project fields**

When the user picks an upsell category and submits, the redirect to `/admin/projects/kippoproject/add/` now carries prefill query params for:

| Field | Source | Notes |
|---|---|---|
| `name` | `<parent_name> Phase 2` (or increments existing `Phase N` suffix) | `_next_upsell_project_name` |
| `start_date` | First of the calendar month after `today` | `_start_of_next_month` |
| `slack_channel_name` | parent | omitted if blank |
| `slack_notification_channel_name` | parent | omitted if blank |
| `document_folder_url` | parent | omitted if blank |
| `github_project_html_url` | parent | omitted if blank |
| `github_project_api_nodeid` | parent | omitted if blank |
| `columnset` | parent's `columnset_id` | omitted if null |
| `docbase_tag` | parent | omitted if blank |
| `category`, `parent_project` | (already passed) | unchanged |

Django admin's `get_changeform_initial_data` picks these up automatically since the keys are model field names.

**Add-form polish**
- Hide `close_comment` from the KippoProject add form (`get_exclude` adds it when `obj is None`). On the change form `close_comment` still appears so closed projects can show their close comment.

## Test plan

- [x] `uv run poe test projects.tests.test_admin` — 29/29 pass (4 new admin-level tests + 3 unit tests for helpers).
- [x] `uv run poe check` — ruff clean.
- [ ] Manually verify in admin: pick an upsell category → OK → confirm the new project add form is prefilled with parent name + " Phase 2", start of next month, slack/docs/github values from the parent, and `close_comment` field is gone.
- [ ] Confirm dropdown defaults to upsellなし on initial render and that `(required)` appears next to "Close Comment:" when the dropdown is on upsellなし (and the textarea position does not shift between states).