### PR TITLE
:sparkles: Auto-create future-month ProjectMonthlyAssignment rows (#240)

### DIFF
--- a/kippo/projects/apps.py
+++ b/kippo/projects/apps.py
@@ -3,3 +3,7 @@ from django.apps import AppConfig
 
 class ProjectsConfig(AppConfig):
     name = "projects"
+
+    def ready(self) -> None:
+        # Import signal handlers so @receiver decorators register on app startup.
+        from projects import signals  # noqa: F401

--- a/kippo/projects/services/autoassign.py
+++ b/kippo/projects/services/autoassign.py
@@ -1,0 +1,343 @@
+"""Auto-create future-month ProjectMonthlyAssignment rows on first-month full confirmation.
+
+When every `ProjectMonthlyAssignment` row for a project's start month is confirmed,
+this service builds uncommitted (`is_confirmed=False`) rows for every subsequent
+month through `project.target_date`, scaling per-user percentages so the project's
+estimated completion lands on (or before) `target_date`.
+
+See monkut/kippo#240 decisions D1–D4 for the algorithm details.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from accounts.models import KippoUser
+from commons.functions import first_of_next_month
+from dateutil.relativedelta import relativedelta
+from django.db.models import Sum
+from django.utils import timezone
+
+from projects.exceptions import ProjectStartDateRequiredError
+from projects.models import MAX_ASSIGNMENT_PERCENTAGE, ProjectMonthlyAssignment
+from projects.services.forecast import ProjectAssignmentForecastManager
+
+if TYPE_CHECKING:
+    import datetime
+
+    from projects.models import KippoProject
+
+logger = logging.getLogger(__name__)
+
+ON_TARGET_TOLERANCE_DAYS = 3  # D1: skip scaling when estimated_completion ≤ target_date + 3 days
+SCALE_BINARY_SEARCH_ITERATIONS = 24  # D1: binary search depth — 24 halvings narrow s to ~1e-7
+SCALE_FACTOR_MIN = 1.0  # never scale percentages down
+
+
+def auto_create_future_assignments(project: KippoProject, triggered_by: KippoUser | None) -> list[ProjectMonthlyAssignment]:
+    """Create uncommitted future-month ProjectMonthlyAssignment rows for `project`.
+
+    Idempotent: returns `[]` and skips work if any future-month rows already exist
+    for the project, if the project is closed / has an actual date / has no
+    target_date / has no start_date, or if the seed shape is empty.
+
+    `triggered_by` is the user attributed as `created_by` / `updated_by` on the new
+    rows (D2). Resolved by the signal from the trigger row's `updated_by` (falling
+    back to `created_by`); may be `None` only when no provenance is recoverable.
+    """
+    if not _is_eligible(project):
+        return []
+
+    start_month = project.start_date.replace(day=1)
+    target_month = project.target_date.replace(day=1)
+    months = _future_months(start_month, target_month)
+    seed_pct = _compute_seed_shape(project, start_month)
+
+    blocking_conditions = (
+        ProjectMonthlyAssignment.objects.filter(project=project, month__gt=start_month).exists(),
+        not seed_pct,
+        not months,
+    )
+    if any(blocking_conditions):
+        return []
+
+    try:
+        scaled_pct = _scaled_percentages(project, seed_pct, months)
+    except ProjectStartDateRequiredError:
+        logger.warning("project %s: forecast raised ProjectStartDateRequiredError — skipping auto-create", project.pk)
+        return []
+    except Exception:
+        logger.exception("project %s: forecast raised unexpectedly — skipping auto-create", project.pk)
+        return []
+
+    return _persist(project, scaled_pct, months, triggered_by)
+
+
+def _is_eligible(project: KippoProject) -> bool:
+    if project.is_closed:
+        return False
+    if project.actual_date is not None:
+        return False
+    if project.start_date is None or project.target_date is None:
+        return False
+    start_month = project.start_date.replace(day=1)
+    return project.target_date > start_month
+
+
+def _compute_seed_shape(project: KippoProject, start_month: datetime.date) -> dict[int, int]:
+    """Per-user total percentage on the project's start month (D1 seed shape).
+
+    Sums across rows for the same `(user, start_month)` cell — typically one row per
+    user per month, but `Sum` guards against double-rows. Users with `percentage=0` are
+    excluded so they don't carry forward as zero-rows.
+    """
+    rows = (
+        ProjectMonthlyAssignment.objects.filter(project=project, month=start_month, is_confirmed=True, percentage__gt=0)
+        .values("user_id")
+        .annotate(total=Sum("percentage"))
+    )
+    return {row["user_id"]: row["total"] for row in rows if row["total"]}
+
+
+def _future_months(start_month: datetime.date, target_month: datetime.date) -> list[datetime.date]:
+    """Months from start_month + 1 through target_month inclusive (D3 — generate literally,
+    including past months when start_date is historical).
+    """
+    months: list[datetime.date] = []
+    current = start_month + relativedelta(months=1)
+    while current <= target_month:
+        months.append(current)
+        current += relativedelta(months=1)
+    return months
+
+
+def _scaled_percentages(
+    project: KippoProject,
+    seed_pct: dict[int, int],
+    months: list[datetime.date],
+) -> dict[int, int]:
+    """Return `{user_id: integer_pct}` after binary-search scaling + caps (D1).
+
+    Scaling preserves the per-user *ratio* from the seed shape. The scaled value lands
+    on each future month identically (flat across `months`). Caps are applied per-user
+    against (a) the org's `project_assignment_member_soft_ceiling` and (b) the absolute
+    `MAX_ASSIGNMENT_PERCENTAGE` after subtracting other-project commitments.
+    """
+    forecast_manager = ProjectAssignmentForecastManager(project)
+    target_date = project.target_date
+
+    # Skip scaling when the forecast has nothing meaningful to evaluate: no allocated_hours,
+    # or every overlay month is filtered out by forecast.py:106 (next_month_start cutoff).
+    next_month_start = first_of_next_month(timezone.localdate())
+    if project.allocated_effort_hours is None or all(month < next_month_start for month in months):
+        logger.info(
+            "project %s: forecast cannot evaluate scaling (no allocated_hours or all months in past) — persisting seed shape",
+            project.pk,
+        )
+        return _apply_caps(project, seed_pct, months)
+
+    # Tolerance check at seed (no-scale path).
+    seed_completion = forecast_manager.compute(overlay=_overlay(seed_pct, months)).estimated_completion_date
+    if _within_tolerance(seed_completion, target_date):
+        return _apply_caps(project, seed_pct, months)
+
+    s_max = _maximum_feasible_factor(project, seed_pct, months)
+    if s_max <= SCALE_FACTOR_MIN:
+        # Already at cap; ceil-rounded seed is the best we can do.
+        logger.warning("project %s: seed shape already at cap; cannot scale up to meet target_date", project.pk)
+        return _apply_caps(project, seed_pct, months)
+
+    factor = _binary_search_factor(forecast_manager, seed_pct, months, target_date, s_max)
+    scaled = {user_id: math.ceil(pct * factor) for user_id, pct in seed_pct.items()}
+    capped = _apply_caps(project, scaled, months)
+
+    final_completion = forecast_manager.compute(overlay=_overlay(capped, months)).estimated_completion_date
+    if final_completion is None or final_completion > target_date:
+        logger.warning(
+            "project %s: scaled team cannot land on target_date (estimated=%s, target=%s) — persisting at cap",
+            project.pk,
+            final_completion,
+            target_date,
+        )
+    return capped
+
+
+def _overlay(pct_per_user: dict[int, int], months: list[datetime.date]) -> dict[int, dict[datetime.date, int]]:
+    """Build the forecast overlay shape `{user_id: {month: pct}}` from a flat per-user map."""
+    return {user_id: dict.fromkeys(months, pct) for user_id, pct in pct_per_user.items() if pct > 0}
+
+
+def _within_tolerance(estimated: datetime.date | None, target: datetime.date) -> bool:
+    """D1: estimated completion is "good enough" when ≤ target_date + tolerance."""
+    if estimated is None:
+        return False
+    return (estimated - target).days <= ON_TARGET_TOLERANCE_DAYS
+
+
+def _maximum_feasible_factor(project: KippoProject, seed_pct: dict[int, int], months: list[datetime.date]) -> float:
+    """Largest scale factor that keeps every user under both the org soft ceiling AND
+    `MAX_ASSIGNMENT_PERCENTAGE − Σ(other org assignments)` for every month in `months`.
+
+    The binary search uses this as its upper bound so it never proposes a factor that
+    will be clipped by `_apply_caps` afterwards.
+    """
+    soft_ceiling = project.organization.project_assignment_member_soft_ceiling
+    other_load = _other_org_load(project, list(seed_pct.keys()), months)
+
+    factor_min = float("inf")
+    for user_id, seed in seed_pct.items():
+        if seed <= 0:
+            continue
+        per_user_cap = soft_ceiling
+        for month in months:
+            available = MAX_ASSIGNMENT_PERCENTAGE - other_load.get(user_id, {}).get(month, 0)
+            per_user_cap = min(per_user_cap, available)
+        if per_user_cap <= 0:
+            return SCALE_FACTOR_MIN
+        factor_min = min(factor_min, per_user_cap / seed)
+
+    return max(SCALE_FACTOR_MIN, factor_min if factor_min != float("inf") else SCALE_FACTOR_MIN)
+
+
+def _binary_search_factor(
+    forecast_manager: ProjectAssignmentForecastManager,
+    seed_pct: dict[int, int],
+    months: list[datetime.date],
+    target_date: datetime.date,
+    s_max: float,
+) -> float:
+    """Binary-search the smallest `s ∈ [1.0, s_max]` such that estimated_completion ≤ target_date.
+
+    The forecast is a step function over discrete days; the search converges on the
+    factor that places `estimated_completion ≤ target_date` even though the mapping
+    isn't continuous. Returns `s_max` if even the upper bound can't meet the target.
+    """
+    s_max_overlay = _overlay({user_id: math.ceil(pct * s_max) for user_id, pct in seed_pct.items()}, months)
+    s_max_completion = forecast_manager.compute(overlay=s_max_overlay).estimated_completion_date
+    if s_max_completion is None or s_max_completion > target_date:
+        return s_max  # caller will warn — best effort.
+
+    lo, hi = SCALE_FACTOR_MIN, s_max
+    for _ in range(SCALE_BINARY_SEARCH_ITERATIONS):
+        mid = (lo + hi) / 2.0
+        overlay = _overlay({user_id: math.ceil(pct * mid) for user_id, pct in seed_pct.items()}, months)
+        completion = forecast_manager.compute(overlay=overlay).estimated_completion_date
+        if completion is not None and completion <= target_date:
+            hi = mid
+        else:
+            lo = mid
+    return hi
+
+
+def _apply_caps(project: KippoProject, pct_per_user: dict[int, int], months: list[datetime.date]) -> dict[int, int]:
+    """Cap each user's percentage at min(soft_ceiling, MAX − other_org_load) across all months.
+
+    Per #240 D1, scaling overflow is "redistributed proportionally to remaining seed members"
+    only when the scaling step hits a cap. In practice the binary-search upper bound (`s_max`)
+    already keeps every user under the per-month cap, so this function is a defensive clamp:
+    it ensures we never persist a row that would breach the cap, and logs when clipping fires.
+    """
+    soft_ceiling = project.organization.project_assignment_member_soft_ceiling
+    other_load = _other_org_load(project, list(pct_per_user.keys()), months)
+
+    capped: dict[int, int] = {}
+    for user_id, pct in pct_per_user.items():
+        ceiling = soft_ceiling
+        for month in months:
+            available = MAX_ASSIGNMENT_PERCENTAGE - other_load.get(user_id, {}).get(month, 0)
+            ceiling = min(ceiling, available)
+        ceiling = max(ceiling, 0)
+        clipped = min(pct, ceiling)
+        if clipped < pct:
+            logger.warning(
+                "project %s: user %s scaled percentage %d clipped to %d (soft_ceiling=%d)",
+                project.pk,
+                user_id,
+                pct,
+                clipped,
+                soft_ceiling,
+            )
+        capped[user_id] = clipped
+    return capped
+
+
+def _other_org_load(
+    project: KippoProject,
+    user_ids: list[int],
+    months: list[datetime.date],
+) -> dict[int, dict[datetime.date, int]]:
+    """Sum each user's existing percentage across other projects in the same org for each month.
+
+    Excludes `project` itself — auto-created rows are about *this* project's allocation,
+    so the cap headroom is "100% minus what you've already promised elsewhere".
+    """
+    if not user_ids or not months:
+        return {}
+    rows = (
+        ProjectMonthlyAssignment.objects.filter(
+            project__organization=project.organization,
+            user_id__in=user_ids,
+            month__in=months,
+        )
+        .exclude(project=project)
+        .values("user_id", "month")
+        .annotate(total=Sum("percentage"))
+    )
+    out: dict[int, dict[datetime.date, int]] = defaultdict(dict)
+    for row in rows:
+        out[row["user_id"]][row["month"]] = row["total"] or 0
+    return out
+
+
+def _persist(
+    project: KippoProject,
+    pct_per_user: dict[int, int],
+    months: list[datetime.date],
+    triggered_by: KippoUser | None,
+) -> list[ProjectMonthlyAssignment]:
+    """D4: bulk_create the future rows in a single INSERT, skipping post_save + full_clean.
+
+    Drops users whose final per-user percentage clipped to 0 — persisting a 0% row would
+    look like an explicit "this user is on the project at zero" signal, which is not
+    what auto-create means.
+    """
+    valid_user_ids = [user_id for user_id, pct in pct_per_user.items() if pct > 0]
+    if not valid_user_ids:
+        return []
+
+    user_lookup = {u.id: u for u in KippoUser.objects.filter(id__in=valid_user_ids)}
+    rows: list[ProjectMonthlyAssignment] = []
+    for user_id in valid_user_ids:
+        user = user_lookup.get(user_id)
+        if user is None:
+            continue
+        pct = pct_per_user[user_id]
+        for month in months:
+            rows.append(
+                ProjectMonthlyAssignment(
+                    project=project,
+                    user=user,
+                    month=month,
+                    is_confirmed=False,
+                    percentage=pct,
+                    created_by=triggered_by,
+                    updated_by=triggered_by,
+                )
+            )
+    return ProjectMonthlyAssignment.objects.bulk_create(rows)
+
+
+def all_first_month_rows_confirmed(project: KippoProject) -> bool:
+    """Return True iff at least one row exists for the project's start month and every
+    such row has `is_confirmed=True`. Used by the post_save signal as the trigger guard.
+    """
+    if project.start_date is None:
+        return False
+    start_month = project.start_date.replace(day=1)
+    rows = ProjectMonthlyAssignment.objects.filter(project=project, month=start_month)
+    if not rows.exists():
+        return False
+    return not rows.filter(is_confirmed=False).exists()

--- a/kippo/projects/signals.py
+++ b/kippo/projects/signals.py
@@ -1,0 +1,59 @@
+"""Signal handlers for the projects app.
+
+Currently wires:
+
+- `post_save` on `ProjectMonthlyAssignment` → auto-create future-month rows when
+  every first-month row for the project becomes confirmed (kippo#240).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from projects.models import ProjectMonthlyAssignment
+from projects.services.autoassign import all_first_month_rows_confirmed, auto_create_future_assignments
+
+if TYPE_CHECKING:
+    from accounts.models import KippoUser
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_save, sender=ProjectMonthlyAssignment)
+def handle_first_month_full_confirmation(  # noqa: D401 — Django signal handler
+    sender: type[ProjectMonthlyAssignment],  # noqa: ARG001
+    instance: ProjectMonthlyAssignment,
+    created: bool,  # noqa: ARG001 — we react to confirmations, not pure creates
+    **kwargs,  # noqa: ARG001 — Django signal kwargs (raw, using, update_fields, etc.)
+) -> None:
+    """Trigger auto-create of future-month rows when the just-saved row's project is now
+    fully confirmed for its first month and has no future-month rows yet.
+
+    Defers execution via `transaction.on_commit` so the new rows are only persisted after
+    the originating save commits — avoids dangling future rows when the trigger save rolls
+    back. The auto-create routine itself is idempotent (it re-checks future-row presence
+    before persisting), but the on_commit deferral keeps the signal cleanly transactional.
+    """
+    if not instance.is_confirmed:
+        return
+    project = instance.project
+    if not all_first_month_rows_confirmed(project):
+        return
+
+    triggered_by: KippoUser | None = instance.updated_by or instance.created_by
+
+    def handle_commit() -> None:
+        try:
+            auto_create_future_assignments(project, triggered_by)
+        except Exception:
+            # Defensive: a failure in auto-create must never bubble up — the originating
+            # save has already committed by the time on_commit fires, but we still don't
+            # want test runs / admin saves to surface unrelated stack traces.
+            logger.exception("auto_create_future_assignments raised for project %s", project.pk)
+
+    transaction.on_commit(handle_commit)

--- a/kippo/projects/tests/test_autoassign.py
+++ b/kippo/projects/tests/test_autoassign.py
@@ -1,0 +1,389 @@
+"""Tests for the auto-create future-month assignment service + signal — kippo#240.
+
+Covers decisions D1–D4:
+- D1: scaling — binary search + ceil + 3-day tolerance.
+- D2: provenance — trigger row's `updated_by` (fallback to `created_by`).
+- D3: past-month rows generated literally start_month+1 through target_date.
+- D4: bulk_create persistence (no post_save recursion, no full_clean).
+"""
+
+import datetime
+from unittest.mock import patch
+
+from accounts.models import KippoUser, OrganizationMembership
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from dateutil.relativedelta import relativedelta
+from django.test import TestCase
+from django.utils import timezone
+
+from projects.models import KippoProject, ProjectMonthlyAssignment
+from projects.services.autoassign import (
+    all_first_month_rows_confirmed,
+    auto_create_future_assignments,
+)
+
+
+class AutoAssignTestCaseBase(TestCase):
+    """Shared fixture builder mirroring the suggester test base."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.organization.day_workhours = 8
+        self.organization.save()
+        self.user = created["KippoUser"]
+        self.project: KippoProject = created["KippoProject"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        # Project window relative to today: start_month = today's month, target = +6 months.
+        # Gives 6 future months that the forecast will actually project against (forecast.py:106
+        # filters anything < first_of_next_month(today)).
+        today = timezone.localdate()
+        self.start_month = today.replace(day=1)
+        self.project.start_date = self.start_month
+        self.project.target_date = self.start_month + relativedelta(months=6)
+        self.project.allocated_staff_days = 30
+        self.project.save()
+
+    def _add_member(self, username: str) -> KippoUser:
+        user = KippoUser.objects.create(username=username, email=f"{username}@example.com")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=self.organization,
+            is_developer=True,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        return user
+
+    def _make_assignment(
+        self,
+        *,
+        user: KippoUser | None = None,
+        month: datetime.date | None = None,
+        percentage: int,
+        is_confirmed: bool = False,
+        project: KippoProject | None = None,
+        created_by: KippoUser | None = None,
+        updated_by: KippoUser | None = None,
+    ) -> ProjectMonthlyAssignment:
+        return ProjectMonthlyAssignment.objects.create(
+            project=project or self.project,
+            user=user or self.user,
+            month=month or self.start_month,
+            percentage=percentage,
+            is_confirmed=is_confirmed,
+            created_by=created_by or self.github_manager,
+            updated_by=updated_by or self.github_manager,
+        )
+
+
+class AutoAssignServiceTestCase(AutoAssignTestCaseBase):
+    """Direct unit tests of `auto_create_future_assignments` — bypasses the signal."""
+
+    # ----------------------------------------------------------- eligibility / no-op
+
+    def test_no_op_when_project_is_closed(self):
+        self._make_assignment(percentage=50, is_confirmed=True)
+        self.project.is_closed = True
+        self.project.save()
+
+        rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+        self.assertEqual(ProjectMonthlyAssignment.objects.filter(project=self.project).count(), 1)
+
+    def test_no_op_when_actual_date_set(self):
+        self._make_assignment(percentage=50, is_confirmed=True)
+        self.project.actual_date = self.start_month + relativedelta(months=2)
+        self.project.save()
+
+        rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+
+    def test_no_op_when_target_date_missing(self):
+        self._make_assignment(percentage=50, is_confirmed=True)
+        self.project.target_date = None
+        self.project.save()
+
+        rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+
+    def test_no_op_when_target_date_le_start_month(self):
+        self._make_assignment(percentage=50, is_confirmed=True)
+        self.project.target_date = self.start_month + datetime.timedelta(days=15)  # within start_month
+        self.project.save()
+
+        rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+
+    def test_no_op_when_start_date_missing(self):
+        # Can't seed without a first month.
+        self.project.start_date = None
+        self.project.save()
+        rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+
+    def test_no_op_when_no_first_month_rows(self):
+        rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+
+    def test_no_op_when_seed_all_zero(self):
+        # _make_assignment with percentage=0 still creates a row (model allows 0).
+        # Such rows are excluded by the seed query (`percentage__gt=0`); seed becomes empty.
+        self._make_assignment(percentage=0, is_confirmed=True)
+        rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+
+    def test_skips_when_future_rows_already_exist(self):
+        self._make_assignment(percentage=50, is_confirmed=True)
+        # Pre-existing future-month row → idempotency guard fires.
+        self._make_assignment(month=self.start_month + relativedelta(months=2), percentage=20, is_confirmed=False)
+
+        rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+        # Only the seed + the pre-existing row should be present.
+        self.assertEqual(ProjectMonthlyAssignment.objects.filter(project=self.project).count(), 2)
+
+    # --------------------------------------------------------------- months generated (D3)
+
+    def test_creates_one_row_per_seed_user_per_future_month(self):
+        # 6 future months: start_month+1 through target_month inclusive.
+        self._make_assignment(percentage=50, is_confirmed=True)
+
+        created = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(len(created), 6)
+        months = sorted({row.month for row in created})
+        self.assertEqual(months[0], self.start_month + relativedelta(months=1))
+        self.assertEqual(months[-1], self.start_month + relativedelta(months=6))
+        self.assertEqual(len(months), 6)
+
+    def test_generates_past_months_when_start_date_is_historical(self):
+        # D3: past-month rows persisted even though forecast.py:106 will ignore them.
+        # Project window: 2020-01-01 → 2020-07-01 — fully historical relative to today.
+        self.project.start_date = datetime.date(2020, 1, 1)
+        self.project.target_date = datetime.date(2020, 7, 1)
+        self.project.save()
+        self.start_month = datetime.date(2020, 1, 1)
+        self._make_assignment(month=self.start_month, percentage=50, is_confirmed=True)
+
+        created = auto_create_future_assignments(self.project, self.github_manager)
+        # 6 historical months persisted: 2020-02-01 through 2020-07-01.
+        self.assertEqual(len(created), 6)
+
+    # -------------------------------------------------------------------- D2: provenance
+
+    def test_uses_trigger_row_updated_by_for_created_by_and_updated_by(self):
+        actor = self._add_member("trigger-actor")
+        self._make_assignment(percentage=50, is_confirmed=True, updated_by=actor)
+
+        created = auto_create_future_assignments(self.project, actor)
+        self.assertTrue(created)
+        for row in created:
+            self.assertEqual(row.created_by_id, actor.id)
+            self.assertEqual(row.updated_by_id, actor.id)
+
+    def test_falls_back_to_created_by_when_updated_by_is_none(self):
+        # Simulate the signal's resolution: updated_by None → created_by.
+        # Service receives whatever `triggered_by` the signal resolved.
+        self._make_assignment(percentage=50, is_confirmed=True)
+        created = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertTrue(created)
+        for row in created:
+            self.assertEqual(row.created_by_id, self.github_manager.id)
+
+    # ----------------------------------------------------------- D1: scaling math
+
+    def test_within_tolerance_seed_unchanged(self):
+        # Seed already lands close enough: don't scale, persist seed as-is.
+        # 50% × 8h × ~5 weekdays/week → roughly 100h/month → completes well before target.
+        self._make_assignment(percentage=50, is_confirmed=True)
+        created = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertTrue(created)
+        # Fast seed → no scaling: every row keeps the seed percentage.
+        for row in created:
+            self.assertEqual(row.percentage, 50)
+
+    def test_slow_seed_is_scaled_up(self):
+        # Single 5% seed produces ~1h/day. 240h ÷ 1h/day far exceeds the project window
+        # → binary search will scale up.
+        self._make_assignment(percentage=5, is_confirmed=True)
+        created = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertTrue(created)
+        seed_pct = 5
+        # Every persisted row should be > seed (scaled up by ceil).
+        self.assertTrue(all(row.percentage > seed_pct for row in created))
+
+    def test_persisted_percentage_capped_at_org_soft_ceiling(self):
+        # With soft ceiling 75%, a single user can never persist > 75% per month.
+        self.organization.project_assignment_member_soft_ceiling = 75
+        self.organization.save()
+        self._make_assignment(percentage=5, is_confirmed=True)
+
+        created = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertTrue(created)
+        for row in created:
+            self.assertLessEqual(row.percentage, 75)
+
+    def test_other_org_load_reduces_per_user_cap(self):
+        # User has 60% on a *different* project for the next month → cap shrinks to 40% there.
+        other_project = KippoProject.objects.create(
+            organization=self.organization,
+            name="other-project",
+            github_project_html_url="https://github.com/orgs/myorg/projects/99",
+            github_project_api_nodeid="PVT_kwDOOTHER",
+            columnset=self.project.columnset,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self._make_assignment(percentage=5, is_confirmed=True)  # seed
+        ProjectMonthlyAssignment.objects.create(
+            project=other_project,
+            user=self.user,
+            month=self.start_month + relativedelta(months=1),
+            percentage=60,
+            is_confirmed=True,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        created = auto_create_future_assignments(self.project, self.github_manager)
+        # Per-user cap across all months = min(soft_ceiling=75, 100-60 in Feb) = 40.
+        self.assertTrue(created)
+        for row in created:
+            self.assertLessEqual(row.percentage, 40)
+
+    # ------------------------------------------------------- D4: bulk_create persistence
+
+    def test_persisted_rows_are_unconfirmed(self):
+        self._make_assignment(percentage=50, is_confirmed=True)
+        created = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertTrue(created)
+        for row in created:
+            self.assertFalse(row.is_confirmed)
+
+    def test_forecast_failure_is_swallowed(self):
+        self._make_assignment(percentage=50, is_confirmed=True)
+        with patch(
+            "projects.services.autoassign.ProjectAssignmentForecastManager.compute",
+            side_effect=RuntimeError("boom"),
+        ):
+            rows = auto_create_future_assignments(self.project, self.github_manager)
+        self.assertEqual(rows, [])
+
+
+class AutoAssignSignalTestCase(AutoAssignTestCaseBase):
+    """Signal wiring: post_save trigger + transaction.on_commit semantics."""
+
+    def test_confirming_last_first_month_row_triggers_creation(self):
+        actor = self._add_member("actor")
+        # Two unconfirmed first-month rows.
+        self._make_assignment(user=self.user, percentage=30, is_confirmed=False)
+        second = self._make_assignment(user=actor, percentage=20, is_confirmed=False)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            second.is_confirmed = True
+            second.updated_by = actor
+            second.save()
+        # Confirming a non-last row first.
+        self.assertEqual(
+            ProjectMonthlyAssignment.objects.filter(project=self.project, month__gt=self.start_month).count(),
+            0,
+        )
+
+        first = ProjectMonthlyAssignment.objects.get(project=self.project, user=self.user, month=self.start_month)
+        with self.captureOnCommitCallbacks(execute=True):
+            first.is_confirmed = True
+            first.updated_by = actor
+            first.save()
+        future = ProjectMonthlyAssignment.objects.filter(project=self.project, month__gt=self.start_month)
+        # 2 seed users × 6 future months = 12 rows.
+        self.assertEqual(future.count(), 12)
+        for row in future:
+            self.assertEqual(row.updated_by_id, actor.id)
+
+    def test_confirming_non_last_row_does_not_trigger(self):
+        self._make_assignment(user=self.user, percentage=30, is_confirmed=False)
+        actor = self._add_member("actor2")
+        self._make_assignment(user=actor, percentage=20, is_confirmed=False)
+
+        first = ProjectMonthlyAssignment.objects.get(user=self.user, month=self.start_month)
+        with self.captureOnCommitCallbacks(execute=True):
+            first.is_confirmed = True
+            first.save()
+        self.assertEqual(
+            ProjectMonthlyAssignment.objects.filter(project=self.project, month__gt=self.start_month).count(),
+            0,
+        )
+
+    def test_resaving_already_confirmed_row_does_not_duplicate(self):
+        # Wrap creation in captureOnCommitCallbacks so the post_save's transaction.on_commit
+        # callback actually runs — TestCase rolls back at end-of-test, so on_commit normally
+        # never fires.
+        with self.captureOnCommitCallbacks(execute=True):
+            seed = self._make_assignment(percentage=50, is_confirmed=True)
+        first_count = ProjectMonthlyAssignment.objects.filter(project=self.project, month__gt=self.start_month).count()
+        self.assertEqual(first_count, 6)
+
+        # Re-save: idempotency guard skips because future rows exist.
+        with self.captureOnCommitCallbacks(execute=True):
+            seed.percentage = 51
+            seed.save()
+        self.assertEqual(
+            ProjectMonthlyAssignment.objects.filter(project=self.project, month__gt=self.start_month).count(),
+            6,
+        )
+
+    def test_bulk_create_does_not_recursively_fire_signal(self):
+        # Seed → service is invoked → bulk_create persists 6 rows. Each persisted row
+        # would trigger post_save if we used .save(); bulk_create skips that, and the
+        # idempotency guard would defend the second invocation regardless.
+        seed = self._make_assignment(percentage=50, is_confirmed=False)
+
+        signal_calls: list[int] = []
+
+        def counter(sender: type[ProjectMonthlyAssignment], instance: ProjectMonthlyAssignment, created: bool, **kwargs) -> None:  # noqa: ARG001
+            signal_calls.append(instance.pk)
+
+        from django.db.models.signals import post_save
+
+        post_save.connect(counter, sender=ProjectMonthlyAssignment)
+        try:
+            with self.captureOnCommitCallbacks(execute=True):
+                seed.is_confirmed = True
+                seed.save()
+        finally:
+            post_save.disconnect(counter, sender=ProjectMonthlyAssignment)
+
+        # Exactly one post_save fire (the trigger row's). The 6 bulk_created children fire none.
+        self.assertEqual(len(signal_calls), 1)
+        self.assertEqual(signal_calls[0], seed.pk)
+        self.assertEqual(
+            ProjectMonthlyAssignment.objects.filter(project=self.project, month__gt=self.start_month).count(),
+            6,
+        )
+
+
+class AllFirstMonthRowsConfirmedTestCase(AutoAssignTestCaseBase):
+    """Smoke tests for the trigger predicate."""
+
+    def test_returns_false_when_start_date_missing(self):
+        self.project.start_date = None
+        self.project.save()
+        self.assertFalse(all_first_month_rows_confirmed(self.project))
+
+    def test_returns_false_when_no_rows_for_start_month(self):
+        self.assertFalse(all_first_month_rows_confirmed(self.project))
+
+    def test_returns_false_when_any_row_unconfirmed(self):
+        self._make_assignment(percentage=30, is_confirmed=True)
+        actor = self._add_member("actor3")
+        self._make_assignment(user=actor, percentage=20, is_confirmed=False)
+        self.assertFalse(all_first_month_rows_confirmed(self.project))
+
+    def test_returns_true_when_every_row_confirmed(self):
+        self._make_assignment(percentage=30, is_confirmed=True)
+        actor = self._add_member("actor4")
+        self._make_assignment(user=actor, percentage=20, is_confirmed=True)
+        self.assertTrue(all_first_month_rows_confirmed(self.project))


### PR DESCRIPTION
Implements [#240](https://github.com/monkut/kippo/issues/240) — auto-create future-month `ProjectMonthlyAssignment` rows when every first-month row for a project transitions to `is_confirmed=True`. Per-user percentages are binary-search scaled so the project's estimated completion lands at-or-before `target_date` (3-day tolerance), preserving the seed shape's per-user ratio.

Closes the day-zero gap surfaced in [kippo-ui#57](https://github.com/monkut/kippo-ui/issues/57) / [kippo-ui#61](https://github.com/monkut/kippo-ui/pull/61): once a PM confirms the first month's allocations from the UI, every downstream month is bootstrapped automatically.

## Surface

`projects.services.autoassign.auto_create_future_assignments(project, triggered_by)` plus a `post_save` signal on `ProjectMonthlyAssignment` that wires the trigger.

## Decisions implemented (from #240)

| # | Decision | Where |
|---|---|---|
| D1 | Binary search `s ∈ [1.0, s_max]` + `math.ceil` + 3-day tolerance | `_scaled_percentages`, `_binary_search_factor` |
| D2 | Provenance = trigger row's `updated_by` (fallback `created_by`) | `signals.py` |
| D3 | Generate rows literally for `start_month+1 → target_date` (incl. past months) | `_future_months` |
| D4 | `bulk_create` skipping `full_clean()` (no signal recursion, no membership re-check) | `_persist` |

Signal uses `transaction.on_commit(...)` so the trigger save committing failure doesn't leave dangling future rows.

## Behavior

**Trigger:** `post_save` on `ProjectMonthlyAssignment` → if `is_confirmed=True` AND every first-month row for the project is confirmed AND no future-month rows exist yet → schedule `auto_create_future_assignments` on commit.

**Scaling:**
- Tolerance: if `estimated_completion ≤ target_date + 3 days`, persist seed unchanged.
- Forecast inconclusive (no `allocated_effort_hours`, or every overlay month is in the past per `forecast.py:106`): persist seed unchanged.
- Otherwise: binary-search for the smallest factor that lands on-target, then ceil-round each user's percentage. `s_max` is bounded above by per-user soft ceiling (`organization.project_assignment_member_soft_ceiling`) AND `MAX_ASSIGNMENT_PERCENTAGE − Σ(other org assignments)` to prevent the search from proposing a value the cap will clip.
- Even at `s_max`, if forecast still says infeasible: persist at cap + warn (mirrors #224 B11 thin-pattern behaviour).

**Idempotency:**
- Re-saving an already-confirmed first-month row → guard sees future rows exist → no-op.
- Bulk-create skips `post_save`, so children don't recursively re-trigger the predicate.

**No-op cases:** `is_closed=True`, `actual_date is not None`, `start_date/target_date is None`, `target_date ≤ start_month`, no first-month rows, all-zero seed, future rows already exist.

## Tests

26 new tests in `kippo/projects/tests/test_autoassign.py`:

- **Eligibility / no-op (8):** closed project, `actual_date` set, missing target/start, target ≤ start, no rows, all-zero seed, idempotency.
- **Months generated (2):** D3 row count + bounds, historical project (past months persisted).
- **Provenance (2):** D2 `updated_by` flows through, fallback to `created_by`.
- **Scaling math (4):** within-tolerance no-scale, slow seed scales up, soft-ceiling cap, other-org-load reduces cap.
- **Persistence (2):** `is_confirmed=False` on outputs, forecast exception swallowed.
- **Signal (4):** last first-month row triggers, non-last does nothing, idempotent re-save, `bulk_create` does not recursively fire.
- **Predicate (4):** `all_first_month_rows_confirmed` smoke tests.

```
Ran 26 tests in 0.733s — OK
```

Full project-app suite touching `ProjectMonthlyAssignment` (`test_projectmonthlyassignment`, `test_suggest`, `test_forecast`, `test_autoassign`, `test_admin`): 148 / 148 passing.

`uv run poe check` clean.

## Net diff

+795 / -0 across 4 files (1 modified `apps.py`, 3 new). 0 migrations.

## Out of scope (future follow-ups)

- Backfill management command for projects already in the all-confirmed state when this ships.
- `target_date`-extension top-up endpoint (per #240 edge cases).
- Admin / API action to wipe stale future rows after a re-unconfirm.