### PR TITLE
:bug: Wrap /members/ response to avoid spectacular auto-pagination (#233 follow-up)

### DIFF
--- a/kippo/projects/tests/test_project_members_endpoint.py
+++ b/kippo/projects/tests/test_project_members_endpoint.py
@@ -65,7 +65,7 @@ class ProjectMembersEndpointTestCase(TestCase):
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        usernames = {row["username"] for row in response.json()}
+        usernames = {row["username"] for row in response.json()["members"]}
         # The default setup user (octocat) plus the two dev users
         self.assertIn("octocat", usernames)
         self.assertIn("dev-1", usernames)
@@ -80,14 +80,14 @@ class ProjectMembersEndpointTestCase(TestCase):
         inactive.save()
 
         response = self.client.get(self.url)
-        usernames = {row["username"] for row in response.json()}
+        usernames = {row["username"] for row in response.json()["members"]}
         self.assertIn(active.username, usernames)
         self.assertNotIn(inactive.username, usernames)
 
     def test_response_shape(self):
         self._add_org_member("dev-shape", is_developer=True, is_project_manager=False)
         response = self.client.get(self.url)
-        rows = response.json()
+        rows = response.json()["members"]
         self.assertGreater(len(rows), 0)
         sample = rows[0]
         for field in ["user_id", "username", "display_name", "github_login", "is_developer", "is_project_manager"]:
@@ -96,7 +96,7 @@ class ProjectMembersEndpointTestCase(TestCase):
     def test_includes_role_flags_from_organization_membership(self):
         pm_user = self._add_org_member("the-pm", is_developer=False, is_project_manager=True)
         response = self.client.get(self.url)
-        target = next(row for row in response.json() if row["username"] == pm_user.username)
+        target = next(row for row in response.json()["members"] if row["username"] == pm_user.username)
         self.assertTrue(target["is_project_manager"])
         self.assertFalse(target["is_developer"])
 
@@ -114,3 +114,18 @@ class ProjectMembersEndpointTestCase(TestCase):
         path = f"{settings.URL_PREFIX}/api/projects/{{id}}/members/"
         self.assertIn(path, schema["paths"])
         self.assertIn("get", schema["paths"][path])
+
+    def test_openapi_schema_response_is_not_paginated(self):
+        """Regression: drf-spectacular auto-paginates `Serializer(many=True)` responses on a
+        ModelViewSet. We wrap in `{members: [...]}` to bypass that — the picker only ever
+        shows ~10s of users and pagination is wasted complexity.
+        """
+        from drf_spectacular.generators import SchemaGenerator
+
+        schema = SchemaGenerator().get_schema(request=None, public=True)
+        members_response = schema["components"]["schemas"]["ProjectMembersResponse"]
+        # Should be `{members: array}`, not `{count, next, previous, results}`
+        self.assertIn("members", members_response["properties"])
+        self.assertNotIn("count", members_response["properties"])
+        self.assertNotIn("results", members_response["properties"])
+        self.assertEqual(members_response["properties"]["members"]["type"], "array")

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -145,7 +145,15 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
         return Response(result.model_dump(mode="json"))
 
     @extend_schema(
-        responses={HTTPStatus.OK: OrganizationMemberSerializer(many=True)},
+        responses={
+            HTTPStatus.OK: OpenApiResponse(
+                response=inline_serializer(
+                    name="ProjectMembersResponse",
+                    fields={"members": OrganizationMemberSerializer(many=True)},
+                ),
+                description="Members of the project's organization eligible for assignment.",
+            ),
+        },
         description=(
             "Active members of the project's organization. Lists every KippoUser with an "
             "OrganizationMembership in the project's org, filtered by KippoUser.is_active=True. "
@@ -178,7 +186,10 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
             }
             for user in members_qs
         ]
-        return Response(OrganizationMemberSerializer(payload, many=True).data)
+        # Wrap in a named-key response so drf-spectacular doesn't auto-paginate the schema
+        # (it does that for `OrganizationMemberSerializer(many=True)` on a ModelViewSet).
+        # The picker only ever displays ~10s of users; pagination would be wasted complexity.
+        return Response({"members": OrganizationMemberSerializer(payload, many=True).data})
 
     @extend_schema(
         request=inline_serializer(


### PR DESCRIPTION
Follow-up bug fix for [PR #235](https://github.com/monkut/kippo/pull/235) ([#233](https://github.com/monkut/kippo/issues/233)). Caught while regenerating the kippo-ui API client against the latest release.

## Bug

The `/api/projects/<id>/members/` endpoint had a runtime ↔ schema mismatch:

| Side | Response shape |
|---|---|
| Runtime | `[{user_id, username, ...}, ...]` (bare array) |
| OpenAPI schema | `PaginatedOrganizationMemberList` = `{count, next, previous, results: [...]}` |

`drf-spectacular` auto-paginates `Serializer(many=True)` responses when declared on a `ModelViewSet` action. Since I returned a bare `Response(serializer.data)` without `paginate_queryset`, the runtime didn't actually paginate — but the generated kippo-ui client (`projectsMembersList`) expected `data.results` and would have crashed.

## Fix

Wrap the response in a named-key shape: `{members: [...]}`. The `@extend_schema` `responses` now declares an `inline_serializer` with a single `members` field referencing `OrganizationMemberSerializer(many=True)` — spectacular doesn't paginate that pattern.

The picker only ever displays ~10s of users; pagination would be wasted complexity for this endpoint.

## Verification

- 8 / 8 tests pass (was 7 — added the regression test).
- New `test_openapi_schema_response_is_not_paginated` asserts `ProjectMembersResponse` has `{members: array}` properties, not `{count, next, previous, results}`.
- `uv run ruff check` and `uv run ruff format --check` clean.

## Net diff
+32 / −6 across 2 files.

## Refs
- [monkut/kippo#233](https://github.com/monkut/kippo/issues/233)
- [monkut/kippo PR #235](https://github.com/monkut/kippo/pull/235) — the original endpoint
- Caught when running `pnpm update:api` on a kippo-ui regen branch — the generated TS expected `data.results.map(...)` which would have NPE'd at runtime.