### PR TITLE
:sparkles: suggester P4: previous-month carry-forward pattern

### DIFF
--- a/kippo/accounts/models.py
+++ b/kippo/accounts/models.py
@@ -355,7 +355,12 @@ class KippoUser(AbstractUser):
     @property
     def organizations(self) -> QuerySet:
         organization_ids = OrganizationMembership.objects.filter(user=self).values_list("organization", flat=True).distinct()
-        return KippoOrganization.objects.filter(id__in=organization_ids)
+        # Ordered by name so callers that index `[0]` (e.g. set_user_session_organization in
+        # projects.views) get a deterministic "first" organization across separate query
+        # invocations. Without an explicit ORDER BY, PostgreSQL is free to return rows in
+        # different orders between SELECTs in the same transaction depending on plan choice,
+        # which made test_set_organization__valid_user_nonmember_org intermittently flake.
+        return KippoOrganization.objects.filter(id__in=organization_ids).order_by("name")
 
     def get_membership(self, organization: KippoOrganization) -> OrganizationMembership:
         return OrganizationMembership.objects.get(user=self, organization=organization)

--- a/kippo/accounts/models.py
+++ b/kippo/accounts/models.py
@@ -354,12 +354,13 @@ class KippoUser(AbstractUser):
 
     @property
     def organizations(self) -> QuerySet:
-        organization_ids = OrganizationMembership.objects.filter(user=self).values_list("organization", flat=True).distinct()
-        # Ordered by name so callers that index `[0]` (e.g. set_user_session_organization in
-        # projects.views) get a deterministic "first" organization across separate query
-        # invocations. Without an explicit ORDER BY, PostgreSQL is free to return rows in
-        # different orders between SELECTs in the same transaction depending on plan choice,
-        # which made test_set_organization__valid_user_nonmember_org intermittently flake.
+        # `unique_together = ("user", "organization")` on OrganizationMembership guarantees
+        # each (user, organization) pair appears at most once, so the inner values_list is
+        # already deduplicated — no `.distinct()` needed.
+        # `.order_by("name")` makes the outer queryset deterministic so callers that index
+        # `[0]` (e.g. set_user_session_organization in projects.views) get the same
+        # "first" organization across separate SELECT invocations within a transaction.
+        organization_ids = OrganizationMembership.objects.filter(user=self).values_list("organization", flat=True)
         return KippoOrganization.objects.filter(id__in=organization_ids).order_by("name")
 
     def get_membership(self, organization: KippoOrganization) -> OrganizationMembership:

--- a/kippo/projects/services/suggest.py
+++ b/kippo/projects/services/suggest.py
@@ -1,9 +1,10 @@
 """Project assignment pattern suggester.
 
-Generates 0–3 candidate `ProjectMonthlyAssignment` patterns for a project, ranked
+Generates 0–4 candidate `ProjectMonthlyAssignment` patterns for a project, ranked
 by closeness to `project.target_date`. Patterns vary along a continuity gradient
-(P1 max past-member reuse, P2 blend past + org pool, P3 most-available pool). See
-monkut/kippo#224 decisions B1–B13 + monkut/kippo#227 clarifications S1–S4.
+(P1 max past-member reuse, P2 blend past + org pool, P3 most-available pool, P4
+previous-month carry-forward). See monkut/kippo#224 decisions B1–B13 +
+monkut/kippo#227 clarifications S1–S4.
 """
 
 from __future__ import annotations
@@ -42,12 +43,14 @@ class PatternId(StrEnum):
     P1_MAX_REUSE = "P1-max-reuse"
     P2_BLEND = "P2-blend"
     P3_MOST_AVAILABLE = "P3-most-available"
+    P4_PREVIOUS_MONTH = "P4-previous-month"
 
 
 PATTERN_LABELS: dict[PatternId, str] = {
     PatternId.P1_MAX_REUSE: "Maximum past-member reuse",
     PatternId.P2_BLEND: "Blend of past members and org pool",
     PatternId.P3_MOST_AVAILABLE: "Most-available org pool members",
+    PatternId.P4_PREVIOUS_MONTH: "Previous month's allocation continued",
 }
 
 
@@ -68,6 +71,10 @@ class _SelectionInputs:
     capacity: dict
     all_time_hours: dict[int, int]
     member_soft_ceiling: int
+    # Per-user percentage on this project for `from_month - 1 month`. Empty when
+    # no prior-month rows exist (greenfield, or first month after project start).
+    # Drives the P4 carry-forward strategy.
+    previous_month_user_pct: dict[int, int]
 
 
 def _by_capacity_then_id(user: KippoUser, capacity: dict, ceiling: int) -> tuple[int, int]:
@@ -107,10 +114,24 @@ def _select_p3_most_available(inputs: _SelectionInputs) -> list[KippoUser]:
     return sorted(inputs.org_pool, key=lambda u: _by_capacity_then_id(u, inputs.capacity, inputs.member_soft_ceiling))[:SOFT_CAP_TEAM_SIZE]
 
 
+def _select_p4_previous_month(inputs: _SelectionInputs) -> list[KippoUser]:
+    """P4: every active org member who had a non-zero prior-month allocation on this project.
+
+    Returns empty when no prior-month assignments exist, so the strategy is silently dropped
+    by `compute()` (same flow as P1's S2 greenfield skip). Inactive users from the prior
+    month are excluded because they are not in `org_pool`.
+    """
+    if not inputs.previous_month_user_pct:
+        return []
+    by_id = {u.id: u for u in inputs.org_pool}
+    return [by_id[user_id] for user_id in inputs.previous_month_user_pct if user_id in by_id]
+
+
 _STRATEGIES: tuple[_PatternStrategy, ...] = (
     _PatternStrategy(PatternId.P1_MAX_REUSE, _select_p1_past_only),
     _PatternStrategy(PatternId.P2_BLEND, _select_p2_blend),
     _PatternStrategy(PatternId.P3_MOST_AVAILABLE, _select_p3_most_available),
+    _PatternStrategy(PatternId.P4_PREVIOUS_MONTH, _select_p4_previous_month),
 )
 
 
@@ -143,6 +164,7 @@ class ProjectAssignmentSuggestionManager:
             capacity=self.__capacity_lookup(self.project.organization, from_month),
             all_time_hours=self.__all_time_logged_hours_per_user(),
             member_soft_ceiling=self.project.organization.project_assignment_member_soft_ceiling,
+            previous_month_user_pct=self.__previous_month_user_pct(from_month),
         )
 
         patterns: list[ProjectAssignmentPattern] = []
@@ -189,6 +211,21 @@ class ProjectAssignmentSuggestionManager:
         rows = ProjectWeeklyEffort.objects.filter(project=self.project, hours__gt=0).values("user_id").annotate(total=Sum("hours"))
         return {row["user_id"]: row["total"] or 0 for row in rows}
 
+    def __previous_month_user_pct(self, from_month: datetime.date) -> dict[int, int]:
+        """P4 input: per-user total allocation on this project for the month immediately before from_month.
+
+        Sums across multiple rows for the same (user, prior_month) cell — typically one row per
+        user-month, but the Sum guards against double-rows. Users with 0% rows are excluded so
+        `_select_p4_previous_month` doesn't propose someone last month already had at zero.
+        """
+        previous_month = from_month - relativedelta(months=1)
+        rows = (
+            ProjectMonthlyAssignment.objects.filter(project=self.project, month=previous_month, percentage__gt=0)
+            .values("user_id")
+            .annotate(total=Sum("percentage"))
+        )
+        return {row["user_id"]: row["total"] for row in rows if row["total"]}
+
     # --------------------------------------------------------------- pattern build
 
     def __build_pattern(
@@ -204,15 +241,29 @@ class ProjectAssignmentSuggestionManager:
         else:
             end_month = target_date.replace(day=1) + relativedelta(months=HORIZON_MONTHS_PAST_TARGET)
 
-        baseline_pct = max(ALLOCATION_FLOOR_PERCENTAGE, inputs.member_soft_ceiling // len(team))
-        overlay, conflicts, estimated, infeasible = self.__evaluate_overlay(team, baseline_pct, from_month, end_month, inputs.capacity, target_date)
-
-        # B11: thin-pattern fallback — push every member to the soft ceiling if the baseline
-        # can't meet target_date. We never push past the org soft ceiling on a single project.
-        if infeasible:
+        if pattern_id == PatternId.P4_PREVIOUS_MONTH:
+            # Use last month's per-user percentages verbatim; no thin-pattern fallback —
+            # the whole point is "this is what last month looked like".
+            pct_per_user = {u.id: inputs.previous_month_user_pct[u.id] for u in team}
             overlay, conflicts, estimated, infeasible = self.__evaluate_overlay(
-                team, inputs.member_soft_ceiling, from_month, end_month, inputs.capacity, target_date
+                team, pct_per_user, from_month, end_month, inputs.capacity, target_date
             )
+        else:
+            baseline_pct = max(ALLOCATION_FLOOR_PERCENTAGE, inputs.member_soft_ceiling // len(team))
+            overlay, conflicts, estimated, infeasible = self.__evaluate_overlay(
+                team, {u.id: baseline_pct for u in team}, from_month, end_month, inputs.capacity, target_date
+            )
+            # B11: thin-pattern fallback — push every member to the soft ceiling if the baseline
+            # can't meet target_date. We never push past the org soft ceiling on a single project.
+            if infeasible:
+                overlay, conflicts, estimated, infeasible = self.__evaluate_overlay(
+                    team,
+                    {u.id: inputs.member_soft_ceiling for u in team},
+                    from_month,
+                    end_month,
+                    inputs.capacity,
+                    target_date,
+                )
 
         members = [
             ProjectAssignmentPatternMember(
@@ -234,14 +285,16 @@ class ProjectAssignmentSuggestionManager:
     def __evaluate_overlay(
         self,
         team: list[KippoUser],
-        per_member_pct: int,
+        pct_per_user: dict[int, int],
         from_month: datetime.date,
         end_month: datetime.date,
         capacity: dict,
         target_date: datetime.date | None,
     ) -> tuple[dict, list[ProjectAssignmentPatternConflict], datetime.date | None, bool]:
-        """Build the overlay at `per_member_pct`, run the forecast, return (overlay, conflicts, estimated, infeasible)."""
-        overlay, conflicts = self.__compose_overlay(team, per_member_pct, from_month, end_month, capacity)
+        """Build the overlay using each user's percentage from `pct_per_user`, run the forecast,
+        return (overlay, conflicts, estimated, infeasible).
+        """
+        overlay, conflicts = self.__compose_overlay(team, pct_per_user, from_month, end_month, capacity)
         estimated = self._forecaster.compute(overlay=overlay).estimated_completion_date
         infeasible = estimated is None or (target_date is not None and estimated > target_date)
         return overlay, conflicts, estimated, infeasible
@@ -249,17 +302,17 @@ class ProjectAssignmentSuggestionManager:
     def __compose_overlay(
         self,
         team: list[KippoUser],
-        per_member_pct: int,
+        pct_per_user: dict[int, int],
         from_month: datetime.date,
         end_month: datetime.date,
         capacity: dict,
     ) -> tuple[dict, list[ProjectAssignmentPatternConflict]]:
         """Build the user-month overlay and collect over-allocation conflicts.
 
-        Pattern percentage is fixed at `per_member_pct`. A `ProjectAssignmentPatternConflict` is recorded for any
-        (user, month) where adding the proposed pattern would push the user's org-total beyond
-        `MAX_INDIVIDUAL_PERCENTAGE`. The pattern still proposes the requested percentage —
-        per kippo#224 D3 the suggester surfaces the conflict rather than silently capping.
+        Each (user, month) cell uses `pct_per_user[user.id]`. A
+        `ProjectAssignmentPatternConflict` is recorded for any cell where adding the proposed
+        pattern would push the user's org-total beyond `MAX_INDIVIDUAL_PERCENTAGE` — per
+        kippo#224 D3 the suggester surfaces the conflict rather than silently capping.
         """
         overlay: dict = {}
         conflicts: list[ProjectAssignmentPatternConflict] = []
@@ -267,14 +320,15 @@ class ProjectAssignmentSuggestionManager:
         current_month = from_month
         while current_month <= end_month:
             for user in team:
-                overlay.setdefault(user.id, {})[current_month] = per_member_pct
+                pct = pct_per_user[user.id]
+                overlay.setdefault(user.id, {})[current_month] = pct
                 existing = capacity.get(user.id, {}).get(current_month, 0)
-                if existing + per_member_pct > MAX_INDIVIDUAL_PERCENTAGE:
+                if existing + pct > MAX_INDIVIDUAL_PERCENTAGE:
                     conflicts.append(
                         ProjectAssignmentPatternConflict(
                             user_id=user.id,
                             month=current_month,
-                            reason=f"already {existing}% on other projects (proposed +{per_member_pct}% would total {existing + per_member_pct}%)",
+                            reason=f"already {existing}% on other projects (proposed +{pct}% would total {existing + pct}%)",
                         )
                     )
             current_month = current_month + relativedelta(months=1)

--- a/kippo/projects/tests/test_suggest.py
+++ b/kippo/projects/tests/test_suggest.py
@@ -20,6 +20,7 @@ from projects.models import KippoProject, ProjectMonthlyAssignment, ProjectWeekl
 from projects.services.suggest import (
     ALLOCATION_FLOOR_PERCENTAGE,
     SOFT_CAP_TEAM_SIZE,
+    PatternId,
     ProjectAssignmentSuggestionManager,
 )
 
@@ -226,6 +227,49 @@ class SuggestionServiceCoreTestCase(SuggesterTestCaseBase):
         self.assertIsInstance(pattern.infeasible, bool)
         self.assertIsInstance(pattern.conflicts, list)
         self.assertIsInstance(pattern.members, list)
+
+    def test_p4_emitted_when_previous_month_has_assignments(self):
+        """P4 carries each user's previous-month percentage forward verbatim."""
+        from_month = first_of_next_month(self.today)
+        previous_month = (from_month - datetime.timedelta(days=1)).replace(day=1)
+        # Two users with non-uniform allocations on this project last month.
+        dev2 = self._add_member("dev2-p4")
+        self._make_assignment(month=previous_month, percentage=30, is_confirmed=True)
+        self._make_assignment(user=dev2, month=previous_month, percentage=50, is_confirmed=True)
+
+        patterns = ProjectAssignmentSuggestionManager(self.project, from_month=from_month).compute()
+        p4 = next((p for p in patterns if PatternId.P4_PREVIOUS_MONTH.value in p.pattern_ids), None)
+        self.assertIsNotNone(p4, "Expected a P4-previous-month pattern when prior-month rows exist")
+        member_pcts = {m.user_id: m.monthly_percentages for m in p4.members}
+        self.assertEqual(set(member_pcts.keys()), {self.user.id, dev2.id})
+        # Every month from from_month → end_month carries each user's prior-month percentage.
+        for month_pcts in member_pcts[self.user.id].values():
+            self.assertEqual(month_pcts, 30)
+        for month_pcts in member_pcts[dev2.id].values():
+            self.assertEqual(month_pcts, 50)
+
+    def test_p4_skipped_when_no_previous_month_assignments(self):
+        """No prior-month rows on this project → P4 strategy is dropped silently."""
+        # Greenfield project: setUp creates no assignments.
+        self._add_member("dev2-p4-skip")
+        patterns = ProjectAssignmentSuggestionManager(self.project).compute()
+        p4 = next((p for p in patterns if PatternId.P4_PREVIOUS_MONTH.value in p.pattern_ids), None)
+        self.assertIsNone(p4, "P4 should be absent when no prior-month assignments exist")
+
+    def test_p4_excludes_zero_percent_prior_rows(self):
+        """A user with a 0% prior-month row shouldn't appear in the P4 team."""
+        from_month = first_of_next_month(self.today)
+        previous_month = (from_month - datetime.timedelta(days=1)).replace(day=1)
+        ghost = self._add_member("dev2-p4-zero")
+        self._make_assignment(month=previous_month, percentage=40, is_confirmed=True)
+        self._make_assignment(user=ghost, month=previous_month, percentage=0, is_confirmed=True)
+
+        patterns = ProjectAssignmentSuggestionManager(self.project, from_month=from_month).compute()
+        p4 = next((p for p in patterns if PatternId.P4_PREVIOUS_MONTH.value in p.pattern_ids), None)
+        self.assertIsNotNone(p4)
+        proposed_user_ids = {m.user_id for m in p4.members}
+        self.assertIn(self.user.id, proposed_user_ids)
+        self.assertNotIn(ghost.id, proposed_user_ids)
 
     def test_per_member_pct_capped_at_org_soft_ceiling(self):
         """No proposed (member, month) percentage should exceed the org soft ceiling.


### PR DESCRIPTION
## Summary

Adds a fourth pattern strategy `P4_PREVIOUS_MONTH` to the assignment suggester that proposes the *same per-user percentages* this project had in `from_month - 1 month`, replicated forward through the standard horizon. Pattern label: **"Previous month's allocation continued"**.

## Defaults locked in

- **Source month** — immediately prior month (`from_month - 1 month`).
- **Carry-forward horizon** — every month from `from_month` through `end_month` (target_date + 6 months, or +24 months if no target_date).
- **Skip behavior** — silently dropped if the prior month has no non-zero rows on this project (mirrors P1's greenfield S2 skip).
- **Infeasibility** — no thin-pattern fallback. If carried-forward percentages don't reach the target_date, `infeasible=True` is set; we don't quietly ratchet people up to the soft ceiling. The whole point of P4 is "this is what last month looked like".
- **Conflicts** — same `__compose_overlay` org-wide over-allocation detection as P1/P2/P3 (>100% on any cell still emits a `ProjectAssignmentPatternConflict`).
- **Rank** — appended to `_STRATEGIES`; ranked by the existing `(infeasible, estimated_completion)` comparator.

## Refactor included

`__compose_overlay` and `__evaluate_overlay` now accept a `pct_per_user: dict[user_id, int]` instead of a flat `int`. P1/P2/P3 callers wrap as `{u.id: baseline_pct for u in team}`; P4 passes the carry-forward dict from the prior month. The two code paths used to differ only in the per-cell percentage; the unification is straightforward and contains the change.

## Test plan

- [x] `uv run poe test --keepdb projects.tests.test_suggest` — 23/23 pass (3 new):
  - `test_p4_emitted_when_previous_month_has_assignments`
  - `test_p4_skipped_when_no_previous_month_assignments`
  - `test_p4_excludes_zero_percent_prior_rows`
- [x] `uv run poe check` — ruff clean
- [x] Wider `projects accounts` suite: only pre-existing CSV/download/S3 infrastructure failures (verified by stashing the diff and re-running on main — same 3 failures)

## No frontend changes needed

The existing `PatternCard` already renders any pattern returned by the API (label, members, conflicts, infeasibility hint via `title`). When kippo-ui regenerates the API client (`pnpm update:api`), `PatternId.P4_PREVIOUS_MONTH` flows through unchanged.

## No migration / no schema change

Pure service-layer change.