### PR TITLE
:alembic: Type SuggestAssignmentsResponse.patterns + JSON-only + descriptions (#231)

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -85,6 +85,52 @@ class OrganizationMemberSerializer(serializers.Serializer):
     is_project_manager = serializers.BooleanField()
 
 
+class ProjectAssignmentPatternMemberSerializer(serializers.Serializer):
+    """One member of a suggested assignment pattern. Mirrors the Pydantic
+    `ProjectAssignmentPatternMember` shape from `projects.definitions`.
+    """
+
+    user_id = serializers.UUIDField(help_text="KippoUser primary key.")
+    is_past_member = serializers.BooleanField(help_text="True when the user already has a row on this project.")
+    monthly_percentages = serializers.DictField(
+        child=serializers.IntegerField(),
+        help_text="Per-month percentage allocation. Keys are first-of-month ISO dates ('YYYY-MM-01').",
+    )
+
+
+class ProjectAssignmentPatternConflictSerializer(serializers.Serializer):
+    """An over-allocation conflict surfaced by the suggester for a (user × month) cell."""
+
+    user_id = serializers.UUIDField()
+    month = serializers.DateField(help_text="First-of-month ISO date.")
+    reason = serializers.CharField()
+
+
+class ProjectAssignmentPatternSerializer(serializers.Serializer):
+    """A complete suggested project-assignment pattern. Mirrors the Pydantic
+    `ProjectAssignmentPattern` shape from `projects.definitions`. Per kippo#231.
+
+    `pattern_ids` carries every strategy key that produced this pattern after dedup
+    (kippo#227 S3) — typically one entry, e.g. `['P1-max-reuse']`, but multiple when
+    strategies converged on the same members + monthly_percentages.
+    """
+
+    pattern_ids = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="Strategy keys that produced this pattern (one entry, or several after dedup).",
+    )
+    label = serializers.CharField(help_text="Human-readable label derived from pattern_ids.")
+    estimated_completion = serializers.DateField(
+        allow_null=True,
+        help_text="Day-precision completion date; null when the pattern can't reach the allocated effort.",
+    )
+    infeasible = serializers.BooleanField(
+        help_text="True when the pattern overshoots target_date or breaches the per-user 100% cap.",
+    )
+    conflicts = ProjectAssignmentPatternConflictSerializer(many=True)
+    members = ProjectAssignmentPatternMemberSerializer(many=True)
+
+
 class ProjectAssignmentRateSerializer(serializers.ModelSerializer):
     """Serializer for ProjectAssignmentRate model."""
 

--- a/kippo/projects/tests/test_suggest.py
+++ b/kippo/projects/tests/test_suggest.py
@@ -290,3 +290,38 @@ class SuggestionEndpointTestCase(SuggesterTestCaseBase):
         path = f"{settings.URL_PREFIX}/api/projects/{{id}}/suggest-assignments/"
         self.assertIn(path, schema["paths"])
         self.assertIn("post", schema["paths"][path])
+
+    def test_openapi_schema_patterns_field_is_typed(self):
+        """kippo#231: response.patterns must reference the typed pattern schema, not a generic JSONField.
+
+        Catches regressions where the inline_serializer reverts to ListField(child=JSONField()).
+        """
+        from drf_spectacular.generators import SchemaGenerator
+
+        schema = SchemaGenerator().get_schema(request=None, public=True)
+        suggest_response = schema["components"]["schemas"]["SuggestAssignmentsResponse"]
+        patterns = suggest_response["properties"]["patterns"]
+        self.assertEqual(patterns["type"], "array")
+        item_schema = patterns["items"]
+        # Either the item is a $ref to the typed model, or it's an inline object with members.
+        # Both indicate the response is typed (not the unknown-shaped `unknown[]` from JSONField).
+        if "$ref" in item_schema:
+            ref = item_schema["$ref"]
+            self.assertIn("ProjectAssignmentPattern", ref)
+        else:
+            self.assertIn("members", item_schema.get("properties", {}))
+            self.assertIn("pattern_ids", item_schema.get("properties", {}))
+
+    def test_openapi_schema_suggest_endpoint_is_json_only(self):
+        """kippo#231: the suggest endpoint must advertise application/json only.
+
+        DRF's default parser_classes include multipart/form-data + form-urlencoded; we restrict
+        to JSONParser so the OpenAPI schema doesn't carry the noise.
+        """
+        from drf_spectacular.generators import SchemaGenerator
+
+        schema = SchemaGenerator().get_schema(request=None, public=True)
+        path = f"{settings.URL_PREFIX}/api/projects/{{id}}/suggest-assignments/"
+        request_body = schema["paths"][path]["post"]["requestBody"]
+        content_types = set(request_body["content"].keys())
+        self.assertEqual(content_types, {"application/json"})

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -6,6 +6,7 @@ from accounts.models import KippoUser
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, inline_serializer
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -24,6 +25,7 @@ from .serializers import (
     KippoProjectSerializer,
     KippoProjectUserStatisfactionResultSerializer,
     OrganizationMemberSerializer,
+    ProjectAssignmentPatternSerializer,
     ProjectAssignmentRateSerializer,
     ProjectMonthlyAssignmentSerializer,
     ProjectMonthlyCostSerializer,
@@ -103,15 +105,27 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
 
     @extend_schema(
         responses={
-            HTTPStatus.OK: inline_serializer(
-                name="ProjectForecastResponse",
-                fields={
-                    "estimated_completion_date": serializers.DateField(allow_null=True),
-                    "delta_from_target_date_days": serializers.IntegerField(allow_null=True),
-                    "target_date": serializers.DateField(allow_null=True),
-                },
+            HTTPStatus.OK: OpenApiResponse(
+                response=inline_serializer(
+                    name="ProjectForecastResponse",
+                    fields={
+                        "estimated_completion_date": serializers.DateField(
+                            allow_null=True,
+                            help_text="Day-precision completion date; null when the project has no future assignments to project from.",
+                        ),
+                        "delta_from_target_date_days": serializers.IntegerField(
+                            allow_null=True,
+                            help_text="Days between estimated_completion_date and target_date. Positive = behind target; negative = ahead.",
+                        ),
+                        "target_date": serializers.DateField(
+                            allow_null=True,
+                            help_text="Echo of project.target_date for client-side delta computation.",
+                        ),
+                    },
+                ),
+                description="Forecast payload — estimated completion date plus delta vs target_date.",
             ),
-            HTTPStatus.BAD_REQUEST: OpenApiResponse(description="project.start_date is required to compute the forecast"),
+            HTTPStatus.BAD_REQUEST: OpenApiResponse(description="project.start_date is required to compute the forecast."),
         },
         description=(
             "Estimated completion date for the project, derived from logged effort + future "
@@ -169,16 +183,31 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
     @extend_schema(
         request=inline_serializer(
             name="SuggestAssignmentsRequest",
-            fields={"from_month": serializers.DateField(required=False, allow_null=True)},
+            fields={
+                "from_month": serializers.DateField(
+                    required=False,
+                    allow_null=True,
+                    help_text=(
+                        "First-of-month ISO date to start projecting from. When omitted, defaults "
+                        "to the first day of the month after the current date."
+                    ),
+                ),
+            },
         ),
         responses={
-            HTTPStatus.OK: inline_serializer(
-                name="SuggestAssignmentsResponse",
-                fields={
-                    "patterns": serializers.ListField(child=serializers.JSONField()),
-                },
+            HTTPStatus.OK: OpenApiResponse(
+                response=inline_serializer(
+                    name="SuggestAssignmentsResponse",
+                    fields={
+                        "patterns": ProjectAssignmentPatternSerializer(many=True),
+                    },
+                ),
+                description=(
+                    "0–3 candidate patterns, ranked by closeness to project.target_date "
+                    "(feasible patterns first). Greenfield projects skip the P1-max-reuse pattern."
+                ),
             ),
-            HTTPStatus.BAD_REQUEST: OpenApiResponse(description="project.start_date is required to compute suggestions"),
+            HTTPStatus.BAD_REQUEST: OpenApiResponse(description="project.start_date is required to compute suggestions."),
         },
         description=(
             "Generate up to 3 candidate assignment patterns for the project. Patterns vary "
@@ -186,7 +215,14 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
             "Returns 400 if the project has no start_date set. See monkut/kippo#224 B1-B13."
         ),
     )
-    @action(detail=True, methods=["post"], url_path="suggest-assignments", permission_classes=[IsAuthenticated])
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="suggest-assignments",
+        permission_classes=[IsAuthenticated],
+        # JSON only — drop the multipart/form-urlencoded variants from the OpenAPI schema.
+        parser_classes=[JSONParser],
+    )
     def suggest_assignments(self, request: Request, pk: str | None = None) -> Response:  # noqa: ARG002
         project = self.get_object()
         from_month_str = (request.data or {}).get("from_month")


### PR DESCRIPTION
Closes the OpenAPI cleanup gaps surfaced by the /simplify review on [kippo-ui PR #58](https://github.com/monkut/kippo-ui/pull/58). Three small improvements bundled together — once kippo-ui runs `pnpm update:api`, the local `SuggestedPattern` declaration in `components/project-assignments/utils.ts` becomes deletable.

## Net diff
+133 / −16 across 3 files. 0 migrations. New schema components surface in OpenAPI via drf-spectacular at runtime.

## 1. Type the `patterns` array

`SuggestAssignmentsResponse.patterns` was previously `unknown[]` on the TS side because the inline_serializer used `serializers.ListField(child=serializers.JSONField())`. Now references a typed `ProjectAssignmentPatternSerializer` that mirrors the Pydantic `ProjectAssignmentPattern` shape:

```python
class ProjectAssignmentPatternSerializer(serializers.Serializer):
    pattern_ids = serializers.ListField(child=serializers.CharField())
    label = serializers.CharField()
    estimated_completion = serializers.DateField(allow_null=True)
    infeasible = serializers.BooleanField()
    conflicts = ProjectAssignmentPatternConflictSerializer(many=True)
    members = ProjectAssignmentPatternMemberSerializer(many=True)
```

Mirrors the [`ProjectAssignmentPattern` Pydantic model](https://github.com/monkut/kippo/blob/main/kippo/projects/definitions.py) used by the suggester service.

## 2. JSON-only on `POST /api/projects/<id>/suggest-assignments/`

`parser_classes=[JSONParser]` on the `@action`. Before, OpenAPI advertised `multipart/form-data` and `application/x-www-form-urlencoded` alongside JSON because of DRF's default parsers — pure noise for an endpoint that takes a tiny `{from_month?}` body.

## 3. Populated descriptions + per-field `help_text`

- Both `forecast` and `suggest_assignments` 200 responses now wrap the body in `OpenApiResponse(..., description=...)` (previously empty).
- Per-field `help_text` on:
  - `ProjectForecastResponse.delta_from_target_date_days` — sign convention (positive = behind target).
  - `ProjectForecastResponse.estimated_completion_date` — null-meaning.
  - `ProjectForecastResponse.target_date` — its echo purpose.
  - `SuggestAssignmentsRequest.from_month` — default behavior when omitted.
  - All fields on `ProjectAssignmentPatternMember` / `Conflict` / `Pattern`.

## Tests — `kippo/projects/tests/test_suggest.py` (2 new)

- `test_openapi_schema_patterns_field_is_typed` — guards the regression where `patterns.items` reverts to the empty JSON schema. Asserts a `$ref` to `ProjectAssignmentPattern` (or the inline shape's properties) so a future serializer change can't silently drop typing.
- `test_openapi_schema_suggest_endpoint_is_json_only` — asserts the request body's content types are exactly `{"application/json"}`.

## Verification

- `uv run python manage.py test projects.tests.test_suggest projects.tests.test_forecast projects.tests.test_project_members_endpoint` → **43 / 43 OK**.
- `uv run ruff check` and `uv run ruff format --check` clean.

## Closes
- [monkut/kippo#231](https://github.com/monkut/kippo/issues/231)

## Refs
- [monkut/kippo-ui#57](https://github.com/monkut/kippo-ui/issues/57) — frontend epic (Phase 3 of [#224](https://github.com/monkut/kippo/issues/224))
- [monkut/kippo-ui PR #58](https://github.com/monkut/kippo-ui/pull/58) — surfaced these cleanup items
- After this lands, kippo-ui can do a single `pnpm update:api` and:
  - drop the local `SuggestedPattern` types from `components/project-assignments/utils.ts`
  - get the typed `members` endpoint from [#235](https://github.com/monkut/kippo/pull/235) at the same time