### PR TITLE
:sparkles: Phase 0: ProjectMonthlyAssignment foundation (#225)

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -97,6 +97,13 @@ class ProjectAssignmentRateInline(LockWhenProjectClosedInlineMixin, AllowIsStaff
     classes = ["collapse"]
 
 
+class ProjectMonthlyAssignmentInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, admin.TabularInline):
+    model = ProjectMonthlyAssignment
+    extra = 0
+    fields = ("user", "month", "percentage", "is_confirmed")
+    classes = ["collapse"]
+
+
 class KippoMilestoneReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
     model = KippoMilestone
     extra = 0
@@ -652,6 +659,7 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # KippoMilestoneReadOnlyInline,
         # KippoMilestoneAdminInline,
         ProjectAssignmentRateInline,
+        ProjectMonthlyAssignmentInline,
         GithubRepositoryProjectInline,
         ProjectWeeklyEffortReadOnlyInine,
         KippoProjectStatusReadOnlyInine,
@@ -1125,7 +1133,9 @@ class ProjectColumnSetAdmin(UserCreatedBaseModelAdmin):
 
 @admin.register(ProjectMonthlyAssignment)
 class ProjectMonthlyAssignmentAdmin(UserCreatedBaseModelAdmin):
-    list_display = ("project", "get_project_organization", "user")
+    list_display = ("project", "get_project_organization", "user", "month", "percentage", "is_confirmed")
+    list_filter = ("is_confirmed", "month", "project__organization")
+    search_fields = ("project__name", "user__username")
 
     def get_project_organization(self, obj: ProjectMonthlyAssignment):
         organization_name = obj.project.organization.name

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -952,10 +952,39 @@ class ProjectMonthlyAssignment(UserCreatedBaseModel):
                     code="invalid_user_organization",
                 )
 
+        # Hard-fail when is_confirmed=True and confirmed-only org-total would exceed 100%.
+        # Unconfirmed projections may exceed (warning-only, see save()) so the suggester can
+        # surface infeasible patterns honestly.
+        if self.is_confirmed and self.user and self.project and self.month and self.percentage is not None:
+            confirmed_others = ProjectMonthlyAssignment.objects.filter(
+                user=self.user,
+                project__organization=self.project.organization,
+                month=self.month,
+                is_confirmed=True,
+            )
+            if self.pk:
+                confirmed_others = confirmed_others.exclude(pk=self.pk)
+            existing_total = confirmed_others.aggregate(total=Sum("percentage"))["total"] or 0
+            if existing_total + self.percentage > MAX_ASSIGNMENT_PERCENTAGE:
+                raise ValidationError(
+                    _(
+                        "Confirmed assignment total %(total)d%% for user '%(user)s' in organization '%(org)s' for month %(month)s exceeds %(cap)d%%",
+                    ),
+                    params={
+                        "total": existing_total + self.percentage,
+                        "user": self.user,
+                        "org": self.project.organization,
+                        "month": self.month.strftime("%Y-%m"),
+                        "cap": MAX_ASSIGNMENT_PERCENTAGE,
+                    },
+                    code="confirmed_assignment_exceeds_cap",
+                )
+
     def save(self, *args, **kwargs) -> None:
         self.full_clean()
         super().save(*args, **kwargs)
         # Log warning if user's total percentage for the organization exceeds 100%
+        # (informational; hard-fail enforcement on confirmed rows lives in clean()).
         if self.user and self.project and self.month:
             total_percentage = (
                 ProjectMonthlyAssignment.objects.filter(

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -952,39 +952,12 @@ class ProjectMonthlyAssignment(UserCreatedBaseModel):
                     code="invalid_user_organization",
                 )
 
-        # Hard-fail when is_confirmed=True and confirmed-only org-total would exceed 100%.
-        # Unconfirmed projections may exceed (warning-only, see save()) so the suggester can
-        # surface infeasible patterns honestly.
-        if self.is_confirmed and self.user and self.project and self.month and self.percentage is not None:
-            confirmed_others = ProjectMonthlyAssignment.objects.filter(
-                user=self.user,
-                project__organization=self.project.organization,
-                month=self.month,
-                is_confirmed=True,
-            )
-            if self.pk:
-                confirmed_others = confirmed_others.exclude(pk=self.pk)
-            existing_total = confirmed_others.aggregate(total=Sum("percentage"))["total"] or 0
-            if existing_total + self.percentage > MAX_ASSIGNMENT_PERCENTAGE:
-                raise ValidationError(
-                    _(
-                        "Confirmed assignment total %(total)d%% for user '%(user)s' in organization '%(org)s' for month %(month)s exceeds %(cap)d%%",
-                    ),
-                    params={
-                        "total": existing_total + self.percentage,
-                        "user": self.user,
-                        "org": self.project.organization,
-                        "month": self.month.strftime("%Y-%m"),
-                        "cap": MAX_ASSIGNMENT_PERCENTAGE,
-                    },
-                    code="confirmed_assignment_exceeds_cap",
-                )
-
     def save(self, *args, **kwargs) -> None:
         self.full_clean()
         super().save(*args, **kwargs)
-        # Log warning if user's total percentage for the organization exceeds 100%
-        # (informational; hard-fail enforcement on confirmed rows lives in clean()).
+        # Warn (do not block) when the user's total percentage for the organization in this
+        # month exceeds 100%. Over-allocation is permitted; UI / admin surfaces are
+        # responsible for visually displaying the warning to end users.
         if self.user and self.project and self.month:
             total_percentage = (
                 ProjectMonthlyAssignment.objects.filter(

--- a/kippo/projects/tests/test_projectmonthlyassignment.py
+++ b/kippo/projects/tests/test_projectmonthlyassignment.py
@@ -1,0 +1,372 @@
+"""Tests for the ProjectMonthlyAssignment model, serializer, and viewset.
+
+Covers the existing surface as part of monkut/kippo#225 (Phase 0 of feature #224):
+- Model: clean() org-membership check, month default, hard-fail on confirmed >100%.
+- Model: save() warning-only on unconfirmed >100%.
+- Serializer: user display + slack metadata derived from OrganizationMembership.
+- ViewSet: org-scoping, filters, permission checks.
+"""
+
+import datetime
+import logging
+from http import HTTPStatus
+
+from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from projects.models import KippoProject, ProjectMonthlyAssignment
+from projects.serializers import ProjectMonthlyAssignmentSerializer
+
+
+class ProjectMonthlyAssignmentModelTestCase(TestCase):
+    """Model validation + persistence behavior."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.user = created["KippoUser"]
+        self.project = created["KippoProject"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+        # Project needs a start_date for the month-default behavior
+        self.project.start_date = datetime.date(2026, 3, 15)
+        self.project.save()
+
+    def _make_assignment(self, **overrides) -> ProjectMonthlyAssignment:
+        defaults = {
+            "project": self.project,
+            "user": self.user,
+            "month": datetime.date(2026, 4, 1),
+            "percentage": 50,
+            "is_confirmed": False,
+            "created_by": self.github_manager,
+            "updated_by": self.github_manager,
+        }
+        defaults.update(overrides)
+        return ProjectMonthlyAssignment(**defaults)
+
+    def test_clean_rejects_user_not_in_project_organization(self):
+        outsider_org = KippoOrganization.objects.create(
+            name="outsider-org",
+            github_organization_name="outsider",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        outsider = KippoUser.objects.create(username="outsider", email="outsider@example.com")
+        OrganizationMembership.objects.create(
+            user=outsider,
+            organization=outsider_org,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        assignment = self._make_assignment(user=outsider)
+        with self.assertRaises(ValidationError) as ctx:
+            assignment.full_clean()
+        self.assertEqual(ctx.exception.error_dict["__all__"][0].code, "invalid_user_organization")
+
+    def test_clean_defaults_month_to_project_start_date_first_of_month(self):
+        # start_date = 2026-03-15, default month should be 2026-03-01
+        assignment = self._make_assignment(month=None)
+        assignment.full_clean()
+        self.assertEqual(assignment.month, datetime.date(2026, 3, 1))
+
+    def test_save_persists_with_valid_data(self):
+        assignment = self._make_assignment(percentage=40)
+        assignment.save()
+        self.assertIsNotNone(assignment.pk)
+
+    def test_save_hard_fails_on_confirmed_total_over_100(self):
+        existing = self._make_assignment(percentage=70, is_confirmed=True)
+        existing.save()
+
+        # Same user/org/month, would push confirmed total to 130%
+        # NOTE: needs a second project in the same org to test cross-project totals
+        second_project = KippoProject.objects.create(
+            name="second-project",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            start_date=datetime.date(2026, 3, 15),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        offending = self._make_assignment(project=second_project, percentage=60, is_confirmed=True)
+        with self.assertRaises(ValidationError) as ctx:
+            offending.save()
+        self.assertEqual(ctx.exception.error_dict["__all__"][0].code, "confirmed_assignment_exceeds_cap")
+
+    def test_save_warns_only_on_unconfirmed_total_over_100(self):
+        # Two unconfirmed rows summing to 130% — should warn but not raise
+        existing = self._make_assignment(percentage=70, is_confirmed=False)
+        existing.save()
+        second_project = KippoProject.objects.create(
+            name="warn-project",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            start_date=datetime.date(2026, 3, 15),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        with self.assertLogs("projects.models", level=logging.WARNING) as logs:
+            second = self._make_assignment(project=second_project, percentage=60, is_confirmed=False)
+            second.save()  # must not raise
+        self.assertTrue(any("exceeds 100%%" in record.getMessage() or "exceeds 100%" in record.getMessage() for record in logs.records))
+        self.assertIsNotNone(second.pk)
+
+    def test_save_does_not_double_count_self_when_updating_confirmed_row(self):
+        assignment = self._make_assignment(percentage=80, is_confirmed=True)
+        assignment.save()
+        # Update same row's percentage upward — must not see itself in the existing total
+        assignment.percentage = 95
+        assignment.save()  # must not raise
+        self.assertEqual(ProjectMonthlyAssignment.objects.get(pk=assignment.pk).percentage, 95)
+
+    def test_save_unconfirmed_does_not_count_against_confirmed_cap(self):
+        # 90% unconfirmed already exists; adding 50% confirmed should succeed because cap
+        # only sums *confirmed* rows.
+        unconfirmed = self._make_assignment(percentage=90, is_confirmed=False)
+        unconfirmed.save()
+
+        second_project = KippoProject.objects.create(
+            name="confirmed-on-top",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            start_date=datetime.date(2026, 3, 15),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        confirmed = self._make_assignment(project=second_project, percentage=50, is_confirmed=True)
+        confirmed.save()  # must not raise — confirmed total is only 50
+        self.assertIsNotNone(confirmed.pk)
+
+    def test_save_promote_unconfirmed_to_confirmed_rejects_when_over_cap(self):
+        # 70% confirmed elsewhere, 50% unconfirmed on this row → toggling to confirmed
+        # would push confirmed total to 120% → must reject.
+        elsewhere = self._make_assignment(percentage=70, is_confirmed=True)
+        elsewhere.save()
+
+        second_project = KippoProject.objects.create(
+            name="promote-test",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            start_date=datetime.date(2026, 3, 15),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        candidate = self._make_assignment(project=second_project, percentage=50, is_confirmed=False)
+        candidate.save()
+        candidate.is_confirmed = True
+        with self.assertRaises(ValidationError) as ctx:
+            candidate.save()
+        self.assertEqual(ctx.exception.error_dict["__all__"][0].code, "confirmed_assignment_exceeds_cap")
+
+
+class ProjectMonthlyAssignmentSerializerTestCase(TestCase):
+    """Serializer derives display/slack fields from OrganizationMembership."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.user = created["KippoUser"]
+        self.project = created["KippoProject"]
+        self.project.start_date = datetime.date(2026, 3, 15)
+        self.project.save()
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        # Annotate user's display_name + the membership's slack fields
+        self.user.first_name = "Octo"
+        self.user.last_name = "Cat"
+        self.user.save()
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.slack_username = "octo-slack"
+        membership.slack_image_url = "https://example.com/octo.png"
+        membership.save()
+
+        self.assignment = ProjectMonthlyAssignment.objects.create(
+            project=self.project,
+            user=self.user,
+            month=datetime.date(2026, 4, 1),
+            percentage=50,
+            is_confirmed=False,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+    def test_serializer_exposes_user_username(self):
+        data = ProjectMonthlyAssignmentSerializer(self.assignment).data
+        self.assertEqual(data["user_username"], self.user.username)
+
+    def test_serializer_user_display_name_from_user(self):
+        data = ProjectMonthlyAssignmentSerializer(self.assignment).data
+        # KippoUser.display_name composes name + parenthetical username; assert components present
+        self.assertIn("Octo Cat", data["user_display_name"])
+
+    def test_serializer_user_slack_fields_from_organization_membership(self):
+        data = ProjectMonthlyAssignmentSerializer(self.assignment).data
+        self.assertEqual(data["user_slack_username"], "octo-slack")
+        self.assertEqual(data["user_slack_image_url"], "https://example.com/octo.png")
+
+    def test_serializer_user_slack_fields_null_when_membership_absent(self):
+        # Wipe membership to force the membership-not-found branch
+        OrganizationMembership.objects.filter(user=self.user, organization=self.organization).delete()
+        data = ProjectMonthlyAssignmentSerializer(self.assignment).data
+        self.assertIsNone(data["user_slack_username"])
+        self.assertIsNone(data["user_slack_image_url"])
+
+
+class ProjectMonthlyAssignmentViewSetTestCase(TestCase):
+    """ViewSet org-scoping, filters, and permissions."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.user = created["KippoUser"]
+        self.project = created["KippoProject"]
+        self.project.start_date = datetime.date(2026, 3, 15)
+        self.project.save()
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        # Second org with its own project, user, and assignment — should be invisible to self.user
+        self.other_org = KippoOrganization.objects.create(
+            name="other-org",
+            github_organization_name="otherorg",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_user = KippoUser.objects.create(username="otheruser", email="other@example.com")
+        OrganizationMembership.objects.create(
+            user=self.other_user,
+            organization=self.other_org,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_project = KippoProject.objects.create(
+            name="other-project",
+            organization=self.other_org,
+            columnset=self.project.columnset,
+            start_date=datetime.date(2026, 3, 15),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        # Three assignments to drive filter tests
+        self.assignment_apr = ProjectMonthlyAssignment.objects.create(
+            project=self.project,
+            user=self.user,
+            month=datetime.date(2026, 4, 1),
+            percentage=50,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.assignment_may = ProjectMonthlyAssignment.objects.create(
+            project=self.project,
+            user=self.user,
+            month=datetime.date(2026, 5, 1),
+            percentage=60,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_assignment = ProjectMonthlyAssignment.objects.create(
+            project=self.other_project,
+            user=self.other_user,
+            month=datetime.date(2026, 4, 1),
+            percentage=70,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.list_url = f"{settings.URL_PREFIX}/api/monthly-assignments/"
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def test_list_requires_authentication(self):
+        anon = APIClient()
+        response = anon.get(self.list_url)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_list_org_scoped_for_regular_user(self):
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ids = {row["id"] for row in response.json()["results"]}
+        self.assertIn(self.assignment_apr.id, ids)
+        self.assertIn(self.assignment_may.id, ids)
+        self.assertNotIn(self.other_assignment.id, ids)
+
+    def test_list_returns_all_orgs_for_superuser(self):
+        superuser = KippoUser.objects.create(username="forecast-super", is_superuser=True, is_staff=True)
+        admin_client = APIClient()
+        admin_client.force_authenticate(user=superuser)
+        response = admin_client.get(self.list_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ids = {row["id"] for row in response.json()["results"]}
+        self.assertIn(self.assignment_apr.id, ids)
+        self.assertIn(self.other_assignment.id, ids)
+
+    def test_filter_by_project(self):
+        response = self.client.get(self.list_url, {"project": str(self.project.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ids = {row["id"] for row in response.json()["results"]}
+        self.assertEqual(ids, {self.assignment_apr.id, self.assignment_may.id})
+
+    def test_filter_by_user(self):
+        response = self.client.get(self.list_url, {"user": str(self.user.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        results = response.json()["results"]
+        self.assertGreater(len(results), 0)
+        for row in results:
+            self.assertEqual(row["user"], str(self.user.id))
+
+    def test_filter_by_month_exact(self):
+        response = self.client.get(self.list_url, {"month": "2026-04-01"})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        for row in response.json()["results"]:
+            self.assertEqual(row["month"], "2026-04-01")
+
+    def test_filter_by_month_gte_and_lte(self):
+        response = self.client.get(
+            self.list_url,
+            {"month_gte": "2026-04-01", "month_lte": "2026-04-30"},
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ids = {row["id"] for row in response.json()["results"]}
+        self.assertEqual(ids, {self.assignment_apr.id})
+
+    def test_create_persists_new_assignment(self):
+        new_month = datetime.date(2026, 6, 1)
+        payload = {
+            "project": str(self.project.id),
+            "user": str(self.user.id),
+            "month": new_month.isoformat(),
+            "percentage": 25,
+            "is_confirmed": False,
+        }
+        response = self.client.post(self.list_url, payload, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
+        self.assertTrue(ProjectMonthlyAssignment.objects.filter(project=self.project, user=self.user, month=new_month).exists())
+
+    def test_partial_update_changes_percentage(self):
+        url = f"{self.list_url}{self.assignment_apr.id}/"
+        response = self.client.patch(url, {"percentage": 75}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assignment_apr.refresh_from_db()
+        self.assertEqual(self.assignment_apr.percentage, 75)
+
+    def test_destroy_removes_row(self):
+        url = f"{self.list_url}{self.assignment_apr.id}/"
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+        self.assertFalse(ProjectMonthlyAssignment.objects.filter(pk=self.assignment_apr.id).exists())
+
+    def test_other_org_assignment_is_invisible_to_user(self):
+        url = f"{self.list_url}{self.other_assignment.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/kippo/projects/tests/test_projectmonthlyassignment.py
+++ b/kippo/projects/tests/test_projectmonthlyassignment.py
@@ -81,27 +81,26 @@ class ProjectMonthlyAssignmentModelTestCase(TestCase):
         assignment.save()
         self.assertIsNotNone(assignment.pk)
 
-    def test_save_hard_fails_on_confirmed_total_over_100(self):
+    def test_save_warns_only_on_confirmed_total_over_100(self):
+        # Two confirmed rows summing to 130% — over-allocation is allowed; logs a warning.
         existing = self._make_assignment(percentage=70, is_confirmed=True)
         existing.save()
-
-        # Same user/org/month, would push confirmed total to 130%
-        # NOTE: needs a second project in the same org to test cross-project totals
         second_project = KippoProject.objects.create(
-            name="second-project",
+            name="confirmed-warn-project",
             organization=self.organization,
             columnset=self.project.columnset,
             start_date=datetime.date(2026, 3, 15),
             created_by=self.github_manager,
             updated_by=self.github_manager,
         )
-        offending = self._make_assignment(project=second_project, percentage=60, is_confirmed=True)
-        with self.assertRaises(ValidationError) as ctx:
-            offending.save()
-        self.assertEqual(ctx.exception.error_dict["__all__"][0].code, "confirmed_assignment_exceeds_cap")
+        with self.assertLogs("projects.models", level=logging.WARNING) as logs:
+            offending = self._make_assignment(project=second_project, percentage=60, is_confirmed=True)
+            offending.save()  # must not raise
+        self.assertTrue(any("exceeds 100" in record.getMessage() for record in logs.records))
+        self.assertIsNotNone(offending.pk)
 
     def test_save_warns_only_on_unconfirmed_total_over_100(self):
-        # Two unconfirmed rows summing to 130% — should warn but not raise
+        # Two unconfirmed rows summing to 130% — over-allocation is allowed; logs a warning.
         existing = self._make_assignment(percentage=70, is_confirmed=False)
         existing.save()
         second_project = KippoProject.objects.create(
@@ -115,38 +114,12 @@ class ProjectMonthlyAssignmentModelTestCase(TestCase):
         with self.assertLogs("projects.models", level=logging.WARNING) as logs:
             second = self._make_assignment(project=second_project, percentage=60, is_confirmed=False)
             second.save()  # must not raise
-        self.assertTrue(any("exceeds 100%%" in record.getMessage() or "exceeds 100%" in record.getMessage() for record in logs.records))
+        self.assertTrue(any("exceeds 100" in record.getMessage() for record in logs.records))
         self.assertIsNotNone(second.pk)
 
-    def test_save_does_not_double_count_self_when_updating_confirmed_row(self):
-        assignment = self._make_assignment(percentage=80, is_confirmed=True)
-        assignment.save()
-        # Update same row's percentage upward — must not see itself in the existing total
-        assignment.percentage = 95
-        assignment.save()  # must not raise
-        self.assertEqual(ProjectMonthlyAssignment.objects.get(pk=assignment.pk).percentage, 95)
-
-    def test_save_unconfirmed_does_not_count_against_confirmed_cap(self):
-        # 90% unconfirmed already exists; adding 50% confirmed should succeed because cap
-        # only sums *confirmed* rows.
-        unconfirmed = self._make_assignment(percentage=90, is_confirmed=False)
-        unconfirmed.save()
-
-        second_project = KippoProject.objects.create(
-            name="confirmed-on-top",
-            organization=self.organization,
-            columnset=self.project.columnset,
-            start_date=datetime.date(2026, 3, 15),
-            created_by=self.github_manager,
-            updated_by=self.github_manager,
-        )
-        confirmed = self._make_assignment(project=second_project, percentage=50, is_confirmed=True)
-        confirmed.save()  # must not raise — confirmed total is only 50
-        self.assertIsNotNone(confirmed.pk)
-
-    def test_save_promote_unconfirmed_to_confirmed_rejects_when_over_cap(self):
-        # 70% confirmed elsewhere, 50% unconfirmed on this row → toggling to confirmed
-        # would push confirmed total to 120% → must reject.
+    def test_save_promote_unconfirmed_to_confirmed_allows_over_cap(self):
+        # 70% confirmed elsewhere + 50% unconfirmed locally → toggling to confirmed pushes
+        # the confirmed total to 120%. Allowed; warning logged.
         elsewhere = self._make_assignment(percentage=70, is_confirmed=True)
         elsewhere.save()
 
@@ -161,9 +134,11 @@ class ProjectMonthlyAssignmentModelTestCase(TestCase):
         candidate = self._make_assignment(project=second_project, percentage=50, is_confirmed=False)
         candidate.save()
         candidate.is_confirmed = True
-        with self.assertRaises(ValidationError) as ctx:
-            candidate.save()
-        self.assertEqual(ctx.exception.error_dict["__all__"][0].code, "confirmed_assignment_exceeds_cap")
+        with self.assertLogs("projects.models", level=logging.WARNING) as logs:
+            candidate.save()  # must not raise
+        self.assertTrue(any("exceeds 100" in record.getMessage() for record in logs.records))
+        candidate.refresh_from_db()
+        self.assertTrue(candidate.is_confirmed)
 
 
 class ProjectMonthlyAssignmentSerializerTestCase(TestCase):


### PR DESCRIPTION
Implements Phase 0 of the User Project Assignment feature ([#224](https://github.com/monkut/kippo/issues/224) / [#225](https://github.com/monkut/kippo/issues/225)).
Three independent strands prepare the existing `ProjectMonthlyAssignment` surface for the forecast ([#226](https://github.com/monkut/kippo/issues/226)) and suggestion ([#227](https://github.com/monkut/kippo/issues/227)) endpoints to come next.

## Net diff
+361 / −2 across 3 files. No new migrations. No OpenAPI changes.

## Strand A — Test coverage (`kippo/projects/tests/test_projectmonthlyassignment.py`, +347)
21 new tests across three `TestCase` classes:

**`ProjectMonthlyAssignmentModelTestCase`**
- `clean()` rejects user not in project's organization.
- `clean()` defaults `month` to `project.start_date.replace(day=1)`.
- `save()` persists with valid data.
- `save()` warn-only when confirmed total > 100% (per [#224 A5](https://github.com/monkut/kippo/issues/224)).
- `save()` warn-only when unconfirmed total > 100%.
- `save()` allows promoting unconfirmed → confirmed even when push pushes confirmed total > 100% (warn-only).

**`ProjectMonthlyAssignmentSerializerTestCase`**
- Exposes `user_username`.
- `user_display_name` composed from `KippoUser.display_name`.
- `user_slack_username` and `user_slack_image_url` derived from `OrganizationMembership` for the project's org.
- Slack fields null when membership absent.

**`ProjectMonthlyAssignmentViewSetTestCase`**
- `list` requires authentication.
- `list` is org-scoped for regular users; superuser sees all.
- Filter by `project` / `user` / `month` / `month_gte`+`month_lte`.
- `create` / `partial_update` / `destroy`.
- Cross-org row is invisible (404).

## Strand B — Validation (`kippo/projects/models.py`, +2/−2 net)
Per [#224 A5](https://github.com/monkut/kippo/issues/224) (revised 2026-05-07 JST): **over-allocation > 100% per user/org/month is permitted on both confirmed and unconfirmed rows; the existing `save()` warning-log already covers visibility**. No model behavior change in this PR — the only edit is a comment clarifying that UI / admin surfaces are responsible for visually displaying the warning to end users.

> History note: `b7422fa` initially added a hard-fail in `clean()` for confirmed rows; reverted in `4dfa97a` after A5 was revised. Net diff against main reflects only the comment update.

## Strand C — Admin polish (`kippo/projects/admin.py`, +12/−1)
- `ProjectMonthlyAssignmentAdmin`: `list_display` adds `month`, `percentage`, `is_confirmed`; new `list_filter` (`is_confirmed`, `month`, `project__organization`) and `search_fields` (`project__name`, `user__username`).
- `KippoProjectAdmin`: new `ProjectMonthlyAssignmentInline` (collapsible TabularInline, respects `LockWhenProjectClosedInlineMixin` like `ProjectAssignmentRateInline`) — lets a PM manage assignments alongside the project change form.

## Verification
- `uv run python manage.py test projects.tests.test_projectmonthlyassignment` → **21 / 21 OK**.
- `uv run python manage.py test projects` → all OK except 5 pre-existing AWS/S3 env errors (unrelated; same on main).
- `uv run ruff check` and `uv run ruff format --check` clean on all touched files.

## Closes
- [monkut/kippo#225](https://github.com/monkut/kippo/issues/225) (Phase 0)

## Refs
- [monkut/kippo#224](https://github.com/monkut/kippo/issues/224) — parent / decision source. **A5 revised 2026-05-07 JST** to warn-only on both confirmed and unconfirmed (was: hard-fail on confirmed).
- [monkut/kippo#226](https://github.com/monkut/kippo/issues/226) — Phase 1 (forecast), unblocked by this PR.
- [monkut/kippo#227](https://github.com/monkut/kippo/issues/227) — Phase 2 (suggester), unblocked by Phase 1.
- [monkut/kippo-ui#57](https://github.com/monkut/kippo-ui/issues/57) — frontend will visually surface the >100% warning (no 4xx blocks).