### PR TITLE
:lipstick: KippoProject admin: org-scope parent_project, hide org field for single-org users

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -574,13 +574,22 @@ class KippoProjectAdminForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super().clean()
         category = cleaned_data.get("category")
+        organization = cleaned_data.get("organization")
+        submitted_parent_project = cleaned_data.get("parent_project")
         # parent_project is readonly on the change form, so it won't appear in cleaned_data there
         # — fall back to the persisted instance value so existing upsell projects keep validating.
-        parent_project = cleaned_data.get("parent_project") or getattr(self.instance, "parent_project", None)
+        parent_project = submitted_parent_project or getattr(self.instance, "parent_project", None)
         if category in UPSELL_CATEGORY_VALUES and not parent_project:
             self.add_error(
                 "parent_project",
                 _("Parent Project is required when an upsell category is selected."),
+            )
+        # On /add/, parent_project must belong to the same organization as the new project.
+        # (On /change/, parent_project is readonly so it isn't in submitted data — skip this check.)
+        if submitted_parent_project and organization and submitted_parent_project.organization_id != organization.id:
+            self.add_error(
+                "parent_project",
+                _("Parent Project must belong to the same organization as this project."),
             )
         return cleaned_data
 
@@ -874,6 +883,11 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             )
         form.base_fields["organization"].initial = user_initial_organization
         form.base_fields["organization"].queryset = user_memberships
+        # On /add/, when the user belongs to exactly one organization there's nothing to choose —
+        # preselect it and hide the field. The queryset is still scoped to the user's orgs so a
+        # tampered submission gets rejected by the field's normal validation.
+        if obj is None and user_initial_organization and len(user_organizations) == 1:
+            form.base_fields["organization"].widget = forms.HiddenInput()
 
         # remove add/change/delete buttons from all ForeignKey fields
         for fieldname in form.base_fields:
@@ -884,9 +898,10 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # parent_project: optional selectable field on add (GET-prefilled by the upsell close-action flow);
         # readonly on change form (handled in get_readonly_fields).
         # Required when category is an upsell value — enforced by KippoProjectAdminForm.clean().
-        # Scope queryset to the user's organizations to avoid leaking project names across orgs (superusers see all).
-        if obj is None and "parent_project" in form.base_fields and not request.user.is_superuser:
-            form.base_fields["parent_project"].queryset = KippoProject.objects.filter(organization__in=request.user.organizations)
+        # Scope queryset to the new project's organization — cross-org parent/child relationships make
+        # no business sense; the form's clean() rejects mismatches at submit-time.
+        if obj is None and "parent_project" in form.base_fields and user_initial_organization:
+            form.base_fields["parent_project"].queryset = KippoProject.objects.filter(organization=user_initial_organization)
         return form
 
     def get_readonly_fields(self, request: DjangoRequest, obj: KippoProject | None = None) -> tuple[str, ...]:

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -516,8 +516,8 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         # available parent options include the existing project
         self.assertContains(response, self.project1.name)
 
-    def test_add_form_parent_project_queryset_scoped_to_user_orgs_for_non_superuser(self):
-        # non-superuser staff: the parent_project dropdown should only list projects from their own orgs
+    def test_add_form_parent_project_queryset_scoped_to_new_projects_organization(self):
+        # parent_project dropdown should only list projects from the same org as the new project being created
         other_org_project = KippoProject.objects.create(
             organization=self.other_organization,
             name="other-org-project",
@@ -529,6 +529,27 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         )
         # log in as a staff user who only belongs to self.organization (not self.other_organization)
         self.client.force_login(self.staffuser_with_org)
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        parent_qs = response.context["adminform"].form.fields["parent_project"].queryset
+        parent_ids = set(parent_qs.values_list("id", flat=True))
+        self.assertIn(self.project1.id, parent_ids)
+        self.assertNotIn(other_org_project.id, parent_ids)
+
+    def test_add_form_parent_project_queryset_excludes_other_orgs_for_superuser(self):
+        # superuser: parent_project queryset is scoped to the new project's org, not globally visible
+        other_org_project = KippoProject.objects.create(
+            organization=self.other_organization,
+            name="other-org-project-superuser-view",
+            category="poc",
+            columnset=ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK),
+            start_date=self.current_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        # superuser_no_org was added to self.organization in setUp; log in
+        self.client.force_login(self.superuser_no_org)
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -602,6 +623,23 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
             data=self._form_data(category="upsell-improvement"),  # no parent_project key
         )
         self.assertTrue(form.is_valid(), form.errors)
+
+    def test_cross_org_parent_project_submission_is_invalid(self):
+        # parent_project from a different organization than the submitted org should be rejected
+        cross_org_parent = KippoProject.objects.create(
+            organization=self.other_organization,
+            name="cross-org-parent",
+            category="poc",
+            columnset=self.columnset,
+            start_date=self.current_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        form = KippoProjectAdminForm(
+            data=self._form_data(category="upsell-improvement", parent_project_id=str(cross_org_parent.id)),
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("parent_project", form.errors)
 
 
 class UpsellPrefillHelpersTestCase(TestCase):
@@ -923,3 +961,46 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
         self.assertIn("category", ordered)
         self.assertIn("parent_project", ordered)
         self.assertNotEqual(ordered[ordered.index("category") + 1], "parent_project")
+
+
+class KippoProjectAdminSingleOrgHidesOrganizationFieldTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """On /add/, hide the organization field when the user belongs to exactly one organization."""
+
+    @staticmethod
+    def _organization_widget(adminform: AdminForm) -> forms.Widget:
+        widget = adminform.form.fields["organization"].widget
+        # ModelChoiceField may wrap with RelatedFieldWidgetWrapper — unwrap to inspect the inner widget
+        return getattr(widget, "widget", widget)
+
+    def test_add_view_hides_organization_field_for_single_org_user(self):
+        # superuser_no_org was added to self.organization in fixture setUp → exactly one org
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        adminform = response.context["adminform"]
+        self.assertIsInstance(self._organization_widget(adminform), forms.HiddenInput)
+        # initial value still preselects the single org
+        self.assertEqual(adminform.form.fields["organization"].initial, self.organization)
+
+    def test_add_view_keeps_organization_field_visible_for_multi_org_user(self):
+        # promote superuser into a second org so they belong to two organizations
+        OrganizationMembership.objects.create(
+            user=self.superuser_no_org,
+            organization=self.other_organization,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        adminform = response.context["adminform"]
+        self.assertNotIsInstance(self._organization_widget(adminform), forms.HiddenInput)
+
+    def test_change_view_does_not_hide_organization_field_for_single_org_user(self):
+        # On /change/, the hide-on-single-org rule must not apply (organization is fixed but visible)
+        existing = self.make_project("single-org-change-target")
+        url = reverse("admin:projects_kippoproject_change", args=[existing.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        adminform = response.context["adminform"]
+        self.assertNotIsInstance(self._organization_widget(adminform), forms.HiddenInput)


### PR DESCRIPTION
## Summary

Three related KippoProject `/add/` form tweaks tightening organization scoping:

- **Hide the organization field on `/add/` when the user belongs to exactly one organization.** The single org is preselected as initial; the field is rendered as `HiddenInput`. The queryset stays scoped to the user's orgs so a tampered submission gets rejected by the field's normal validation.
- **Filter `parent_project` queryset by the new project's organization** (`organization=user_initial_organization`). Previously, non-superusers saw projects from all of their orgs and superusers saw every project across the system. Cross-org parent/child relationships make no business sense.
- **Reject cross-org `parent_project` submissions in `KippoProjectAdminForm.clean()`.** Catches form tampering and any client-side org-change-without-parent-update edge cases. Skipped on `/change/` since `parent_project` is readonly there.

## Test plan

- [x] `python manage.py test projects.tests.test_admin` — 53 tests pass (4 new)
- [x] Existing parent-project queryset test renamed/repointed to assert the new (tighter) scope
- [x] New test: superuser sees only same-org projects in the parent_project dropdown
- [x] New test: cross-org `parent_project` submission rejected by `clean()`
- [x] New test class: organization field is `HiddenInput` for single-org user, regular Select for multi-org user, and not hidden on `/change/`
- [ ] Manual: `/add/` as single-org staff — organization field absent (HiddenInput), project saves with that org
- [ ] Manual: `/add/` as multi-org user — organization Select still visible, parent_project dropdown matches initial org
- [ ] Manual: tamper with parent_project to a different org's project ID and submit — form returns validation error