### PR TITLE
:lipstick: KippoProject admin: declutter /add/ form

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -92,6 +92,7 @@ class LockWhenProjectClosedInlineMixin:
 class ProjectAssignmentRateInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, admin.TabularInline):
     model = ProjectAssignmentRate
     extra = 0
+    max_num = 10
     fields = ("role", "rate_per_day")
 
 
@@ -583,9 +584,29 @@ class KippoProjectAdminForm(forms.ModelForm):
         return cleaned_data
 
 
+def _insert_field_after(fields: list[str], target: str, reference: str) -> list[str]:
+    """Return a new list with `target` placed immediately after `reference`. No-op if reference is missing.
+
+    If `target` already exists elsewhere in `fields`, it is moved (not duplicated).
+    """
+    if reference not in fields:
+        return list(fields)
+    rebuilt = [f for f in fields if f != target]
+    rebuilt.insert(rebuilt.index(reference) + 1, target)
+    return rebuilt
+
+
 @admin.register(KippoProject)
 class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     form = KippoProjectAdminForm
+    # Inlines hidden on /add/ (only meaningful once a project exists). Exposed as a class
+    # attribute so tests and subclasses can reference the same source of truth.
+    HIDDEN_ON_ADD_INLINES = (
+        ProjectWeeklyEffortReadOnlyInine,
+        ProjectWeeklyEffortAdminInline,
+        KippoProjectStatusReadOnlyInine,
+        KippoProjectStatusAdminInline,
+    )
     list_display = (
         "id",
         "name",
@@ -633,6 +654,12 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # - if not can't add new projects
         return request.user.memberships.exists()
 
+    def get_inlines(self, request: DjangoRequest, obj: KippoProject | None = None):
+        inlines = list(super().get_inlines(request, obj))
+        if obj is None:
+            inlines = [cls for cls in inlines if cls not in self.HIDDEN_ON_ADD_INLINES]
+        return inlines
+
     def get_exclude(self, request: DjangoRequest, obj: KippoProject | None = None):
         excluded = list(super().get_exclude(request, obj) or ())
         if obj is None and "close_comment" not in excluded:
@@ -644,6 +671,10 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         if "close_comment" in fields:
             fields.remove("close_comment")
             fields.append("close_comment")
+        # On add, surface parent_project right after organization (model order would otherwise bury it
+        # several rows down). The close-action upsell flow prefills it via GET; manual users see it as optional.
+        if obj is None:
+            fields = _insert_field_after(fields, "parent_project", "organization")
         return fields
 
     def get_updated_by_display(self, obj: KippoProject) -> str:
@@ -961,6 +992,23 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
         if "/change/" in request.path:
             return False
         return super().has_delete_permission(request, obj)
+
+    def get_fieldsets(self, request: DjangoRequest, obj: KippoProject | None = None):
+        # On add, expose optional parent_project in Details after `organization` for manual creation.
+        # The close-project upsell flow redirects to KippoProjectAdmin (not this admin), so this
+        # branch only fires for users initiating creation directly.
+        fieldsets = super().get_fieldsets(request, obj)
+        if obj is None:
+            rebuilt = []
+            for label, opts in fieldsets:
+                fields = list(opts.get("fields", ()))
+                if "organization" in fields:
+                    new_fields = _insert_field_after(fields, "parent_project", "organization")
+                    rebuilt.append((label, {**opts, "fields": tuple(new_fields)}))
+                else:
+                    rebuilt.append((label, opts))
+            fieldsets = rebuilt
+        return fieldsets
 
     def get_queryset(self, request: DjangoRequest):
         """Custom ordering: anon-projects first, then by confidence (desc), target_date (asc), name (asc)."""

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -13,14 +13,16 @@ from django.urls import reverse
 from django.utils import timezone
 
 from projects.admin import (
+    ActiveKippoProjectAdmin,
     KippoMilestoneAdmin,
     KippoProjectAdmin,
     KippoProjectAdminForm,
+    ProjectAssignmentRateInline,
     ProjectWeeklyEffortAdminInline,
     _next_upsell_project_name,
     _start_of_next_month,
 )
-from projects.models import KippoMilestone, KippoProject, KippoProjectStatus, ProjectColumnSet
+from projects.models import ActiveKippoProject, KippoMilestone, KippoProject, KippoProjectStatus, ProjectColumnSet
 
 
 class MockRequest:
@@ -785,3 +787,139 @@ class ReopenProjectActionTestCase(KippoProjectAdminFixtureTestCaseBase):
         self.assertEqual(KippoProjectStatus.objects.filter(project=self.open_project).count(), 0)
         messages_list = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("no closed projects" in m.lower() for m in messages_list), messages_list)
+
+
+class KippoProjectAdminInlinesTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """Status & weekly-effort inlines should be hidden on /add/ but present on /change/."""
+
+    def setUp(self):
+        super().setUp()
+        self.project = self.make_project("inline-test-project")
+
+    def test_add_view_hides_status_and_weeklyeffort_inlines(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        inlines = modeladmin.get_inlines(self.staff_user_request, obj=None)
+        for cls in KippoProjectAdmin.HIDDEN_ON_ADD_INLINES:
+            self.assertNotIn(cls, inlines, f"{cls.__name__} should be hidden on add")
+
+    def test_change_view_shows_status_and_weeklyeffort_inlines(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        inlines = modeladmin.get_inlines(self.staff_user_request, obj=self.project)
+        for cls in KippoProjectAdmin.HIDDEN_ON_ADD_INLINES:
+            self.assertIn(cls, inlines, f"{cls.__name__} should be present on change")
+
+    def test_activekippoproject_add_view_hides_status_and_weeklyeffort_inlines(self):
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        inlines = modeladmin.get_inlines(self.staff_user_request, obj=None)
+        for cls in KippoProjectAdmin.HIDDEN_ON_ADD_INLINES:
+            self.assertNotIn(cls, inlines, f"{cls.__name__} should be hidden on ActiveKippoProject add")
+
+    def test_activekippoproject_change_view_shows_status_and_weeklyeffort_inlines(self):
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        inlines = modeladmin.get_inlines(self.staff_user_request, obj=self.project)
+        for cls in KippoProjectAdmin.HIDDEN_ON_ADD_INLINES:
+            self.assertIn(cls, inlines, f"{cls.__name__} should be present on ActiveKippoProject change")
+
+    def test_add_view_keeps_assignment_rate_and_repository_inlines(self):
+        from projects.admin import GithubRepositoryProjectInline
+
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        inlines = modeladmin.get_inlines(self.staff_user_request, obj=None)
+        self.assertIn(ProjectAssignmentRateInline, inlines)
+        self.assertIn(GithubRepositoryProjectInline, inlines)
+
+
+class ProjectAssignmentRateInlineConfigTestCase(TestCase):
+    def test_max_num_is_10(self):
+        self.assertEqual(ProjectAssignmentRateInline.max_num, 10)
+
+
+class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """parent_project should appear in Details fieldset (after organization) on add — not on change."""
+
+    def setUp(self):
+        super().setUp()
+        self.existing_project = self.make_project("existing-project")
+
+    @staticmethod
+    def _details_fieldset_fields(fieldsets: list) -> tuple:
+        for _label, opts in fieldsets:
+            if "organization" in opts.get("fields", ()):
+                return tuple(opts["fields"])
+        raise AssertionError("No fieldset containing 'organization' found")
+
+    def test_add_fieldsets_place_parent_project_immediately_after_organization(self):
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        fieldsets = modeladmin.get_fieldsets(self.super_user_request, obj=None)
+        details_fields = self._details_fieldset_fields(fieldsets)
+        self.assertIn("parent_project", details_fields)
+        org_index = details_fields.index("organization")
+        self.assertEqual(details_fields[org_index + 1], "parent_project")
+
+    def test_change_fieldsets_omit_parent_project(self):
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        fieldsets = modeladmin.get_fieldsets(self.super_user_request, obj=self.existing_project)
+        details_fields = self._details_fieldset_fields(fieldsets)
+        self.assertNotIn("parent_project", details_fields)
+
+    def test_class_fieldsets_attribute_unchanged_after_get_fieldsets(self):
+        # get_fieldsets must not mutate the class attribute (would persist across requests)
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        modeladmin.get_fieldsets(self.super_user_request, obj=None)
+        for _label, opts in ActiveKippoProjectAdmin.fieldsets:
+            self.assertNotIn("parent_project", opts["fields"])
+
+    def test_add_view_renders_parent_project_select(self):
+        url = reverse("admin:projects_activekippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        adminform = response.context["adminform"]
+        self.assertIn("parent_project", adminform.form.fields)
+        # available parent options include the existing project
+        self.assertContains(response, self.existing_project.name)
+        # field must be a Select (not hidden) so users can pick a parent
+        widget = adminform.form.fields["parent_project"].widget
+        inner_widget = getattr(widget, "widget", widget)
+        self.assertNotIsInstance(inner_widget, forms.HiddenInput)
+
+    def test_kippoproject_add_view_still_exposes_parent_project_for_close_action_prefill(self):
+        # KippoProjectAdmin (the close-action target) must continue to expose parent_project on /add/
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url, {"category": "upsell-improvement", "parent_project": str(self.existing_project.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        adminform = response.context["adminform"]
+        self.assertIn("parent_project", adminform.form.fields)
+        self.assertEqual(adminform.form.initial.get("parent_project"), str(self.existing_project.id))
+
+    @staticmethod
+    def _ordered_form_field_names(adminform: AdminForm) -> list:
+        # AdminForm iteration yields Fieldsets → Fieldlines → AdminFields/AdminReadonlyFields.
+        # Editable fields wrap a BoundField (.field has .name); readonly fields store .field as a dict.
+        names = []
+        for fieldset in adminform:
+            for fieldline in fieldset:
+                for admin_field in fieldline:
+                    f = admin_field.field
+                    names.append(f["name"] if isinstance(f, dict) else f.name)
+        return names
+
+    def test_kippoproject_add_view_places_parent_project_immediately_after_organization(self):
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ordered = self._ordered_form_field_names(response.context["adminform"])
+        self.assertIn("organization", ordered)
+        self.assertIn("parent_project", ordered)
+        self.assertEqual(ordered[ordered.index("organization") + 1], "parent_project")
+
+    def test_kippoproject_change_view_does_not_reorder_parent_project_after_organization(self):
+        # On change view we don't reposition parent_project — it stays in its model-declaration slot
+        # (which is several rows down, after project_manager).
+        existing = self.make_project("ordering-change-target")
+        url = reverse("admin:projects_kippoproject_change", args=[existing.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ordered = self._ordered_form_field_names(response.context["adminform"])
+        self.assertIn("organization", ordered)
+        self.assertIn("parent_project", ordered)
+        self.assertNotEqual(ordered[ordered.index("organization") + 1], "parent_project")


### PR DESCRIPTION
## Summary

Three small UX adjustments to the KippoProject / ActiveKippoProject admin **add** view:

- **Hide noisy inlines on /add/.** ProjectWeeklyEffort (read-only + write) and KippoProjectStatus (read-only + write) inlines only become useful once the project exists, so they're hidden until you visit /change/.
- **Cap ProjectAssignmentRate** inline rows at \`max_num=10\`.
- **Surface \`parent_project\` immediately after \`organization\`** on /add/ for both admins (Details fieldset on ActiveKippoProject, reordered default layout on KippoProject). The close-project upsell flow already prefills it; this also makes it discoverable for manual creation.

A small helper \`_insert_field_after\` and a \`HIDDEN_ON_ADD_INLINES\` class attribute were factored out to keep the two admins (and tests) using a single source of truth.

## Test plan

- [x] \`uv run python kippo/manage.py test projects.tests.test_admin\` — 48 tests pass (11 new)
- [x] \`uv run poe check\` — clean
- New tests cover:
  - inline visibility on /add/ vs /change/ for both KippoProject and ActiveKippoProject
  - \`ProjectAssignmentRateInline.max_num == 10\`
  - \`parent_project\` placement (immediately after \`organization\`) on both admins' /add/, absent from ActiveKippoProject /change/
  - regression guard against mutating the class \`fieldsets\` attribute
  - close-action prefill flow still exposes \`parent_project\`