### PR TITLE
:lipstick: KippoProject admin: collapse assignment rates, hide internal fields, reorder parent_project

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -94,6 +94,7 @@ class ProjectAssignmentRateInline(LockWhenProjectClosedInlineMixin, AllowIsStaff
     extra = 0
     max_num = 10
     fields = ("role", "rate_per_day")
+    classes = ["collapse"]
 
 
 class KippoMilestoneReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
@@ -662,8 +663,13 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
 
     def get_exclude(self, request: DjangoRequest, obj: KippoProject | None = None):
         excluded = list(super().get_exclude(request, obj) or ())
-        if obj is None and "close_comment" not in excluded:
-            excluded.append("close_comment")
+        if obj is None:
+            if "close_comment" not in excluded:
+                excluded.append("close_comment")
+            if "survey_issued" not in excluded:
+                excluded.append("survey_issued")
+        if not request.user.is_superuser and "github_project_api_nodeid" not in excluded:
+            excluded.append("github_project_api_nodeid")
         return tuple(excluded)
 
     def get_fields(self, request: DjangoRequest, obj: KippoProject | None = None):
@@ -671,10 +677,11 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         if "close_comment" in fields:
             fields.remove("close_comment")
             fields.append("close_comment")
-        # On add, surface parent_project right after organization (model order would otherwise bury it
-        # several rows down). The close-action upsell flow prefills it via GET; manual users see it as optional.
+        # On add, surface parent_project right after category (the upsell category drives whether
+        # parent_project is required). The close-action upsell flow prefills it via GET;
+        # manual users see it as optional.
         if obj is None:
-            fields = _insert_field_after(fields, "parent_project", "organization")
+            fields = _insert_field_after(fields, "parent_project", "category")
         return fields
 
     def get_updated_by_display(self, obj: KippoProject) -> str:
@@ -994,7 +1001,7 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
         return super().has_delete_permission(request, obj)
 
     def get_fieldsets(self, request: DjangoRequest, obj: KippoProject | None = None):
-        # On add, expose optional parent_project in Details after `organization` for manual creation.
+        # On add, expose optional parent_project in Details after `category` for manual creation.
         # The close-project upsell flow redirects to KippoProjectAdmin (not this admin), so this
         # branch only fires for users initiating creation directly.
         fieldsets = super().get_fieldsets(request, obj)
@@ -1002,12 +1009,18 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
             rebuilt = []
             for label, opts in fieldsets:
                 fields = list(opts.get("fields", ()))
-                if "organization" in fields:
-                    new_fields = _insert_field_after(fields, "parent_project", "organization")
+                if "category" in fields:
+                    new_fields = _insert_field_after(fields, "parent_project", "category")
                     rebuilt.append((label, {**opts, "fields": tuple(new_fields)}))
                 else:
                     rebuilt.append((label, opts))
             fieldsets = rebuilt
+        # github_project_api_nodeid is excluded from the form for non-superusers; mirror that here
+        # so AdminForm rendering doesn't try to look up a field that isn't in the form.
+        if not request.user.is_superuser:
+            fieldsets = [
+                (label, {**opts, "fields": tuple(f for f in opts.get("fields", ()) if f != "github_project_api_nodeid")}) for label, opts in fieldsets
+            ]
         return fieldsets
 
     def get_queryset(self, request: DjangoRequest):

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -835,7 +835,7 @@ class ProjectAssignmentRateInlineConfigTestCase(TestCase):
 
 
 class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixtureTestCaseBase):
-    """parent_project should appear in Details fieldset (after organization) on add — not on change."""
+    """parent_project should appear in Details fieldset (after category) on add — not on change."""
 
     def setUp(self):
         super().setUp()
@@ -844,17 +844,17 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
     @staticmethod
     def _details_fieldset_fields(fieldsets: list) -> tuple:
         for _label, opts in fieldsets:
-            if "organization" in opts.get("fields", ()):
+            if "category" in opts.get("fields", ()):
                 return tuple(opts["fields"])
-        raise AssertionError("No fieldset containing 'organization' found")
+        raise AssertionError("No fieldset containing 'category' found")
 
-    def test_add_fieldsets_place_parent_project_immediately_after_organization(self):
+    def test_add_fieldsets_place_parent_project_immediately_after_category(self):
         modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
         fieldsets = modeladmin.get_fieldsets(self.super_user_request, obj=None)
         details_fields = self._details_fieldset_fields(fieldsets)
         self.assertIn("parent_project", details_fields)
-        org_index = details_fields.index("organization")
-        self.assertEqual(details_fields[org_index + 1], "parent_project")
+        category_index = details_fields.index("category")
+        self.assertEqual(details_fields[category_index + 1], "parent_project")
 
     def test_change_fieldsets_omit_parent_project(self):
         modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
@@ -903,16 +903,16 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
                     names.append(f["name"] if isinstance(f, dict) else f.name)
         return names
 
-    def test_kippoproject_add_view_places_parent_project_immediately_after_organization(self):
+    def test_kippoproject_add_view_places_parent_project_immediately_after_category(self):
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         ordered = self._ordered_form_field_names(response.context["adminform"])
-        self.assertIn("organization", ordered)
+        self.assertIn("category", ordered)
         self.assertIn("parent_project", ordered)
-        self.assertEqual(ordered[ordered.index("organization") + 1], "parent_project")
+        self.assertEqual(ordered[ordered.index("category") + 1], "parent_project")
 
-    def test_kippoproject_change_view_does_not_reorder_parent_project_after_organization(self):
+    def test_kippoproject_change_view_does_not_reorder_parent_project_after_category(self):
         # On change view we don't reposition parent_project — it stays in its model-declaration slot
         # (which is several rows down, after project_manager).
         existing = self.make_project("ordering-change-target")
@@ -920,6 +920,6 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         ordered = self._ordered_form_field_names(response.context["adminform"])
-        self.assertIn("organization", ordered)
+        self.assertIn("category", ordered)
         self.assertIn("parent_project", ordered)
-        self.assertNotEqual(ordered[ordered.index("organization") + 1], "parent_project")
+        self.assertNotEqual(ordered[ordered.index("category") + 1], "parent_project")


### PR DESCRIPTION
## Summary

Several small KippoProject admin form tweaks:

- **`ProjectAssignmentRate` inline** now starts collapsed, matching the pattern used by other inlines on the project change form.
- **`GitHubプロジェクトAPIノードID` (`github_project_api_nodeid`)** is hidden from the form unless the requesting user is a superuser. Mirror-stripped from `ActiveKippoProjectAdmin.fieldsets` to keep AdminForm rendering happy when the field is excluded from the form.
- **`アンケート発行済み` (`survey_issued`)** is hidden on `/add/` (still editable on `/change/`).
- **`parent_project`** on `/add/` is now positioned immediately after `category` in both `KippoProjectAdmin` and `ActiveKippoProjectAdmin` (the upsell category drives whether `parent_project` is required, so they belong adjacent).

## Test plan

- [x] `python manage.py test projects.tests.test_admin` — 48 tests pass
- [x] Existing parent-project ordering tests updated to assert the new `category` anchor
- [ ] Manual: superuser sees `github_project_api_nodeid` on both `KippoProject` and `ActiveKippoProject` change forms
- [ ] Manual: non-superuser staff does not see `github_project_api_nodeid` on either change form
- [ ] Manual: `/add/` form does not render `survey_issued`; `/change/` form still does
- [ ] Manual: `ProjectAssignmentRate` inline renders collapsed by default on the change form