### PR TITLE
:sparkles: Add GET /api/projects/<id>/members/ endpoint (#233)

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -72,6 +72,19 @@ class GithubRepositoryInlineSerializer(serializers.Serializer):
     repository_url = serializers.URLField()
 
 
+class OrganizationMemberSerializer(serializers.Serializer):
+    """Minimal projection of a `KippoUser` + their `OrganizationMembership` for use as a
+    user-picker source on the kippo-ui add-assignment modal (kippo-ui#57). Per kippo#233.
+    """
+
+    user_id = serializers.UUIDField(help_text="KippoUser primary key.")
+    username = serializers.CharField()
+    display_name = serializers.CharField(help_text="Composed first + last + (github_login).")
+    github_login = serializers.CharField(allow_blank=True)
+    is_developer = serializers.BooleanField()
+    is_project_manager = serializers.BooleanField()
+
+
 class ProjectAssignmentRateSerializer(serializers.ModelSerializer):
     """Serializer for ProjectAssignmentRate model."""
 

--- a/kippo/projects/tests/test_project_members_endpoint.py
+++ b/kippo/projects/tests/test_project_members_endpoint.py
@@ -1,0 +1,116 @@
+"""Tests for GET /api/projects/<id>/members/ — kippo#233.
+
+Lists active org members for the project's organization. Source for kippo-ui's
+add-assignment user picker (kippo-ui#57).
+"""
+
+from http import HTTPStatus
+
+from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+
+class ProjectMembersEndpointTestCase(TestCase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.project = created["KippoProject"]
+        self.user = created["KippoUser"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        # Cross-org user — should not appear in this project's members
+        self.other_org = KippoOrganization.objects.create(
+            name="other-org-for-members-test",
+            github_organization_name="otherorg-members",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.outsider = KippoUser.objects.create(username="members-outsider", email="outsider@example.com")
+        OrganizationMembership.objects.create(
+            user=self.outsider,
+            organization=self.other_org,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/members/"
+
+    def _add_org_member(self, username: str, *, is_developer: bool = True, is_project_manager: bool = False) -> KippoUser:
+        user = KippoUser.objects.create(username=username, email=f"{username}@example.com")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=self.organization,
+            is_developer=is_developer,
+            is_project_manager=is_project_manager,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        return user
+
+    def test_unauthenticated_returns_401(self):
+        anon = APIClient()
+        response = anon.get(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_returns_active_members_of_project_organization(self):
+        self._add_org_member("dev-1")
+        self._add_org_member("dev-2")
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        usernames = {row["username"] for row in response.json()}
+        # The default setup user (octocat) plus the two dev users
+        self.assertIn("octocat", usernames)
+        self.assertIn("dev-1", usernames)
+        self.assertIn("dev-2", usernames)
+        # outsider is not in this org
+        self.assertNotIn("members-outsider", usernames)
+
+    def test_excludes_inactive_users(self):
+        active = self._add_org_member("active-dev")
+        inactive = self._add_org_member("inactive-dev")
+        inactive.is_active = False
+        inactive.save()
+
+        response = self.client.get(self.url)
+        usernames = {row["username"] for row in response.json()}
+        self.assertIn(active.username, usernames)
+        self.assertNotIn(inactive.username, usernames)
+
+    def test_response_shape(self):
+        self._add_org_member("dev-shape", is_developer=True, is_project_manager=False)
+        response = self.client.get(self.url)
+        rows = response.json()
+        self.assertGreater(len(rows), 0)
+        sample = rows[0]
+        for field in ["user_id", "username", "display_name", "github_login", "is_developer", "is_project_manager"]:
+            self.assertIn(field, sample)
+
+    def test_includes_role_flags_from_organization_membership(self):
+        pm_user = self._add_org_member("the-pm", is_developer=False, is_project_manager=True)
+        response = self.client.get(self.url)
+        target = next(row for row in response.json() if row["username"] == pm_user.username)
+        self.assertTrue(target["is_project_manager"])
+        self.assertFalse(target["is_developer"])
+
+    def test_cross_org_user_gets_404(self):
+        cross = APIClient()
+        cross.force_authenticate(user=self.outsider)
+        response = cross.get(self.url)
+        # Org-scoped queryset hides the project from this user — DRF returns 404
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_openapi_schema_exposes_members_endpoint(self):
+        from drf_spectacular.generators import SchemaGenerator
+
+        schema = SchemaGenerator().get_schema(request=None, public=True)
+        path = f"{settings.URL_PREFIX}/api/projects/{{id}}/members/"
+        self.assertIn(path, schema["paths"])
+        self.assertIn("get", schema["paths"][path])

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -2,6 +2,7 @@ import datetime
 from http import HTTPStatus
 from typing import Any
 
+from accounts.models import KippoUser
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, inline_serializer
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
@@ -22,6 +23,7 @@ from .permissions import IsSuperuserOrReadUpdateCreateOwn, IsSuperuserOrReadUpda
 from .serializers import (
     KippoProjectSerializer,
     KippoProjectUserStatisfactionResultSerializer,
+    OrganizationMemberSerializer,
     ProjectAssignmentRateSerializer,
     ProjectMonthlyAssignmentSerializer,
     ProjectMonthlyCostSerializer,
@@ -127,6 +129,42 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
                 status=HTTPStatus.BAD_REQUEST,
             )
         return Response(result.model_dump(mode="json"))
+
+    @extend_schema(
+        responses={HTTPStatus.OK: OrganizationMemberSerializer(many=True)},
+        description=(
+            "Active members of the project's organization. Lists every KippoUser with an "
+            "OrganizationMembership in the project's org, filtered by KippoUser.is_active=True. "
+            "Used by kippo-ui's add-assignment picker so day-zero projects can pick from anyone "
+            "in the org rather than only users already on the project."
+        ),
+    )
+    @action(detail=True, methods=["get"], url_path="members", permission_classes=[IsAuthenticated])
+    def members(self, request: Request, pk: str | None = None) -> Response:  # noqa: ARG002
+        project = self.get_object()
+        members_qs = (
+            KippoUser.objects.filter(
+                is_active=True,
+                organizationmembership__organization=project.organization,
+            )
+            .select_related()
+            .prefetch_related("organizationmembership_set")
+            .order_by("username")
+            .distinct()
+        )
+        memberships_by_user = {m.user_id: m for m in project.organization.organizationmembership_set.filter(user__in=members_qs)}
+        payload = [
+            {
+                "user_id": user.id,
+                "username": user.username,
+                "display_name": user.display_name.strip() or user.username,
+                "github_login": user.github_login or "",
+                "is_developer": memberships_by_user[user.id].is_developer if user.id in memberships_by_user else False,
+                "is_project_manager": (memberships_by_user[user.id].is_project_manager if user.id in memberships_by_user else False),
+            }
+            for user in members_qs
+        ]
+        return Response(OrganizationMemberSerializer(payload, many=True).data)
 
     @extend_schema(
         request=inline_serializer(


### PR DESCRIPTION
Closes the user-picker gap surfaced by kippo-ui#57 / [PR #61](https://github.com/monkut/kippo-ui/pull/61). New action on `KippoProjectViewSet` returns the active members of the project's organization, so kippo-ui's "Add Assignment" modal can include genuinely-new users (not just those already on the project).

## Net diff
+167 / 0 across 3 files (1 new test file). 0 migrations. New endpoint surfaces in OpenAPI via drf-spectacular at runtime.

## Surface

`GET /api/projects/<id>/members/`

```ts
// Generated client return type after `pnpm update:api` on kippo-ui
type OrganizationMember = {
  user_id: string;          // UUID
  username: string;
  display_name: string;     // composed; falls back to username
  github_login: string;     // empty string when unset
  is_developer: boolean;
  is_project_manager: boolean;
};
```

- Implemented as `@action(detail=True, methods=["get"], url_path="members", permission_classes=[IsAuthenticated])` on `KippoProjectViewSet`.
- Filter: `KippoUser.is_active=True` AND `OrganizationMembership.organization == project.organization`.
- Org-scoping inherits from the viewset's existing `get_queryset` — cross-org callers get **404** (`get_object` filters before the action runs).
- Ordered by `username` (stable for picker UI).
- New `OrganizationMemberSerializer` (in `projects/serializers.py`) declares the response shape with field-level `help_text` so the OpenAPI client gets typed JSDoc.

## Tests — `kippo/projects/tests/test_project_members_endpoint.py` (7 tests)
- Unauthenticated → 401
- Returns active members of the project's organization
- Excludes `KippoUser.is_active=False`
- Response shape carries all expected fields
- `is_developer` / `is_project_manager` flags from `OrganizationMembership` are surfaced correctly (PM-only user check)
- Cross-org user → 404
- OpenAPI schema includes `/api/projects/{id}/members/`

## Verification
- `uv run python manage.py test projects.tests.test_project_members_endpoint` → **7 / 7 OK**
- Full `projects` suite → 255 ran; all OK except 5 pre-existing AWS/S3 env errors (unrelated; same as on `main`).
- `uv run ruff check` and `uv run ruff format --check` clean on touched files.

## Closes
- [monkut/kippo#233](https://github.com/monkut/kippo/issues/233)

## Refs
- [monkut/kippo-ui#57](https://github.com/monkut/kippo-ui/issues/57) — frontend epic that surfaces this picker
- [monkut/kippo-ui PR #61](https://github.com/monkut/kippo-ui/pull/61) — Phase 3c, where the user-picker limitation was first noted
- [monkut/kippo#224](https://github.com/monkut/kippo/issues/224) — User Project Assignment feature parent
- [monkut/kippo#231](https://github.com/monkut/kippo/issues/231) — sibling OpenAPI typing follow-up (typed `patterns` schema)