### PR TITLE
:sparkles: KippoProject admin: clickable created-project link, Close Comment last

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -29,7 +29,7 @@ from django.http import (
 )
 from django.template.response import TemplateResponse
 from django.utils import timezone
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from octocat.functions import copy_project_v2, create_project_v2, get_organization_id
@@ -349,9 +349,14 @@ def create_github_organizational_project_action(modeladmin: admin.ModelAdmin, re
         for m in errors:
             modeladmin.message_user(request, message=m, level=messages.ERROR)
     if successful_creation_projects:
+        project_links = format_html_join(
+            ", ",
+            '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>',
+            ((url, name) for name, url in successful_creation_projects),
+        )
         modeladmin.message_user(
             request,
-            message=f"({len(successful_creation_projects)}) GitHub Projects Created: {successful_creation_projects}",
+            message=format_html("({}) GitHub Projects Created: {}", len(successful_creation_projects), project_links),
             level=messages.INFO,
         )
 
@@ -613,6 +618,13 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         if obj is None and "close_comment" not in excluded:
             excluded.append("close_comment")
         return tuple(excluded)
+
+    def get_fields(self, request: DjangoRequest, obj: KippoProject | None = None):
+        fields = list(super().get_fields(request, obj))
+        if "close_comment" in fields:
+            fields.remove("close_comment")
+            fields.append("close_comment")
+        return fields
 
     def get_updated_by_display(self, obj: KippoProject) -> str:
         result = ""


### PR DESCRIPTION
## Summary

Two small KippoProject admin tweaks:

- **Create GitHub Organizational Project action** — the success message now renders each created project's name as a clickable anchor (opens in new tab) pointing to its GitHub Project URL, instead of dumping a Python tuple repr into the message.
- **Change form** — `Close Comment` is moved to the last field on the edit page (overriding `get_fields`). The field is still excluded on the Add page, matching prior behavior via `get_exclude`.

## Test plan

- [ ] Open the KippoProject admin, select one or more projects without a GitHub Project URL, run **Create Github Organizational Project(s) for selected**, and confirm the success banner shows each project name as a clickable link in a new tab.
- [ ] Open an existing KippoProject in the admin and confirm `Close Comment` is the last form field (after `survey_issued`/`survey_issued_datetime`).
- [ ] Open the Add KippoProject page and confirm `Close Comment` is not present.