### PR TITLE
:sparkles: Hide parent_project + organization on upsell add form (#232)

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -475,6 +475,8 @@ def _build_upsell_prefill_params(project: KippoProject, selected_category: str) 
     params = {
         "category": selected_category,
         "parent_project": str(project.id),
+        "organization": str(project.organization_id),
+        "_upsell_source": "close",
         "name": _next_upsell_project_name(project.name),
         "start_date": _start_of_next_month(today).isoformat(),
         "slack_channel_name": project.slack_channel_name,
@@ -939,7 +941,24 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # no business sense; the form's clean() rejects mismatches at submit-time.
         if obj is None and "parent_project" in form.base_fields and user_initial_organization:
             form.base_fields["parent_project"].queryset = KippoProject.objects.filter(organization=user_initial_organization)
+
+        if obj is None and request.GET.get("_upsell_source") == "close":
+            self._apply_upsell_source_widgets(form, user_memberships)
         return form
+
+    @staticmethod
+    def _apply_upsell_source_widgets(form: Form, user_memberships: models.QuerySet) -> None:
+        """Hide parent_project + organization on the upsell close-action redirect.
+
+        Values still POST and the existing validator runs; only the widgets are swapped to hidden.
+        parent_project queryset is widened to all of the user's orgs because the default scope
+        (user_initial_organization) may not match the parent's org for multi-org users.
+        """
+        if "parent_project" in form.base_fields:
+            form.base_fields["parent_project"].widget = forms.HiddenInput()
+            form.base_fields["parent_project"].queryset = KippoProject.objects.filter(organization__in=user_memberships)
+        if "organization" in form.base_fields:
+            form.base_fields["organization"].widget = forms.HiddenInput()
 
     def get_readonly_fields(self, request: DjangoRequest, obj: KippoProject | None = None) -> tuple[str, ...]:
         readonly_fields = tuple(super().get_readonly_fields(request, obj))
@@ -981,6 +1000,9 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         parent_project_id = request.GET.get("parent_project")
         if parent_project_id:
             initial["parent_project"] = parent_project_id
+        organization_id = request.GET.get("organization")
+        if organization_id:
+            initial["organization"] = organization_id
         return initial
 
     def save_model(self, request: DjangoRequest, obj: KippoProject, form: Form, change: bool):

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -363,6 +363,10 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         params = parse_qs(parsed.query)
         self.assertEqual(params.get("category"), ["upsell-improvement"])
         self.assertEqual(params.get("parent_project"), [str(self.project1.id)])
+        # close-action upsell redirect must include the parent's organization and the upsell marker
+        # so the add form can derive the org server-side and detect the entry point.
+        self.assertEqual(params.get("organization"), [str(self.project1.organization_id)])
+        self.assertEqual(params.get("_upsell_source"), ["close"])
 
         self.project1.refresh_from_db()
         self.assertTrue(self.project1.is_closed)
@@ -557,6 +561,83 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         parent_ids = set(parent_qs.values_list("id", flat=True))
         self.assertIn(self.project1.id, parent_ids)
         self.assertNotIn(other_org_project.id, parent_ids)
+
+    def test_upsell_redirect_hides_parent_project_and_organization(self):
+        # close-action upsell redirect: parent_project and organization must render as hidden inputs
+        # so the user cannot edit them; the values still POST so the existing validator runs.
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(
+            url,
+            {
+                "_upsell_source": "close",
+                "category": "upsell-improvement",
+                "parent_project": str(self.project1.id),
+                "organization": str(self.project1.organization_id),
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        adminform = response.context["adminform"]
+        for field_name in ("parent_project", "organization"):
+            with self.subTest(field=field_name):
+                widget = adminform.form.fields[field_name].widget
+                inner_widget = getattr(widget, "widget", widget)
+                self.assertIsInstance(inner_widget, forms.HiddenInput)
+        content = response.content.decode()
+        self.assertIn('type="hidden" name="parent_project"', content)
+        self.assertIn('type="hidden" name="organization"', content)
+
+    def test_manual_add_without_upsell_marker_keeps_organization_visible(self):
+        # manual add (no _upsell_source marker) — organization should NOT be forced hidden by the
+        # upsell branch. (When the user has multiple orgs, organization is shown as a visible select.)
+        url = reverse("admin:projects_kippoproject_add")
+        # GET with parent_project but no _upsell_source: must remain in manual-add mode
+        response = self.client.get(url, {"category": "upsell-improvement", "parent_project": str(self.project1.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        adminform = response.context["adminform"]
+        # parent_project remains selectable (not hidden)
+        self._assert_parent_project_selectable(adminform, response.content.decode())
+
+    def test_upsell_form_with_derived_organization_is_valid_and_saves_parent(self):
+        # the upsell prefill always sets organization = parent_project.organization, so the form
+        # validator's parent-org invariant is satisfied by construction. Save and verify the result.
+        form = KippoProjectAdminForm(
+            data={
+                "organization": str(self.project1.organization_id),
+                "parent_project": str(self.project1.id),
+                "name": "project1 Phase 2",
+                "phase": "lead-evaluation",
+                "confidence": "80",
+                "category": "upsell-improvement",
+                "columnset": str(self.project1.columnset_id),
+                "start_date": self.current_date.isoformat(),
+            },
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        new_project = form.save(commit=False)
+        new_project.created_by = self.superuser_no_org
+        new_project.updated_by = self.superuser_no_org
+        new_project.save()
+        self.assertEqual(new_project.parent_project_id, self.project1.id)
+        self.assertEqual(new_project.organization_id, self.project1.organization_id)
+
+    def test_upsell_form_with_mismatched_organization_is_rejected(self):
+        # tampered POST: hidden organization differs from parent_project.organization — the existing
+        # validator must catch the mismatch (no validator changes were made for this issue).
+        form = KippoProjectAdminForm(
+            data={
+                # parent is in self.organization, but the submitted organization is the other org
+                "organization": str(self.other_organization.id),
+                "parent_project": str(self.project1.id),
+                "name": "tampered-project",
+                "phase": "lead-evaluation",
+                "confidence": "80",
+                "category": "upsell-improvement",
+                "columnset": str(self.project1.columnset_id),
+                "start_date": self.current_date.isoformat(),
+            },
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("parent_project", form.errors)
 
 
 class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):


### PR DESCRIPTION
Closes #232.

## Summary

When the close-project upsell flow redirects to the KippoProject add form, `parent_project` and `organization` are no longer editable inputs — both render as `forms.HiddenInput` so admins can't accidentally change values that are derived from the close action.

## Approach

- **Explicit marker** (`_upsell_source=close`) added to the redirect query string by `_build_upsell_prefill_params`. The add form keys on the marker, not on the presence of `parent_project` in the GET params, so manual paste of `?parent_project=<id>` keeps the field selectable (preserves intent of `test_add_form_prefills_from_get_params`).
- **Organization derivation** done in `_build_upsell_prefill_params` from `parent_project.organization`. The existing `KippoProjectAdminForm.clean()` invariant (`parent_project.organization == organization`) is satisfied by construction — no validator changes.
- **Hidden widgets** keep values flowing through Django's normal form lifecycle. A tampered POST with mismatched org is rejected by the same validator that protects manual-add submissions.
- **Wider parent_project queryset** in upsell mode (scoped to all of the user's orgs, not just `user_initial_organization`) so multi-org users can still POST a parent that lives in an org other than their session-default.

## Files changed

- `kippo/projects/admin.py`
  - `_build_upsell_prefill_params`: adds `organization` and `_upsell_source`.
  - `KippoProjectAdmin.get_changeform_initial_data`: seeds `organization` initial from GET.
  - `KippoProjectAdmin.get_form`: routes through new `_apply_upsell_source_widgets` helper when `_upsell_source=close`.
- `kippo/projects/tests/test_admin.py`
  - extends `test_upsell_flow_closes_and_redirects` to assert `organization=<parent_org_id>` and `_upsell_source=close` in the redirect.
  - new `test_upsell_redirect_hides_parent_project_and_organization` — asserts `HiddenInput` widgets and `<input type=\"hidden\">` HTML.
  - new `test_manual_add_without_upsell_marker_keeps_organization_visible` — confirms manual-add behavior preserved.
  - new `test_upsell_form_with_derived_organization_is_valid_and_saves_parent` — POST path saves a project with parent_project + parent's organization.
  - new `test_upsell_form_with_mismatched_organization_is_rejected` — sanity-checks that the existing invariant still fires on tampered POST.

## Test plan
- [x] `uv run python manage.py test projects.tests.test_admin` — 61 tests pass.
- [x] `uv run poe check` — ruff clean.
- [x] Existing `test_add_form_prefills_from_get_params` and `test_manual_add_form_exposes_parent_project_as_selectable` still pass — manual /add/ unchanged.
- [x] Pyright: no new patterns of error introduced (same Django-stub limitations as the surrounding code).
- [ ] Manual: open `/admin/projects/kippoproject/add/?_upsell_source=close&parent_project=<id>&organization=<org_id>&category=upsell-improvement` and verify only one form input is rendered for parent_project / organization, with type=hidden.