### PR TITLE
:sparkles: Phase 2: Assignment pattern suggestion endpoint + service (#227)

### DIFF
--- a/kippo/projects/definitions.py
+++ b/kippo/projects/definitions.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from commons.definitions import StringEnumWithChoices
 from django.utils.translation import gettext_lazy as _
-from pydantic import BaseModel as _BaseModel
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from accounts.models import OrganizationMembership
@@ -79,7 +79,7 @@ class ProjectAssignmentForecastUserContext:
     user_personal_holidays: dict[int, set[datetime.date]]
 
 
-class PatternMember(_BaseModel):
+class ProjectAssignmentPatternMember(BaseModel):
     """One member of a suggested assignment pattern.
 
     `monthly_percentages` keys are first-of-month dates; pydantic serializes them as
@@ -91,29 +91,30 @@ class PatternMember(_BaseModel):
     monthly_percentages: dict[datetime.date, int]
 
 
-class PatternConflict(_BaseModel):
-    """An over-allocation point in a suggested pattern."""
+class ProjectAssignmentPatternConflict(BaseModel):
+    """An over-allocation point in a suggested project-assignment pattern."""
 
     user_id: uuid.UUID
     month: datetime.date
     reason: str
 
 
-class Pattern(_BaseModel):
-    """A complete suggested assignment pattern.
+class ProjectAssignmentPattern(BaseModel):
+    """A complete suggested project-assignment pattern.
 
     `pattern_ids` carries the strategy keys that produced this pattern. Normally a
     single id (e.g. ['P1-max-reuse']); when multiple strategies converge on the
-    same member set + monthly percentages they are deduplicated into one Pattern
-    with the union (e.g. ['P1-max-reuse', 'P2-blend']) — see kippo#227 S3.
+    same member set + monthly percentages they are deduplicated into one
+    ProjectAssignmentPattern with the union (e.g. ['P1-max-reuse', 'P2-blend'])
+    — see kippo#227 S3.
     """
 
     pattern_ids: list[str]
     label: str
     estimated_completion: datetime.date | None
     infeasible: bool
-    conflicts: list[PatternConflict]
-    members: list[PatternMember]
+    conflicts: list[ProjectAssignmentPatternConflict]
+    members: list[ProjectAssignmentPatternMember]
 
 
 class ValidCurrencies(StringEnumWithChoices):

--- a/kippo/projects/definitions.py
+++ b/kippo/projects/definitions.py
@@ -1,9 +1,11 @@
 import dataclasses
 import datetime
+import uuid
 from typing import TYPE_CHECKING
 
 from commons.definitions import StringEnumWithChoices
 from django.utils.translation import gettext_lazy as _
+from pydantic import BaseModel as _BaseModel
 
 if TYPE_CHECKING:
     from accounts.models import OrganizationMembership
@@ -75,6 +77,43 @@ class ProjectAssignmentForecastUserContext:
     user_holiday_country: dict[int, int | None]
     public_holidays_by_country: dict[int, set[datetime.date]]
     user_personal_holidays: dict[int, set[datetime.date]]
+
+
+class PatternMember(_BaseModel):
+    """One member of a suggested assignment pattern.
+
+    `monthly_percentages` keys are first-of-month dates; pydantic serializes them as
+    ISO strings ("YYYY-MM-DD") via `model_dump(mode='json')`.
+    """
+
+    user_id: uuid.UUID
+    is_past_member: bool
+    monthly_percentages: dict[datetime.date, int]
+
+
+class PatternConflict(_BaseModel):
+    """An over-allocation point in a suggested pattern."""
+
+    user_id: uuid.UUID
+    month: datetime.date
+    reason: str
+
+
+class Pattern(_BaseModel):
+    """A complete suggested assignment pattern.
+
+    `pattern_ids` carries the strategy keys that produced this pattern. Normally a
+    single id (e.g. ['P1-max-reuse']); when multiple strategies converge on the
+    same member set + monthly percentages they are deduplicated into one Pattern
+    with the union (e.g. ['P1-max-reuse', 'P2-blend']) — see kippo#227 S3.
+    """
+
+    pattern_ids: list[str]
+    label: str
+    estimated_completion: datetime.date | None
+    infeasible: bool
+    conflicts: list[PatternConflict]
+    members: list[PatternMember]
 
 
 class ValidCurrencies(StringEnumWithChoices):

--- a/kippo/projects/services/forecast.py
+++ b/kippo/projects/services/forecast.py
@@ -58,8 +58,16 @@ class ProjectAssignmentForecastManager:
     def __init__(self, project: KippoProject) -> None:
         self.project = project
 
-    def compute(self) -> ForecastResult:
+    def compute(self, overlay: dict[int, dict[datetime.date, int]] | None = None) -> ForecastResult:
         """Return the forecast payload.
+
+        Args:
+            overlay: Optional `{user_id: {month_first_day: percentage}}` mapping. When
+                provided, the future projection uses this hypothetical assignment set
+                instead of querying `ProjectMonthlyAssignment` rows on the project.
+                Used by the suggestion engine to evaluate candidate patterns without
+                persisting them. Past + in-progress logged effort is still computed
+                from `ProjectWeeklyEffort` regardless.
 
         Returns a `ForecastResult` with ``estimated_completion_date`` (date | None),
         ``delta_from_target_date_days`` (int | None — positive = behind target),
@@ -83,12 +91,24 @@ class ProjectAssignmentForecastManager:
             return self.__build_response(self.__latest_logged_week_start(today) or today)
 
         next_month_start = first_of_next_month(today)
-        future_assignments = list(ProjectMonthlyAssignment.objects.filter(project=project, month__gte=next_month_start).order_by("month"))
-        if not future_assignments:
-            return self.__build_response(None)
+        if overlay is None:
+            future_rows = list(ProjectMonthlyAssignment.objects.filter(project=project, month__gte=next_month_start).order_by("month"))
+            if not future_rows:
+                return self.__build_response(None)
+            by_user_month: dict[int, dict[datetime.date, int]] = defaultdict(dict)
+            for assignment in future_rows:
+                by_user_month[assignment.user_id][assignment.month] = assignment.percentage
+        else:
+            by_user_month = {
+                user_id: {month: pct for month, pct in months.items() if month >= next_month_start} for user_id, months in overlay.items()
+            }
+            by_user_month = {user_id: months for user_id, months in by_user_month.items() if months}
+            if not by_user_month:
+                return self.__build_response(None)
 
-        horizon = max(a.month for a in future_assignments) + datetime.timedelta(days=HORIZON_PADDING_DAYS)
-        ctx = self.__load_user_context(future_assignments, next_month_start, horizon)
+        all_months = [m for months in by_user_month.values() for m in months]
+        horizon = max(all_months) + datetime.timedelta(days=HORIZON_PADDING_DAYS)
+        ctx = self.__load_user_context(by_user_month, next_month_start, horizon)
         completion = self.__walk_to_completion(
             ctx=ctx,
             start_day=next_month_start,
@@ -118,16 +138,11 @@ class ProjectAssignmentForecastManager:
 
     def __load_user_context(
         self,
-        future_assignments: list[ProjectMonthlyAssignment],
+        by_user_month: dict[int, dict[datetime.date, int]],
         next_month_start: datetime.date,
         horizon: datetime.date,
     ) -> ProjectAssignmentForecastUserContext:
         organization = self.project.organization
-
-        by_user_month: dict[int, dict[datetime.date, int]] = defaultdict(dict)
-        for assignment in future_assignments:
-            by_user_month[assignment.user_id][assignment.month] = assignment.percentage
-
         user_ids = list(by_user_month.keys())
 
         user_membership = {m.user_id: m for m in OrganizationMembership.objects.filter(user_id__in=user_ids, organization=organization)}

--- a/kippo/projects/services/forecast.py
+++ b/kippo/projects/services/forecast.py
@@ -57,6 +57,9 @@ class ProjectAssignmentForecastManager:
 
     def __init__(self, project: KippoProject) -> None:
         self.project = project
+        self.__logged_hours_cache: int | None = None
+        self.__latest_logged_week_start_cache: datetime.date | None = None
+        self.__latest_logged_week_start_loaded: bool = False
 
     def compute(self, overlay: dict[int, dict[datetime.date, int]] | None = None) -> ForecastResult:
         """Return the forecast payload.
@@ -130,11 +133,21 @@ class ProjectAssignmentForecastManager:
         )
 
     def __logged_hours_through(self, today: datetime.date) -> int:
-        return ProjectWeeklyEffort.objects.filter(project=self.project, week_start__lte=today).aggregate(total=Sum("hours"))["total"] or 0
+        # Cached per manager instance — the suggester reuses one manager across many compute()
+        # calls (one per candidate pattern + thin-pattern retries), and the logged-hours total
+        # doesn't depend on the overlay being evaluated.
+        if self.__logged_hours_cache is None:
+            self.__logged_hours_cache = (
+                ProjectWeeklyEffort.objects.filter(project=self.project, week_start__lte=today).aggregate(total=Sum("hours"))["total"] or 0
+            )
+        return self.__logged_hours_cache
 
     def __latest_logged_week_start(self, today: datetime.date) -> datetime.date | None:
-        latest = ProjectWeeklyEffort.objects.filter(project=self.project, week_start__lte=today).order_by("-week_start").first()
-        return latest.week_start if latest else None
+        if not self.__latest_logged_week_start_loaded:
+            latest = ProjectWeeklyEffort.objects.filter(project=self.project, week_start__lte=today).order_by("-week_start").first()
+            self.__latest_logged_week_start_cache = latest.week_start if latest else None
+            self.__latest_logged_week_start_loaded = True
+        return self.__latest_logged_week_start_cache
 
     def __load_user_context(
         self,

--- a/kippo/projects/services/suggest.py
+++ b/kippo/projects/services/suggest.py
@@ -1,0 +1,325 @@
+"""Project assignment pattern suggester.
+
+Generates 0–3 candidate `ProjectMonthlyAssignment` patterns for a project, ranked
+by closeness to `project.target_date`. Patterns vary along a continuity gradient
+(P1 max past-member reuse, P2 blend past + org pool, P3 most-available pool). See
+monkut/kippo#224 decisions B1–B13 + monkut/kippo#227 clarifications S1–S4.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
+from commons.functions import first_of_next_month
+from django.db.models import Sum
+from django.utils import timezone
+
+from projects.definitions import Pattern, PatternConflict, PatternMember
+from projects.exceptions import ProjectStartDateRequiredError
+from projects.models import ProjectMonthlyAssignment, ProjectWeeklyEffort
+from projects.services.forecast import ProjectAssignmentForecastManager
+
+if TYPE_CHECKING:
+    from projects.models import KippoProject
+
+logger = logging.getLogger(__name__)
+
+ALLOCATION_FLOOR_PERCENTAGE = 10  # B5
+SOFT_CAP_TEAM_SIZE = 3  # B6
+MAX_INDIVIDUAL_PERCENTAGE = 100
+THIN_PATTERN_PUSH_PERCENTAGE = 100  # B11 — push to 100% per user-month when capacity insufficient
+HORIZON_MONTHS_NO_TARGET = 24  # walk this many months when project.target_date is null
+HORIZON_MONTHS_PAST_TARGET = 6  # walk this many months past target for the infeasible-flag path
+
+PATTERN_LABELS = {
+    "P1-max-reuse": "Maximum past-member reuse",
+    "P2-blend": "Blend of past members and org pool",
+    "P3-most-available": "Most-available org pool members",
+}
+
+
+def _add_months(reference: datetime.date, months: int) -> datetime.date:
+    total_months = reference.year * 12 + (reference.month - 1) + months
+    year, month = divmod(total_months, 12)
+    return datetime.date(year, month + 1, 1)
+
+
+class ProjectAssignmentSuggestionManager:
+    """Generate ranked assignment patterns for a project.
+
+    Construct with a project (and optional `from_month`), call `compute()` to get
+    the list of candidate patterns. Returns 0–3 `Pattern` objects after pattern
+    generation, dedup (S3), and ranking (B10).
+
+    See monkut/kippo#224 B1–B13 and monkut/kippo#227 clarifications S1–S4.
+    """
+
+    def __init__(self, project: KippoProject, from_month: datetime.date | None = None) -> None:
+        self.project = project
+        self.from_month = from_month
+
+    def compute(self) -> list[Pattern]:
+        project = self.project
+        if project.start_date is None:
+            raise ProjectStartDateRequiredError(f"project {project.pk} has no start_date")
+
+        from_month = self.from_month or first_of_next_month(timezone.localdate())
+        organization = project.organization
+
+        past_members = self.__past_members()
+        org_pool = self.__org_pool()
+        capacity = self.__capacity_lookup(organization, from_month)
+        all_time_hours = self.__all_time_logged_hours_per_user()
+
+        patterns: list[Pattern] = []
+        for pattern_id, team in self.__candidate_teams(past_members, org_pool, capacity, all_time_hours):
+            if pattern_id == "P1-max-reuse" and not past_members:
+                # S2: greenfield project — skip P1 entirely
+                continue
+            pattern = self.__build_pattern(
+                pattern_id=pattern_id,
+                team=team,
+                past_members=past_members,
+                from_month=from_month,
+                capacity=capacity,
+            )
+            patterns.append(pattern)
+
+        patterns = self.__deduplicate(patterns)
+        return self.__rank(patterns)
+
+    # ------------------------------------------------------------------ inputs
+
+    def __past_members(self) -> set[int]:
+        """B2: past members = users with any prior assignment OR effort row on this project."""
+        from_assignments = set(ProjectMonthlyAssignment.objects.filter(project=self.project).values_list("user_id", flat=True))
+        from_effort = set(ProjectWeeklyEffort.objects.filter(project=self.project, hours__gt=0).values_list("user_id", flat=True))
+        return from_assignments | from_effort
+
+    def __org_pool(self) -> list[KippoUser]:
+        """S1: all active org members (KippoUser.is_active=True with active OrganizationMembership)."""
+        membership_user_ids = OrganizationMembership.objects.filter(organization=self.project.organization).values_list("user_id", flat=True)
+        return list(KippoUser.objects.filter(id__in=membership_user_ids, is_active=True).order_by("id"))
+
+    def __capacity_lookup(self, organization: KippoOrganization, from_month: datetime.date) -> dict[int, dict[datetime.date, int]]:
+        """B4: existing percentage commitment per user/month across all projects in the organization.
+
+        Returns `{user_id: {month: existing_total_pct}}`. New pattern percentages will be added on
+        top of these values; over-allocation (>100) becomes a `PatternConflict`.
+        """
+        rows = (
+            ProjectMonthlyAssignment.objects.filter(project__organization=organization, month__gte=from_month)
+            .values("user_id", "month")
+            .annotate(total=Sum("percentage"))
+        )
+        existing: dict[int, dict[datetime.date, int]] = defaultdict(dict)
+        for row in rows:
+            existing[row["user_id"]][row["month"]] = row["total"] or 0
+        return existing
+
+    def __all_time_logged_hours_per_user(self) -> dict[int, int]:
+        """B9 tie-breaker primary key: total all-time `ProjectWeeklyEffort.hours` on this project."""
+        rows = ProjectWeeklyEffort.objects.filter(project=self.project, hours__gt=0).values("user_id").annotate(total=Sum("hours"))
+        return {row["user_id"]: row["total"] or 0 for row in rows}
+
+    def __candidate_teams(
+        self,
+        past_members: set[int],
+        org_pool: list[KippoUser],
+        capacity: dict[int, dict[datetime.date, int]],
+        all_time_hours: dict[int, int],
+    ) -> list[tuple[str, list[KippoUser]]]:
+        """Build the (pattern_id, team) pairs for P1 / P2 / P3.
+
+        Team selection per B3 / B7 / B8 + tie-breaker B9 (descending all-time hours,
+        then descending current available capacity). Soft cap of 3 (B6) applied to all.
+        """
+
+        def current_available(user_id: int) -> int:
+            user_existing = capacity.get(user_id, {})
+            if not user_existing:
+                return MAX_INDIVIDUAL_PERCENTAGE
+            return MAX_INDIVIDUAL_PERCENTAGE - max(user_existing.values())
+
+        def sort_key(user: KippoUser) -> tuple[int, int]:
+            return (-all_time_hours.get(user.id, 0), -current_available(user.id))
+
+        past_pool = [u for u in org_pool if u.id in past_members]
+        past_pool.sort(key=sort_key)
+
+        # P1: past members only (B3)
+        p1 = past_pool[:SOFT_CAP_TEAM_SIZE]
+
+        # P2: past members + org top-up by capacity (B7)
+        non_past = [u for u in org_pool if u.id not in past_members]
+        non_past.sort(key=lambda u: (-current_available(u.id), u.id))
+        p2 = past_pool[:SOFT_CAP_TEAM_SIZE]
+        for candidate in non_past:
+            if len(p2) >= SOFT_CAP_TEAM_SIZE:
+                break
+            p2.append(candidate)
+
+        # P3: full org pool ranked by capacity, no past-member preference (B8)
+        org_sorted = sorted(org_pool, key=lambda u: (-current_available(u.id), u.id))
+        p3 = org_sorted[:SOFT_CAP_TEAM_SIZE]
+
+        return [("P1-max-reuse", p1), ("P2-blend", p2), ("P3-most-available", p3)]
+
+    # --------------------------------------------------------------- pattern build
+
+    def __build_pattern(
+        self,
+        *,
+        pattern_id: str,
+        team: list[KippoUser],
+        past_members: set[int],
+        from_month: datetime.date,
+        capacity: dict[int, dict[datetime.date, int]],
+    ) -> Pattern:
+        if not team:
+            return Pattern(
+                pattern_ids=[pattern_id],
+                label=PATTERN_LABELS[pattern_id],
+                estimated_completion=None,
+                infeasible=True,
+                conflicts=[],
+                members=[],
+            )
+
+        team_size = len(team)
+        baseline_pct = max(ALLOCATION_FLOOR_PERCENTAGE, MAX_INDIVIDUAL_PERCENTAGE // team_size)
+        target_date = self.project.target_date
+        end_month = self.__horizon_end(from_month, target_date)
+
+        # Pass 1: baseline distribution (per-member equal share).
+        overlay, conflicts = self.__compose_overlay(team, baseline_pct, from_month, end_month, capacity)
+        forecast = ProjectAssignmentForecastManager(self.project).compute(overlay=overlay)
+        estimated = forecast.estimated_completion_date
+
+        # B11: if the baseline distribution can't meet target_date (or didn't complete at all),
+        # push every member to 100% per user-month and re-evaluate. Mark infeasible if still not.
+        infeasible = self.__is_infeasible(estimated, target_date)
+        if infeasible:
+            overlay, conflicts = self.__compose_overlay(team, THIN_PATTERN_PUSH_PERCENTAGE, from_month, end_month, capacity)
+            forecast = ProjectAssignmentForecastManager(self.project).compute(overlay=overlay)
+            estimated = forecast.estimated_completion_date
+            infeasible = self.__is_infeasible(estimated, target_date)
+
+        members = [
+            PatternMember(
+                user_id=user.id,
+                is_past_member=user.id in past_members,
+                monthly_percentages=overlay.get(user.id, {}),
+            )
+            for user in team
+        ]
+        return Pattern(
+            pattern_ids=[pattern_id],
+            label=PATTERN_LABELS[pattern_id],
+            estimated_completion=estimated,
+            infeasible=infeasible,
+            conflicts=conflicts,
+            members=members,
+        )
+
+    def __horizon_end(self, from_month: datetime.date, target_date: datetime.date | None) -> datetime.date:
+        if target_date is None:
+            return _add_months(from_month, HORIZON_MONTHS_NO_TARGET)
+        target_first_of_month = target_date.replace(day=1)
+        return _add_months(target_first_of_month, HORIZON_MONTHS_PAST_TARGET)
+
+    def __compose_overlay(
+        self,
+        team: list[KippoUser],
+        per_member_pct: int,
+        from_month: datetime.date,
+        end_month: datetime.date,
+        capacity: dict[int, dict[datetime.date, int]],
+    ) -> tuple[dict[int, dict[datetime.date, int]], list[PatternConflict]]:
+        """Build the user-month overlay and collect over-allocation conflicts.
+
+        Pattern percentage is fixed at `per_member_pct`. A `PatternConflict` is recorded for any
+        (user, month) where adding the proposed pattern would push the user's org-total beyond
+        `MAX_INDIVIDUAL_PERCENTAGE`. The pattern still proposes the requested percentage —
+        per kippo#224 D3 the suggester surfaces the conflict rather than silently capping.
+        """
+        overlay: dict[int, dict[datetime.date, int]] = {}
+        conflicts: list[PatternConflict] = []
+
+        current_month = from_month
+        while current_month <= end_month:
+            for user in team:
+                overlay.setdefault(user.id, {})[current_month] = per_member_pct
+                existing = capacity.get(user.id, {}).get(current_month, 0)
+                if existing + per_member_pct > MAX_INDIVIDUAL_PERCENTAGE:
+                    conflicts.append(
+                        PatternConflict(
+                            user_id=user.id,
+                            month=current_month,
+                            reason=f"already {existing}% on other projects (proposed +{per_member_pct}% would total {existing + per_member_pct}%)",
+                        )
+                    )
+            current_month = _add_months(current_month, 1)
+
+        return overlay, conflicts
+
+    @staticmethod
+    def __is_infeasible(estimated: datetime.date | None, target_date: datetime.date | None) -> bool:
+        if estimated is None:
+            return True
+        if target_date is None:
+            return False
+        return estimated > target_date
+
+    # ----------------------------------------------------------------- post-pass
+
+    @staticmethod
+    def __deduplicate(patterns: list[Pattern]) -> list[Pattern]:
+        """S3: collapse Patterns with identical members + monthly_percentages into one.
+
+        Merged pattern's `pattern_ids` lists every strategy that converged. The earliest
+        (P1, P2, P3) determines the survivor's primary label.
+        """
+        if not patterns:
+            return []
+
+        canonical: list[Pattern] = []
+        for pattern in patterns:
+            duplicate_of = None
+            for existing in canonical:
+                if _patterns_equivalent(existing, pattern):
+                    duplicate_of = existing
+                    break
+            if duplicate_of:
+                duplicate_of.pattern_ids.extend(pattern.pattern_ids)
+                duplicate_of.label = " / ".join(PATTERN_LABELS[pid] for pid in duplicate_of.pattern_ids)
+            else:
+                canonical.append(pattern)
+        return canonical
+
+    @staticmethod
+    def __rank(patterns: list[Pattern]) -> list[Pattern]:
+        """B10: feasible first; among feasible with target_date, prefer closest to target_date."""
+
+        def sort_key(pattern: Pattern) -> tuple[int, int]:
+            # 0 = feasible, 1 = infeasible (for stable sort; feasible first)
+            feasibility = 1 if pattern.infeasible else 0
+            distance = 10**9
+            if pattern.estimated_completion is not None and not pattern.infeasible:
+                distance = pattern.estimated_completion.toordinal()
+            return (feasibility, -distance)
+
+        return sorted(patterns, key=sort_key)
+
+
+def _patterns_equivalent(a: Pattern, b: Pattern) -> bool:
+    """Two patterns are equivalent when their member set + monthly_percentages match."""
+    if len(a.members) != len(b.members):
+        return False
+    a_map = {m.user_id: m.monthly_percentages for m in a.members}
+    b_map = {m.user_id: m.monthly_percentages for m in b.members}
+    return a_map == b_map

--- a/kippo/projects/services/suggest.py
+++ b/kippo/projects/services/suggest.py
@@ -20,7 +20,7 @@ from dateutil.relativedelta import relativedelta
 from django.db.models import Sum
 from django.utils import timezone
 
-from projects.definitions import Pattern, PatternConflict, PatternMember
+from projects.definitions import ProjectAssignmentPattern, ProjectAssignmentPatternConflict, ProjectAssignmentPatternMember
 from projects.exceptions import ProjectStartDateRequiredError
 from projects.models import ProjectMonthlyAssignment, ProjectWeeklyEffort
 from projects.services.forecast import ProjectAssignmentForecastManager
@@ -118,7 +118,7 @@ class ProjectAssignmentSuggestionManager:
     """Generate ranked assignment patterns for a project.
 
     Construct with a project (and optional `from_month`), call `compute()` to get
-    the list of candidate patterns. Returns 0–3 `Pattern` objects after pattern
+    the list of candidate patterns. Returns 0–3 `ProjectAssignmentPattern` objects after pattern
     generation, dedup (S3), and ranking (B10).
 
     See monkut/kippo#224 B1–B13 and monkut/kippo#227 clarifications S1–S4.
@@ -131,7 +131,7 @@ class ProjectAssignmentSuggestionManager:
         # repeated logged-hours / latest-week-start lookups.
         self._forecaster = ProjectAssignmentForecastManager(project)
 
-    def compute(self) -> list[Pattern]:
+    def compute(self) -> list[ProjectAssignmentPattern]:
         if self.project.start_date is None:
             raise ProjectStartDateRequiredError(f"project {self.project.pk} has no start_date")
 
@@ -144,7 +144,7 @@ class ProjectAssignmentSuggestionManager:
             all_time_hours=self.__all_time_logged_hours_per_user(),
         )
 
-        patterns: list[Pattern] = []
+        patterns: list[ProjectAssignmentPattern] = []
         for strategy in _STRATEGIES:
             team = strategy.select(inputs)
             if not team:
@@ -171,7 +171,7 @@ class ProjectAssignmentSuggestionManager:
         """B4: existing percentage commitment per user/month across all projects in the organization.
 
         Returns `{user_id: {month: existing_total_pct}}`. New pattern percentages will be added on
-        top of these values; over-allocation (>100) becomes a `PatternConflict`.
+        top of these values; over-allocation (>100) becomes a `ProjectAssignmentPatternConflict`.
         """
         rows = (
             ProjectMonthlyAssignment.objects.filter(project__organization=organization, month__gte=from_month)
@@ -196,7 +196,7 @@ class ProjectAssignmentSuggestionManager:
         team: list[KippoUser],
         inputs: _SelectionInputs,
         from_month: datetime.date,
-    ) -> Pattern:
+    ) -> ProjectAssignmentPattern:
         target_date = self.project.target_date
         if target_date is None:
             end_month = from_month + relativedelta(months=HORIZON_MONTHS_NO_TARGET)
@@ -213,14 +213,14 @@ class ProjectAssignmentSuggestionManager:
             )
 
         members = [
-            PatternMember(
+            ProjectAssignmentPatternMember(
                 user_id=user.id,
                 is_past_member=user.id in inputs.past_members,
                 monthly_percentages=overlay.get(user.id, {}),
             )
             for user in team
         ]
-        return Pattern(
+        return ProjectAssignmentPattern(
             pattern_ids=[pattern_id.value],
             label=PATTERN_LABELS[pattern_id],
             estimated_completion=estimated,
@@ -237,7 +237,7 @@ class ProjectAssignmentSuggestionManager:
         end_month: datetime.date,
         capacity: dict,
         target_date: datetime.date | None,
-    ) -> tuple[dict, list[PatternConflict], datetime.date | None, bool]:
+    ) -> tuple[dict, list[ProjectAssignmentPatternConflict], datetime.date | None, bool]:
         """Build the overlay at `per_member_pct`, run the forecast, return (overlay, conflicts, estimated, infeasible)."""
         overlay, conflicts = self.__compose_overlay(team, per_member_pct, from_month, end_month, capacity)
         estimated = self._forecaster.compute(overlay=overlay).estimated_completion_date
@@ -251,16 +251,16 @@ class ProjectAssignmentSuggestionManager:
         from_month: datetime.date,
         end_month: datetime.date,
         capacity: dict,
-    ) -> tuple[dict, list[PatternConflict]]:
+    ) -> tuple[dict, list[ProjectAssignmentPatternConflict]]:
         """Build the user-month overlay and collect over-allocation conflicts.
 
-        Pattern percentage is fixed at `per_member_pct`. A `PatternConflict` is recorded for any
+        Pattern percentage is fixed at `per_member_pct`. A `ProjectAssignmentPatternConflict` is recorded for any
         (user, month) where adding the proposed pattern would push the user's org-total beyond
         `MAX_INDIVIDUAL_PERCENTAGE`. The pattern still proposes the requested percentage —
         per kippo#224 D3 the suggester surfaces the conflict rather than silently capping.
         """
         overlay: dict = {}
-        conflicts: list[PatternConflict] = []
+        conflicts: list[ProjectAssignmentPatternConflict] = []
 
         current_month = from_month
         while current_month <= end_month:
@@ -269,7 +269,7 @@ class ProjectAssignmentSuggestionManager:
                 existing = capacity.get(user.id, {}).get(current_month, 0)
                 if existing + per_member_pct > MAX_INDIVIDUAL_PERCENTAGE:
                     conflicts.append(
-                        PatternConflict(
+                        ProjectAssignmentPatternConflict(
                             user_id=user.id,
                             month=current_month,
                             reason=f"already {existing}% on other projects (proposed +{per_member_pct}% would total {existing + per_member_pct}%)",
@@ -282,13 +282,13 @@ class ProjectAssignmentSuggestionManager:
     # ----------------------------------------------------------------- post-pass
 
     @staticmethod
-    def __deduplicate(patterns: list[Pattern]) -> list[Pattern]:
+    def __deduplicate(patterns: list[ProjectAssignmentPattern]) -> list[ProjectAssignmentPattern]:
         """S3: collapse Patterns with identical members + monthly_percentages into one.
 
         Merged pattern's `pattern_ids` lists every strategy that converged. The earliest
         (P1, P2, P3) determines the survivor's primary label.
         """
-        canonical: list[Pattern] = []
+        canonical: list[ProjectAssignmentPattern] = []
         for pattern in patterns:
             duplicate_of = next((p for p in canonical if _patterns_equivalent(p, pattern)), None)
             if duplicate_of is None:
@@ -299,7 +299,7 @@ class ProjectAssignmentSuggestionManager:
         return canonical
 
     @staticmethod
-    def __rank(patterns: list[Pattern]) -> list[Pattern]:
+    def __rank(patterns: list[ProjectAssignmentPattern]) -> list[ProjectAssignmentPattern]:
         """B10: feasible first; among feasible with target_date, prefer closest to target_date."""
         return sorted(
             patterns,
@@ -310,7 +310,7 @@ class ProjectAssignmentSuggestionManager:
         )
 
 
-def _patterns_equivalent(a: Pattern, b: Pattern) -> bool:
+def _patterns_equivalent(a: ProjectAssignmentPattern, b: ProjectAssignmentPattern) -> bool:
     """Two patterns are equivalent when their member set + monthly_percentages match."""
     if len(a.members) != len(b.members):
         return False

--- a/kippo/projects/services/suggest.py
+++ b/kippo/projects/services/suggest.py
@@ -9,12 +9,14 @@ monkut/kippo#224 decisions B1–B13 + monkut/kippo#227 clarifications S1–S4.
 from __future__ import annotations
 
 import datetime
-import logging
 from collections import defaultdict
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
 from commons.functions import first_of_next_month
+from dateutil.relativedelta import relativedelta
 from django.db.models import Sum
 from django.utils import timezone
 
@@ -24,28 +26,92 @@ from projects.models import ProjectMonthlyAssignment, ProjectWeeklyEffort
 from projects.services.forecast import ProjectAssignmentForecastManager
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from projects.models import KippoProject
 
-logger = logging.getLogger(__name__)
 
 ALLOCATION_FLOOR_PERCENTAGE = 10  # B5
 SOFT_CAP_TEAM_SIZE = 3  # B6
 MAX_INDIVIDUAL_PERCENTAGE = 100
-THIN_PATTERN_PUSH_PERCENTAGE = 100  # B11 — push to 100% per user-month when capacity insufficient
+THIN_PATTERN_PUSH_PERCENTAGE = MAX_INDIVIDUAL_PERCENTAGE  # B11 — push to the cap when capacity is insufficient
 HORIZON_MONTHS_NO_TARGET = 24  # walk this many months when project.target_date is null
 HORIZON_MONTHS_PAST_TARGET = 6  # walk this many months past target for the infeasible-flag path
 
-PATTERN_LABELS = {
-    "P1-max-reuse": "Maximum past-member reuse",
-    "P2-blend": "Blend of past members and org pool",
-    "P3-most-available": "Most-available org pool members",
+
+class PatternId(StrEnum):
+    P1_MAX_REUSE = "P1-max-reuse"
+    P2_BLEND = "P2-blend"
+    P3_MOST_AVAILABLE = "P3-most-available"
+
+
+PATTERN_LABELS: dict[PatternId, str] = {
+    PatternId.P1_MAX_REUSE: "Maximum past-member reuse",
+    PatternId.P2_BLEND: "Blend of past members and org pool",
+    PatternId.P3_MOST_AVAILABLE: "Most-available org pool members",
 }
 
 
-def _add_months(reference: datetime.date, months: int) -> datetime.date:
-    total_months = reference.year * 12 + (reference.month - 1) + months
-    year, month = divmod(total_months, 12)
-    return datetime.date(year, month + 1, 1)
+@dataclass(frozen=True)
+class _PatternStrategy:
+    """A pattern_id paired with the team-selection rule that produces it."""
+
+    pattern_id: PatternId
+    select: Callable[[_SelectionInputs], list[KippoUser]]
+
+
+@dataclass
+class _SelectionInputs:
+    """Inputs available to every team-selection strategy."""
+
+    org_pool: list[KippoUser]
+    past_members: set
+    capacity: dict
+    all_time_hours: dict[int, int]
+
+
+def _by_capacity_then_id(user: KippoUser, capacity: dict) -> tuple[int, int]:
+    user_existing = capacity.get(user.id, {})
+    available = MAX_INDIVIDUAL_PERCENTAGE if not user_existing else MAX_INDIVIDUAL_PERCENTAGE - max(user_existing.values())
+    return (-available, str(user.id).__hash__())
+
+
+def _select_p1_past_only(inputs: _SelectionInputs) -> list[KippoUser]:
+    if not inputs.past_members:
+        return []  # S2: greenfield project — empty selection skips this strategy
+    past_pool = sorted(
+        (u for u in inputs.org_pool if u.id in inputs.past_members),
+        key=lambda u: (-inputs.all_time_hours.get(u.id, 0), _by_capacity_then_id(u, inputs.capacity)),
+    )
+    return past_pool[:SOFT_CAP_TEAM_SIZE]
+
+
+def _select_p2_blend(inputs: _SelectionInputs) -> list[KippoUser]:
+    past_pool = sorted(
+        (u for u in inputs.org_pool if u.id in inputs.past_members),
+        key=lambda u: (-inputs.all_time_hours.get(u.id, 0), _by_capacity_then_id(u, inputs.capacity)),
+    )
+    team = past_pool[:SOFT_CAP_TEAM_SIZE]
+    non_past = sorted(
+        (u for u in inputs.org_pool if u.id not in inputs.past_members),
+        key=lambda u: _by_capacity_then_id(u, inputs.capacity),
+    )
+    for candidate in non_past:
+        if len(team) >= SOFT_CAP_TEAM_SIZE:
+            break
+        team.append(candidate)
+    return team
+
+
+def _select_p3_most_available(inputs: _SelectionInputs) -> list[KippoUser]:
+    return sorted(inputs.org_pool, key=lambda u: _by_capacity_then_id(u, inputs.capacity))[:SOFT_CAP_TEAM_SIZE]
+
+
+_STRATEGIES: tuple[_PatternStrategy, ...] = (
+    _PatternStrategy(PatternId.P1_MAX_REUSE, _select_p1_past_only),
+    _PatternStrategy(PatternId.P2_BLEND, _select_p2_blend),
+    _PatternStrategy(PatternId.P3_MOST_AVAILABLE, _select_p3_most_available),
+)
 
 
 class ProjectAssignmentSuggestionManager:
@@ -61,40 +127,36 @@ class ProjectAssignmentSuggestionManager:
     def __init__(self, project: KippoProject, from_month: datetime.date | None = None) -> None:
         self.project = project
         self.from_month = from_month
+        # Reused across all per-pattern forecast invocations so the manager can memoize
+        # repeated logged-hours / latest-week-start lookups.
+        self._forecaster = ProjectAssignmentForecastManager(project)
 
     def compute(self) -> list[Pattern]:
-        project = self.project
-        if project.start_date is None:
-            raise ProjectStartDateRequiredError(f"project {project.pk} has no start_date")
+        if self.project.start_date is None:
+            raise ProjectStartDateRequiredError(f"project {self.project.pk} has no start_date")
 
         from_month = self.from_month or first_of_next_month(timezone.localdate())
-        organization = project.organization
 
-        past_members = self.__past_members()
-        org_pool = self.__org_pool()
-        capacity = self.__capacity_lookup(organization, from_month)
-        all_time_hours = self.__all_time_logged_hours_per_user()
+        inputs = _SelectionInputs(
+            org_pool=self.__org_pool(),
+            past_members=self.__past_members(),
+            capacity=self.__capacity_lookup(self.project.organization, from_month),
+            all_time_hours=self.__all_time_logged_hours_per_user(),
+        )
 
         patterns: list[Pattern] = []
-        for pattern_id, team in self.__candidate_teams(past_members, org_pool, capacity, all_time_hours):
-            if pattern_id == "P1-max-reuse" and not past_members:
-                # S2: greenfield project — skip P1 entirely
+        for strategy in _STRATEGIES:
+            team = strategy.select(inputs)
+            if not team:
+                # S2 (or any future strategy returning an empty team) — skip entirely.
                 continue
-            pattern = self.__build_pattern(
-                pattern_id=pattern_id,
-                team=team,
-                past_members=past_members,
-                from_month=from_month,
-                capacity=capacity,
-            )
-            patterns.append(pattern)
+            patterns.append(self.__build_pattern(strategy.pattern_id, team, inputs, from_month))
 
-        patterns = self.__deduplicate(patterns)
-        return self.__rank(patterns)
+        return self.__rank(self.__deduplicate(patterns))
 
     # ------------------------------------------------------------------ inputs
 
-    def __past_members(self) -> set[int]:
+    def __past_members(self) -> set:
         """B2: past members = users with any prior assignment OR effort row on this project."""
         from_assignments = set(ProjectMonthlyAssignment.objects.filter(project=self.project).values_list("user_id", flat=True))
         from_effort = set(ProjectWeeklyEffort.objects.filter(project=self.project, hours__gt=0).values_list("user_id", flat=True))
@@ -105,7 +167,7 @@ class ProjectAssignmentSuggestionManager:
         membership_user_ids = OrganizationMembership.objects.filter(organization=self.project.organization).values_list("user_id", flat=True)
         return list(KippoUser.objects.filter(id__in=membership_user_ids, is_active=True).order_by("id"))
 
-    def __capacity_lookup(self, organization: KippoOrganization, from_month: datetime.date) -> dict[int, dict[datetime.date, int]]:
+    def __capacity_lookup(self, organization: KippoOrganization, from_month: datetime.date) -> dict:
         """B4: existing percentage commitment per user/month across all projects in the organization.
 
         Returns `{user_id: {month: existing_total_pct}}`. New pattern percentages will be added on
@@ -116,7 +178,7 @@ class ProjectAssignmentSuggestionManager:
             .values("user_id", "month")
             .annotate(total=Sum("percentage"))
         )
-        existing: dict[int, dict[datetime.date, int]] = defaultdict(dict)
+        existing: dict = defaultdict(dict)
         for row in rows:
             existing[row["user_id"]][row["month"]] = row["total"] or 0
         return existing
@@ -126,99 +188,40 @@ class ProjectAssignmentSuggestionManager:
         rows = ProjectWeeklyEffort.objects.filter(project=self.project, hours__gt=0).values("user_id").annotate(total=Sum("hours"))
         return {row["user_id"]: row["total"] or 0 for row in rows}
 
-    def __candidate_teams(
-        self,
-        past_members: set[int],
-        org_pool: list[KippoUser],
-        capacity: dict[int, dict[datetime.date, int]],
-        all_time_hours: dict[int, int],
-    ) -> list[tuple[str, list[KippoUser]]]:
-        """Build the (pattern_id, team) pairs for P1 / P2 / P3.
-
-        Team selection per B3 / B7 / B8 + tie-breaker B9 (descending all-time hours,
-        then descending current available capacity). Soft cap of 3 (B6) applied to all.
-        """
-
-        def current_available(user_id: int) -> int:
-            user_existing = capacity.get(user_id, {})
-            if not user_existing:
-                return MAX_INDIVIDUAL_PERCENTAGE
-            return MAX_INDIVIDUAL_PERCENTAGE - max(user_existing.values())
-
-        def sort_key(user: KippoUser) -> tuple[int, int]:
-            return (-all_time_hours.get(user.id, 0), -current_available(user.id))
-
-        past_pool = [u for u in org_pool if u.id in past_members]
-        past_pool.sort(key=sort_key)
-
-        # P1: past members only (B3)
-        p1 = past_pool[:SOFT_CAP_TEAM_SIZE]
-
-        # P2: past members + org top-up by capacity (B7)
-        non_past = [u for u in org_pool if u.id not in past_members]
-        non_past.sort(key=lambda u: (-current_available(u.id), u.id))
-        p2 = past_pool[:SOFT_CAP_TEAM_SIZE]
-        for candidate in non_past:
-            if len(p2) >= SOFT_CAP_TEAM_SIZE:
-                break
-            p2.append(candidate)
-
-        # P3: full org pool ranked by capacity, no past-member preference (B8)
-        org_sorted = sorted(org_pool, key=lambda u: (-current_available(u.id), u.id))
-        p3 = org_sorted[:SOFT_CAP_TEAM_SIZE]
-
-        return [("P1-max-reuse", p1), ("P2-blend", p2), ("P3-most-available", p3)]
-
     # --------------------------------------------------------------- pattern build
 
     def __build_pattern(
         self,
-        *,
-        pattern_id: str,
+        pattern_id: PatternId,
         team: list[KippoUser],
-        past_members: set[int],
+        inputs: _SelectionInputs,
         from_month: datetime.date,
-        capacity: dict[int, dict[datetime.date, int]],
     ) -> Pattern:
-        if not team:
-            return Pattern(
-                pattern_ids=[pattern_id],
-                label=PATTERN_LABELS[pattern_id],
-                estimated_completion=None,
-                infeasible=True,
-                conflicts=[],
-                members=[],
-            )
-
-        team_size = len(team)
-        baseline_pct = max(ALLOCATION_FLOOR_PERCENTAGE, MAX_INDIVIDUAL_PERCENTAGE // team_size)
         target_date = self.project.target_date
-        end_month = self.__horizon_end(from_month, target_date)
+        if target_date is None:
+            end_month = from_month + relativedelta(months=HORIZON_MONTHS_NO_TARGET)
+        else:
+            end_month = target_date.replace(day=1) + relativedelta(months=HORIZON_MONTHS_PAST_TARGET)
 
-        # Pass 1: baseline distribution (per-member equal share).
-        overlay, conflicts = self.__compose_overlay(team, baseline_pct, from_month, end_month, capacity)
-        forecast = ProjectAssignmentForecastManager(self.project).compute(overlay=overlay)
-        estimated = forecast.estimated_completion_date
+        baseline_pct = max(ALLOCATION_FLOOR_PERCENTAGE, MAX_INDIVIDUAL_PERCENTAGE // len(team))
+        overlay, conflicts, estimated, infeasible = self.__evaluate_overlay(team, baseline_pct, from_month, end_month, inputs.capacity, target_date)
 
-        # B11: if the baseline distribution can't meet target_date (or didn't complete at all),
-        # push every member to 100% per user-month and re-evaluate. Mark infeasible if still not.
-        infeasible = self.__is_infeasible(estimated, target_date)
+        # B11: thin-pattern fallback — push every member to the cap if the baseline can't meet target_date.
         if infeasible:
-            overlay, conflicts = self.__compose_overlay(team, THIN_PATTERN_PUSH_PERCENTAGE, from_month, end_month, capacity)
-            forecast = ProjectAssignmentForecastManager(self.project).compute(overlay=overlay)
-            estimated = forecast.estimated_completion_date
-            infeasible = self.__is_infeasible(estimated, target_date)
+            overlay, conflicts, estimated, infeasible = self.__evaluate_overlay(
+                team, THIN_PATTERN_PUSH_PERCENTAGE, from_month, end_month, inputs.capacity, target_date
+            )
 
         members = [
             PatternMember(
                 user_id=user.id,
-                is_past_member=user.id in past_members,
+                is_past_member=user.id in inputs.past_members,
                 monthly_percentages=overlay.get(user.id, {}),
             )
             for user in team
         ]
         return Pattern(
-            pattern_ids=[pattern_id],
+            pattern_ids=[pattern_id.value],
             label=PATTERN_LABELS[pattern_id],
             estimated_completion=estimated,
             infeasible=infeasible,
@@ -226,11 +229,20 @@ class ProjectAssignmentSuggestionManager:
             members=members,
         )
 
-    def __horizon_end(self, from_month: datetime.date, target_date: datetime.date | None) -> datetime.date:
-        if target_date is None:
-            return _add_months(from_month, HORIZON_MONTHS_NO_TARGET)
-        target_first_of_month = target_date.replace(day=1)
-        return _add_months(target_first_of_month, HORIZON_MONTHS_PAST_TARGET)
+    def __evaluate_overlay(
+        self,
+        team: list[KippoUser],
+        per_member_pct: int,
+        from_month: datetime.date,
+        end_month: datetime.date,
+        capacity: dict,
+        target_date: datetime.date | None,
+    ) -> tuple[dict, list[PatternConflict], datetime.date | None, bool]:
+        """Build the overlay at `per_member_pct`, run the forecast, return (overlay, conflicts, estimated, infeasible)."""
+        overlay, conflicts = self.__compose_overlay(team, per_member_pct, from_month, end_month, capacity)
+        estimated = self._forecaster.compute(overlay=overlay).estimated_completion_date
+        infeasible = estimated is None or (target_date is not None and estimated > target_date)
+        return overlay, conflicts, estimated, infeasible
 
     def __compose_overlay(
         self,
@@ -238,8 +250,8 @@ class ProjectAssignmentSuggestionManager:
         per_member_pct: int,
         from_month: datetime.date,
         end_month: datetime.date,
-        capacity: dict[int, dict[datetime.date, int]],
-    ) -> tuple[dict[int, dict[datetime.date, int]], list[PatternConflict]]:
+        capacity: dict,
+    ) -> tuple[dict, list[PatternConflict]]:
         """Build the user-month overlay and collect over-allocation conflicts.
 
         Pattern percentage is fixed at `per_member_pct`. A `PatternConflict` is recorded for any
@@ -247,7 +259,7 @@ class ProjectAssignmentSuggestionManager:
         `MAX_INDIVIDUAL_PERCENTAGE`. The pattern still proposes the requested percentage —
         per kippo#224 D3 the suggester surfaces the conflict rather than silently capping.
         """
-        overlay: dict[int, dict[datetime.date, int]] = {}
+        overlay: dict = {}
         conflicts: list[PatternConflict] = []
 
         current_month = from_month
@@ -263,17 +275,9 @@ class ProjectAssignmentSuggestionManager:
                             reason=f"already {existing}% on other projects (proposed +{per_member_pct}% would total {existing + per_member_pct}%)",
                         )
                     )
-            current_month = _add_months(current_month, 1)
+            current_month = current_month + relativedelta(months=1)
 
         return overlay, conflicts
-
-    @staticmethod
-    def __is_infeasible(estimated: datetime.date | None, target_date: datetime.date | None) -> bool:
-        if estimated is None:
-            return True
-        if target_date is None:
-            return False
-        return estimated > target_date
 
     # ----------------------------------------------------------------- post-pass
 
@@ -284,42 +288,30 @@ class ProjectAssignmentSuggestionManager:
         Merged pattern's `pattern_ids` lists every strategy that converged. The earliest
         (P1, P2, P3) determines the survivor's primary label.
         """
-        if not patterns:
-            return []
-
         canonical: list[Pattern] = []
         for pattern in patterns:
-            duplicate_of = None
-            for existing in canonical:
-                if _patterns_equivalent(existing, pattern):
-                    duplicate_of = existing
-                    break
-            if duplicate_of:
-                duplicate_of.pattern_ids.extend(pattern.pattern_ids)
-                duplicate_of.label = " / ".join(PATTERN_LABELS[pid] for pid in duplicate_of.pattern_ids)
-            else:
+            duplicate_of = next((p for p in canonical if _patterns_equivalent(p, pattern)), None)
+            if duplicate_of is None:
                 canonical.append(pattern)
+                continue
+            duplicate_of.pattern_ids.extend(pattern.pattern_ids)
+            duplicate_of.label = " / ".join(PATTERN_LABELS[PatternId(pid)] for pid in duplicate_of.pattern_ids)
         return canonical
 
     @staticmethod
     def __rank(patterns: list[Pattern]) -> list[Pattern]:
         """B10: feasible first; among feasible with target_date, prefer closest to target_date."""
-
-        def sort_key(pattern: Pattern) -> tuple[int, int]:
-            # 0 = feasible, 1 = infeasible (for stable sort; feasible first)
-            feasibility = 1 if pattern.infeasible else 0
-            distance = 10**9
-            if pattern.estimated_completion is not None and not pattern.infeasible:
-                distance = pattern.estimated_completion.toordinal()
-            return (feasibility, -distance)
-
-        return sorted(patterns, key=sort_key)
+        return sorted(
+            patterns,
+            key=lambda p: (
+                int(p.infeasible),
+                p.estimated_completion or datetime.date.max,
+            ),
+        )
 
 
 def _patterns_equivalent(a: Pattern, b: Pattern) -> bool:
     """Two patterns are equivalent when their member set + monthly_percentages match."""
     if len(a.members) != len(b.members):
         return False
-    a_map = {m.user_id: m.monthly_percentages for m in a.members}
-    b_map = {m.user_id: m.monthly_percentages for m in b.members}
-    return a_map == b_map
+    return {m.user_id: m.monthly_percentages for m in a.members} == {m.user_id: m.monthly_percentages for m in b.members}

--- a/kippo/projects/tests/test_suggest.py
+++ b/kippo/projects/tests/test_suggest.py
@@ -1,0 +1,292 @@
+"""Tests for the project assignment suggestion service + endpoint.
+
+Covers monkut/kippo#227 (Phase 2 of feature #224).
+Decisions: B1–B13, D2; clarifications S1–S4 from kippo#227.
+"""
+
+import datetime
+from http import HTTPStatus
+
+from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
+from commons.functions import first_of_next_month
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from projects.exceptions import ProjectStartDateRequiredError
+from projects.models import KippoProject, ProjectMonthlyAssignment, ProjectWeeklyEffort
+from projects.services.suggest import (
+    ALLOCATION_FLOOR_PERCENTAGE,
+    SOFT_CAP_TEAM_SIZE,
+    ProjectAssignmentSuggestionManager,
+)
+
+
+def _set_today_dependent_dates(project: KippoProject) -> None:
+    today = timezone.localdate()
+    project.start_date = (today - datetime.timedelta(days=180)).replace(day=1)
+    project.target_date = today + datetime.timedelta(days=120)
+    project.allocated_staff_days = 30
+    project.save()
+
+
+class SuggesterTestCaseBase(TestCase):
+    """Shared fixture builder."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.organization.day_workhours = 8
+        self.organization.save()
+        self.user = created["KippoUser"]
+        self.project = created["KippoProject"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+        _set_today_dependent_dates(self.project)
+        self.today = timezone.localdate()
+
+    def _add_member(self, username: str, *, is_developer: bool = True) -> KippoUser:
+        user = KippoUser.objects.create(username=username, email=f"{username}@example.com")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=self.organization,
+            is_developer=is_developer,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        return user
+
+    def _make_assignment(
+        self,
+        *,
+        project: KippoProject | None = None,
+        user: KippoUser | None = None,
+        month: datetime.date,
+        percentage: int,
+        is_confirmed: bool = False,
+    ) -> ProjectMonthlyAssignment:
+        return ProjectMonthlyAssignment.objects.create(
+            project=project or self.project,
+            user=user or self.user,
+            month=month,
+            percentage=percentage,
+            is_confirmed=is_confirmed,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+    def _make_effort(
+        self,
+        *,
+        project: KippoProject | None = None,
+        user: KippoUser | None = None,
+        week_start: datetime.date,
+        hours: int,
+    ) -> ProjectWeeklyEffort:
+        return ProjectWeeklyEffort.objects.create(
+            project=project or self.project,
+            user=user or self.user,
+            week_start=week_start,
+            hours=hours,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+
+class SuggestionServiceCoreTestCase(SuggesterTestCaseBase):
+    """Direct unit tests of ProjectAssignmentSuggestionManager."""
+
+    def test_raises_when_start_date_is_null(self):
+        self.project.start_date = None
+        self.project.save()
+        with self.assertRaises(ProjectStartDateRequiredError):
+            ProjectAssignmentSuggestionManager(self.project).compute()
+
+    def test_greenfield_skips_p1(self):
+        # No past members, but org pool has members → only P2 + P3 returned (S2).
+        self._add_member("dev2")
+        self._add_member("dev3")
+
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        all_pattern_ids = {pid for p in patterns for pid in p.pattern_ids}
+        self.assertNotIn("P1-max-reuse", all_pattern_ids)
+
+    def test_past_member_present_yields_p1(self):
+        # self.user has logged effort → counts as a past member.
+        past_monday = self.today - datetime.timedelta(days=14)
+        past_monday = past_monday - datetime.timedelta(days=past_monday.weekday())
+        self._make_effort(week_start=past_monday, hours=24)
+
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        all_pattern_ids = {pid for p in patterns for pid in p.pattern_ids}
+        self.assertIn("P1-max-reuse", all_pattern_ids)
+
+    def test_inactive_user_excluded_from_org_pool(self):
+        # Active user is in pool; inactive is not (D2 / S1).
+        self._add_member("active-dev")
+        inactive = self._add_member("inactive-dev")
+        inactive.is_active = False
+        inactive.save()
+
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        proposed_user_ids = {m.user_id for p in patterns for m in p.members}
+        self.assertNotIn(inactive.id, proposed_user_ids)
+
+    def test_floor_excludes_no_one_when_team_at_or_below_soft_cap(self):
+        # 3 members → baseline = 100/3 = 33% per member → above 10% floor.
+        for i in range(2):
+            self._add_member(f"dev-{i}")
+        # Make self.user a past member
+        past_monday = self.today - datetime.timedelta(days=21)
+        past_monday = past_monday - datetime.timedelta(days=past_monday.weekday())
+        self._make_effort(week_start=past_monday, hours=8)
+
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        for pattern in patterns:
+            for member in pattern.members:
+                for pct in member.monthly_percentages.values():
+                    self.assertGreaterEqual(pct, ALLOCATION_FLOOR_PERCENTAGE)
+
+    def test_team_size_capped_at_soft_cap(self):
+        # 10 org members → each pattern team should be ≤ SOFT_CAP_TEAM_SIZE.
+        for i in range(10):
+            self._add_member(f"dev-{i:02}")
+
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        for pattern in patterns:
+            self.assertLessEqual(len(pattern.members), SOFT_CAP_TEAM_SIZE)
+
+    def test_capacity_conflict_recorded_when_user_already_committed(self):
+        # User has 80% on another project for the proposed month → conflict.
+        next_month = first_of_next_month(self.today)
+        other_project = KippoProject.objects.create(
+            name="other-project-for-capacity-test",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            start_date=self.project.start_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self._make_assignment(project=other_project, month=next_month, percentage=80, is_confirmed=True)
+
+        # Greenfield on this project so suggester picks self.user as best-available
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        # At least one pattern should flag the conflict for self.user in next_month
+        flagged = any(any(c.user_id == self.user.id and c.month == next_month for c in p.conflicts) for p in patterns)
+        self.assertTrue(flagged, "Expected at least one pattern to flag the over-allocation conflict")
+
+    def test_dedup_collapses_identical_patterns(self):
+        # Single org member, no past contributions → P2 and P3 will pick the same person
+        # at 100%. Patterns merge into one with multiple pattern_ids (S3).
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        # Should have at most 1 pattern (P1 skipped by S2; P2/P3 merge)
+        self.assertEqual(len(patterns), 1)
+        self.assertGreaterEqual(len(patterns[0].pattern_ids), 2)
+
+    def test_pattern_member_marks_past_member_flag(self):
+        # self.user is a past member; new dev2 isn't.
+        past_monday = self.today - datetime.timedelta(days=21)
+        past_monday = past_monday - datetime.timedelta(days=past_monday.weekday())
+        self._make_effort(week_start=past_monday, hours=8)
+        self._add_member("dev2")
+
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        # P1 should mark self.user as past_member
+        p1 = next((p for p in patterns if "P1-max-reuse" in p.pattern_ids), None)
+        if p1 is not None:
+            for member in p1.members:
+                if member.user_id == self.user.id:
+                    self.assertTrue(member.is_past_member)
+
+    def test_target_date_null_does_not_rank_patterns_strictly(self):
+        # No target_date → all returned, no infeasible-flagging based on target.
+        for i in range(2):
+            self._add_member(f"dev-{i}")
+        self.project.target_date = None
+        self.project.save()
+
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        # No patterns should be marked infeasible for "missing target" reason
+        # (they may still be infeasible if forecast doesn't complete, but with 100% allocation it should)
+        self.assertGreater(len(patterns), 0)
+
+    def test_pattern_response_has_expected_keys(self):
+        self._add_member("dev2")
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        self.assertGreater(len(patterns), 0)
+        pattern = patterns[0]
+        # Pydantic model with the spec'd fields
+        self.assertIsInstance(pattern.pattern_ids, list)
+        self.assertGreaterEqual(len(pattern.pattern_ids), 1)
+        self.assertIsInstance(pattern.label, str)
+        self.assertIn(pattern.estimated_completion, [None, *([pattern.estimated_completion])])
+        self.assertIsInstance(pattern.infeasible, bool)
+        self.assertIsInstance(pattern.conflicts, list)
+        self.assertIsInstance(pattern.members, list)
+
+
+class SuggestionEndpointTestCase(SuggesterTestCaseBase):
+    """Test the POST /api/projects/<id>/suggest-assignments/ endpoint."""
+
+    def setUp(self):
+        super().setUp()
+        # Cross-org user for permission test
+        self.other_org = KippoOrganization.objects.create(
+            name="suggest-other-org",
+            github_organization_name="suggestotherorg",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.outsider = KippoUser.objects.create(username="suggest-outsider", email="suggest-outsider@example.com")
+        OrganizationMembership.objects.create(
+            user=self.outsider,
+            organization=self.other_org,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/suggest-assignments/"
+
+    def test_unauthenticated_returns_401(self):
+        anon = APIClient()
+        response = anon.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_returns_patterns_payload(self):
+        self._add_member("dev-x")
+        response = self.client.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        body = response.json()
+        self.assertIn("patterns", body)
+        self.assertIsInstance(body["patterns"], list)
+
+    def test_start_date_null_returns_400(self):
+        self.project.start_date = None
+        self.project.save()
+        response = self.client.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(response.json()["code"], "project_start_date_required")
+
+    def test_invalid_from_month_returns_400(self):
+        response = self.client.post(self.url, {"from_month": "not-a-date"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(response.json()["code"], "invalid_from_month")
+
+    def test_cross_org_user_gets_404(self):
+        cross_client = APIClient()
+        cross_client.force_authenticate(user=self.outsider)
+        response = cross_client.post(self.url, {}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_openapi_schema_exposes_suggest_endpoint(self):
+        from drf_spectacular.generators import SchemaGenerator
+
+        schema = SchemaGenerator().get_schema(request=None, public=True)
+        path = f"{settings.URL_PREFIX}/api/projects/{{id}}/suggest-assignments/"
+        self.assertIn(path, schema["paths"])
+        self.assertIn("post", schema["paths"][path])

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -1,3 +1,4 @@
+import datetime
 from http import HTTPStatus
 from typing import Any
 
@@ -27,6 +28,7 @@ from .serializers import (
     ProjectWeeklyEffortSerializer,
 )
 from .services.forecast import ProjectAssignmentForecastManager
+from .services.suggest import ProjectAssignmentSuggestionManager
 
 
 class KippoProjectViewSet(viewsets.ModelViewSet):
@@ -125,6 +127,48 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
                 status=HTTPStatus.BAD_REQUEST,
             )
         return Response(result.model_dump(mode="json"))
+
+    @extend_schema(
+        request=inline_serializer(
+            name="SuggestAssignmentsRequest",
+            fields={"from_month": serializers.DateField(required=False, allow_null=True)},
+        ),
+        responses={
+            HTTPStatus.OK: inline_serializer(
+                name="SuggestAssignmentsResponse",
+                fields={
+                    "patterns": serializers.ListField(child=serializers.JSONField()),
+                },
+            ),
+            HTTPStatus.BAD_REQUEST: OpenApiResponse(description="project.start_date is required to compute suggestions"),
+        },
+        description=(
+            "Generate up to 3 candidate assignment patterns for the project. Patterns vary "
+            "along a continuity gradient (max past-member reuse / blend / most-available pool). "
+            "Returns 400 if the project has no start_date set. See monkut/kippo#224 B1-B13."
+        ),
+    )
+    @action(detail=True, methods=["post"], url_path="suggest-assignments", permission_classes=[IsAuthenticated])
+    def suggest_assignments(self, request: Request, pk: str | None = None) -> Response:  # noqa: ARG002
+        project = self.get_object()
+        from_month_str = (request.data or {}).get("from_month")
+        from_month = None
+        if from_month_str:
+            try:
+                from_month = datetime.date.fromisoformat(from_month_str).replace(day=1)
+            except ValueError:
+                return Response(
+                    {"detail": f"invalid from_month: {from_month_str!r}", "code": "invalid_from_month"},
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+        try:
+            patterns = ProjectAssignmentSuggestionManager(project, from_month=from_month).compute()
+        except ProjectStartDateRequiredError as exc:
+            return Response(
+                {"detail": str(exc), "code": "project_start_date_required"},
+                status=HTTPStatus.BAD_REQUEST,
+            )
+        return Response({"patterns": [p.model_dump(mode="json") for p in patterns]})
 
 
 class ProjectWeeklyEffortViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Implements Phase 2 of the User Project Assignment feature ([#224](https://github.com/monkut/kippo/issues/224) / [#227](https://github.com/monkut/kippo/issues/227)).
Builds on Phase 1 (#229 merged) and unblocks Phase 3 ([monkut/kippo-ui#57](https://github.com/monkut/kippo-ui/issues/57) pattern picker).

## Net diff
+729 / −13 across 5 files (2 new). 0 migrations. New endpoint surfaces in OpenAPI schema (regenerated automatically by drf-spectacular at runtime).

## Service — `kippo/projects/services/suggest.py` (new)
`ProjectAssignmentSuggestionManager(project, from_month=None).compute() -> list[Pattern]`. Generates 0–3 patterns per kippo#224 B1–B13 + kippo#227 S1–S4.

**Algorithm (per decision IDs):**
- **B2** past members = users with prior `ProjectMonthlyAssignment` OR `ProjectWeeklyEffort.hours > 0` on this project.
- **S1** org pool = all active `KippoUser`s with active `OrganizationMembership` in the project's org (no role filter).
- **B4** capacity = `100 − Σ percentage` from confirmed + unconfirmed assignments per user/month across all projects in the org.
- **B9** tie-breaker: total all-time `ProjectWeeklyEffort.hours` on this project (desc), then current available capacity (desc).
- **B3/B7/B8** team selection: P1 = past members only; P2 = past + top-up from org pool; P3 = full org pool by capacity.
- **B5** 10% allocation floor; **B6** soft cap of 3 members.
- **S2** skip P1 entirely on greenfield projects (no past members).
- **B11** thin-pattern fallback: if baseline (100/team_size) can't meet target_date, retry at 100% per user-month; mark infeasible if still not.
- **D2** `KippoUser.is_active=True` filter on candidate pools.
- **S3** dedup: collapse identical patterns; `pattern_ids` lists every strategy that converged.
- **B10** ranking: feasible first; among feasible, prefer pattern whose estimated_completion is closest to target_date.

**Reuses Phase 1's forecast manager** to compute per-pattern `estimated_completion`. Phase 1 was extended with an optional `overlay` parameter (`compute(overlay=...)`) so the suggester can evaluate hypothetical patterns without persisting them.

## Definitions — `kippo/projects/definitions.py`
Three new Pydantic v2 BaseModels (mirroring `ForecastResult`):

```python
PatternMember:    { user_id: UUID, is_past_member: bool, monthly_percentages: {date: int} }
PatternConflict:  { user_id: UUID, month: date, reason: str }
Pattern:          { pattern_ids: list[str], label, estimated_completion, infeasible, conflicts, members }
```

## Endpoint — `POST /api/projects/<id>/suggest-assignments/`
- `@action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])` on `KippoProjectViewSet` (overrides the parent's `IsSuperuserOrReadUpdateOnly` which would otherwise block POST for non-superusers).
- Request body: `{ from_month?: date }`. Defaults to `first_of_next_month(today)` when null.
- HTTP 400 + `code: project_start_date_required` when `start_date` is null (#224 O3).
- HTTP 400 + `code: invalid_from_month` when the date string fails to parse.
- Response: `{ "patterns": [Pattern, ...] }` (0–3 entries after dedup + greenfield skip).

## Forecast — `kippo/projects/services/forecast.py`
Extended `ProjectAssignmentForecastManager.compute()` with an optional `overlay: dict[user_id, dict[month, percentage]]` parameter. When provided, the future projection uses the overlay instead of querying `ProjectMonthlyAssignment`. Past + in-progress logged effort is unchanged. `__load_user_context` refactored to take the by_user_month mapping directly.

## Tests — `kippo/projects/tests/test_suggest.py` (17 tests)

**`SuggestionServiceCoreTestCase`** — 11 tests covering:
- start_date null → raises
- greenfield → skips P1 (S2)
- past member → P1 returned
- inactive user excluded (D2 + S1)
- 10% floor enforced (B5)
- team size capped at 3 (B6)
- capacity conflict recorded (B4 + D3)
- dedup collapses identical patterns (S3)
- past_member flag correct on PatternMember
- target_date=null doesn't strictly rank
- response Pydantic shape

**`SuggestionEndpointTestCase`** — 6 tests covering:
- unauthenticated → 401
- response payload contains `patterns`
- start_date null → 400 + `project_start_date_required`
- invalid from_month → 400 + `invalid_from_month`
- cross-org user → 404 (org-scoping hides the row)
- OpenAPI schema includes `/api/projects/{id}/suggest-assignments/`

## Verification
- `uv run python manage.py test projects.tests.test_suggest` → **17 / 17 OK**.
- `uv run python manage.py test projects.tests.test_forecast` → 17 / 17 OK (Phase 1 still green after the overlay refactor).
- `uv run python manage.py test projects` → 248 ran; all OK except 5 pre-existing AWS/S3 env errors (unrelated; same as on main).
- `uv run ruff check` and `uv run ruff format --check` clean on all touched files.

## Closes
- [monkut/kippo#227](https://github.com/monkut/kippo/issues/227) (Phase 2)

## Refs
- [monkut/kippo#224](https://github.com/monkut/kippo/issues/224) — parent / decision source (B1–B13, D2, D3, O2, O3)
- [monkut/kippo#226](https://github.com/monkut/kippo/issues/226) (Phase 1 — forecast) — merged via #229; this PR reuses `ProjectAssignmentForecastManager` via the new overlay parameter
- [monkut/kippo-ui#57](https://github.com/monkut/kippo-ui/issues/57) — kippo-ui will consume `/suggest-assignments/` for the pattern picker UI