### PR TITLE
fix(db+migrations): rustyhip OPTIONS endpoint + SQLite-safe 0034 migration

### DIFF
--- a/kippo/kippo/settings.py
+++ b/kippo/kippo/settings.py
@@ -127,16 +127,18 @@ MEDIA_URL = os.getenv("MEDIA_URL", "/media/")
 
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
-DATABASES = {
-    "default": {
-        "ENGINE": os.getenv("DB_ENGINE", "django.db.backends.postgresql"),
-        "NAME": os.getenv("DB_NAME", "kippo"),
-        "USER": os.getenv("DB_USER", "postgres"),
-        "PASSWORD": os.getenv("DB_PASSWORD", "mysecretpassword"),
-        "HOST": os.getenv("DB_HOST", "127.0.0.1"),
-        "PORT": os.getenv("DB_PORT", "5432"),
-    }
+_db_engine = os.getenv("DB_ENGINE", "django.db.backends.postgresql")
+_db_config: dict = {
+    "ENGINE": _db_engine,
+    "NAME": os.getenv("DB_NAME", "kippo"),
+    "USER": os.getenv("DB_USER", "postgres"),
+    "PASSWORD": os.getenv("DB_PASSWORD", "mysecretpassword"),
+    "HOST": os.getenv("DB_HOST", "127.0.0.1"),
+    "PORT": os.getenv("DB_PORT", "5432"),
 }
+if _db_engine == "rustyhip":
+    _db_config["OPTIONS"] = {"endpoint": os.getenv("RUSTYHIP_ENDPOINT", "http://localhost:9000")}
+DATABASES = {"default": _db_config}
 
 
 # Password validation

--- a/kippo/projects/migrations/0034_alter_projectcolumnset_label_category_prefixes_and_more.py
+++ b/kippo/projects/migrations/0034_alter_projectcolumnset_label_category_prefixes_and_more.py
@@ -3,6 +3,57 @@
 import projects.models
 from django.db import migrations, models
 
+# Recreate projects_projectcolumnset in one shot to avoid SQLite rejecting the
+# postgres-specific varchar(10)[] column type when _remake_table copies the old
+# schema during an AlterField call. Running both AlterField ops via raw SQL lets
+# us write the final schema directly without going through PRAGMA table_info.
+_CREATE_NEW = """
+CREATE TABLE "new__projects_projectcolumnset" (
+    "id" char(32) NOT NULL PRIMARY KEY,
+    "name" varchar(256) NOT NULL,
+    "created_datetime" datetime NOT NULL,
+    "updated_datetime" datetime NOT NULL,
+    "label_category_prefixes" text NULL CHECK ((JSON_VALID("label_category_prefixes") OR "label_category_prefixes" IS NULL)),
+    "label_estimate_prefixes" text NULL CHECK ((JSON_VALID("label_estimate_prefixes") OR "label_estimate_prefixes" IS NULL)),
+    "organization_id" char(32) NULL REFERENCES "accounts_kippoorganization" ("id") DEFERRABLE INITIALLY DEFERRED,
+    "default_column_name" varchar(256) NOT NULL
+)
+"""
+
+_COPY_DATA = """
+INSERT INTO "new__projects_projectcolumnset"
+    SELECT "id", "name", "created_datetime", "updated_datetime",
+           "label_category_prefixes", "label_estimate_prefixes",
+           "organization_id", "default_column_name"
+    FROM "projects_projectcolumnset"
+"""
+
+_DROP_OLD = 'DROP TABLE "projects_projectcolumnset"'
+
+_RENAME = 'ALTER TABLE "new__projects_projectcolumnset" RENAME TO "projects_projectcolumnset"'
+
+# Reverse: plain text columns (no CHECK), compatible with pre-migration state
+_BWD_CREATE_NEW = """
+CREATE TABLE "new__projects_projectcolumnset" (
+    "id" char(32) NOT NULL PRIMARY KEY,
+    "name" varchar(256) NOT NULL,
+    "created_datetime" datetime NOT NULL,
+    "updated_datetime" datetime NOT NULL,
+    "label_category_prefixes" text NULL,
+    "label_estimate_prefixes" text NULL,
+    "organization_id" char(32) NULL REFERENCES "accounts_kippoorganization" ("id") DEFERRABLE INITIALLY DEFERRED,
+    "default_column_name" varchar(256) NOT NULL
+)
+"""
+
+_BWD_COPY_DATA = _COPY_DATA.replace('"new__projects_projectcolumnset"', '"bwd__projects_projectcolumnset"').replace(
+    '"projects_projectcolumnset"', '"new__projects_projectcolumnset"'
+)
+
+_BWD_DROP_OLD = 'DROP TABLE "new__projects_projectcolumnset"'
+
+_BWD_RENAME = 'ALTER TABLE "bwd__projects_projectcolumnset" RENAME TO "projects_projectcolumnset"'
+
 
 class Migration(migrations.Migration):
 
@@ -11,14 +62,24 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name='projectcolumnset',
-            name='label_category_prefixes',
-            field=models.JSONField(blank=True, default=projects.models.category_prefixes_default, help_text='Github Issue Labels Category Prefixes', null=True),
-        ),
-        migrations.AlterField(
-            model_name='projectcolumnset',
-            name='label_estimate_prefixes',
-            field=models.JSONField(blank=True, default=projects.models.estimate_prefixes_default, help_text='Github Issue Labels Estimate Prefixes', null=True),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(sql=_CREATE_NEW, reverse_sql=migrations.RunSQL.noop),
+                migrations.RunSQL(sql=_COPY_DATA, reverse_sql=migrations.RunSQL.noop),
+                migrations.RunSQL(sql=_DROP_OLD, reverse_sql=migrations.RunSQL.noop),
+                migrations.RunSQL(sql=_RENAME, reverse_sql=migrations.RunSQL.noop),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name='projectcolumnset',
+                    name='label_category_prefixes',
+                    field=models.JSONField(blank=True, default=projects.models.category_prefixes_default, help_text='Github Issue Labels Category Prefixes', null=True),
+                ),
+                migrations.AlterField(
+                    model_name='projectcolumnset',
+                    name='label_estimate_prefixes',
+                    field=models.JSONField(blank=True, default=projects.models.estimate_prefixes_default, help_text='Github Issue Labels Estimate Prefixes', null=True),
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
## Summary

- **settings.py**: Pass `RUSTYHIP_ENDPOINT` to `DATABASES['default']['OPTIONS']['endpoint']` when `DB_ENGINE=rustyhip`. The `django-rustyhip` backend requires `OPTIONS['endpoint']` — it does not read `HOST`.
- **projects/0034**: Replace `AlterField` operations with `RunSQL` + `SeparateDatabaseAndState`. When Django's SQLite schema editor remakes the table for the first `AlterField`, it copies the unmodified `label_estimate_prefixes varchar(10)[]` type from `PRAGMA table_info()` into the new CREATE TABLE — which rustyhip/SQLite rejects. The `RunSQL` approach writes both fields' final schema in a single operation, bypassing `_remake_table` entirely.

## Test plan

- [x] `zappa manage dev migrate` completes without errors
- [x] Admin login at `/dev/admin/login/` returns 200
- [x] Login with credentials succeeds (302 → `/dev/admin/`)
- [x] Superuser `shane` confirmed active

## Deployment

- Lambda: `https://mnzyopnb1c.execute-api.us-west-2.amazonaws.com/dev`
- `DB_ENGINE=rustyhip` must be set in Lambda env (already applied manually; add to `zappa_settings.json` on the deploy machine)