### PR TITLE
fix(static): wire STORAGES with kippo-ui-aware CompressedManifestStaticFilesStorage (#262)

### DIFF
--- a/kippo/commons/storage.py
+++ b/kippo/commons/storage.py
@@ -1,0 +1,42 @@
+"""Static-files storage subclasses for kippo.
+
+`KippoStaticFilesStorage` wires WhiteNoise's compressed-manifest backend into
+Django's 5.1+ ``STORAGES`` API while leaving the kippo-ui SPA bundle untouched.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+
+from django.core.files.base import File
+from whitenoise.storage import CompressedManifestStaticFilesStorage
+
+
+class KippoStaticFilesStorage(CompressedManifestStaticFilesStorage):
+    """Manifest + compression for Django assets; bypasses both for the kippo-ui bundle.
+
+    Vite pre-hashes the SPA assets (e.g. ``entry.client-B8yIs_ty.js``) and the
+    SPA's ``index.html`` hard-codes those filenames as plain ``<script>`` /
+    ``<link>`` tags. Letting Django re-hash them at ``collectstatic`` would 404
+    every reference on ``/prod/ui/*``.
+
+    The ``ui/`` prefix is therefore:
+      * not hashed (``hashed_name`` returns the input verbatim), and
+      * skipped from ``post_process`` so neither Django's URL rewriter nor
+        WhiteNoise's ``.gz`` writer touches the Vite output.
+
+    Admin and other Django-owned assets are hashed and compressed normally.
+    ``manifest_strict = False`` lets any future ``{% static "ui/..." %}`` call
+    fall back to the verbatim path instead of raising.
+    """
+
+    manifest_strict = False
+    _UI_PREFIX = "ui/"
+
+    def hashed_name(self, name: str, content: File | None = None, filename: str | None = None) -> str:
+        if name.startswith(self._UI_PREFIX):
+            return name
+        return super().hashed_name(name, content, filename)
+
+    def post_process(self, paths: dict[str, Any], **options: Any) -> Iterator[tuple[str, str, bool]]:  # noqa: ANN401
+        django_paths = {k: v for k, v in paths.items() if not k.startswith(self._UI_PREFIX)}
+        yield from super().post_process(django_paths, **options)

--- a/kippo/commons/tests/test_storage.py
+++ b/kippo/commons/tests/test_storage.py
@@ -1,0 +1,35 @@
+from django.core.files.base import ContentFile
+from django.test import SimpleTestCase
+
+from commons.storage import KippoStaticFilesStorage
+
+
+class KippoStaticFilesStorageTestCase(SimpleTestCase):
+    def setUp(self) -> None:
+        self.storage = KippoStaticFilesStorage()
+
+    def test_hashed_name_passes_ui_paths_through_verbatim(self) -> None:
+        # Vite-pre-hashed asset under the SPA bundle prefix.
+        name = "ui/assets/entry.client-B8yIs_ty.js"
+
+        result = self.storage.hashed_name(name, content=ContentFile(b"console.log('vite');"))
+
+        assert result == name, (
+            "ui/ paths must be returned verbatim so Vite's pre-hashed filenames are not "
+            "double-hashed (which would 404 every <script>/<link> in the SPA's index.html)."
+        )
+
+    def test_hashed_name_hashes_admin_paths(self) -> None:
+        name = "admin/css/base.css"
+        content = ContentFile(b"body { color: red; }")
+
+        result = self.storage.hashed_name(name, content=content)
+
+        assert result != name, "Admin assets must be content-hashed for cache-busting."
+        assert result.startswith("admin/css/base."), f"Expected hashed name to keep prefix and ext, got {result!r}"
+        assert result.endswith(".css"), f"Expected hashed name to keep .css ext, got {result!r}"
+
+    def test_manifest_strict_is_false(self) -> None:
+        # manifest_strict=False lets {% static "ui/..." %} lookups fall back gracefully
+        # when the path is intentionally absent from staticfiles.json.
+        assert self.storage.manifest_strict is False

--- a/kippo/kippo/settings.py
+++ b/kippo/kippo/settings.py
@@ -94,7 +94,13 @@ MIDDLEWARE = [
 
 # https://github.com/evansd/whitenoise/issues/164
 WHITENOISE_STATIC_PREFIX = "/static/"
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+# Django 5.1 removed STATICFILES_STORAGE; STORAGES is the supported API.
+# KippoStaticFilesStorage hashes Django assets but passes the Vite-pre-hashed
+# kippo-ui bundle through verbatim — see commons/storage.py for the why.
+STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "commons.storage.KippoStaticFilesStorage"},
+}
 
 ROOT_URLCONF = "kippo.urls"
 


### PR DESCRIPTION
Closes #262.

## Summary

- `STATICFILES_STORAGE` was removed in Django 5.1, so the line at `kippo/kippo/settings.py:97` was silently ignored on the pinned `django>=5.2,<5.3`. Production has been running without `staticfiles.json` and without admin-asset cache-busting.
- The naive fix (swap in `whitenoise.storage.CompressedManifestStaticFilesStorage` via the new `STORAGES` dict — PR #259's approach) breaks the kippo-ui SPA: Vite already pre-hashes its assets and the SPA's `index.html` hard-codes those filenames, so Django double-hashes on top and 404s every `<script>`/`<link>` on `/prod/ui/*`.
- This PR wires the manifest backend via a custom subclass `commons.storage.KippoStaticFilesStorage` that bypasses both `hashed_name` and `post_process` for any path under `ui/`. Admin and other Django-owned assets are hashed and gzip-compressed normally; the Vite bundle is copied through verbatim.

## Why a subclass instead of the non-manifest variant

Issue #262 originally proposed `CompressedStaticFilesStorage` (non-manifest) — but that gives up admin-asset cache-busting. The subclass approach keeps the manifest benefit for everything we own while protecting the third-party Vite bundle we don't.

`HashedFilesMixin.hashed_name()` (Django's `staticfiles/storage.py:135`) is the only place Django decides the final on-disk name. Returning the input verbatim for `ui/` paths means:
- The file is "saved" under its source name (no `.<hash>` suffix injected).
- The manifest entry is `name → name`, so `stored_name()` / `url()` resolve to the source name if anyone ever does call `{% static "ui/..." %}`.
- Per-reference URL rewriting in adjustable files (Django's `_url()`) also routes through `hashed_name()`, so `import`/`url(...)` inside `ui/` CSS/JS that resolves to a `ui/` sibling is rewritten to the same name (no-op).

The `post_process` filter is belt-and-suspenders — it skips Django's adjustable-file pass (Django 5 treats `.js` as adjustable for `import` rewriting) and avoids WhiteNoise writing `.gz` siblings for the Vite bundle (CloudFront edge-gzip already handles `ui/` compression).

`manifest_strict = False` lets any future `{% static "ui/..." %}` call fall back to the verbatim path instead of raising on a missing manifest entry.

## Local verification

Ran `collectstatic --noinput --clear` into a throwaway STATIC_ROOT and confirmed:

| Check | Result |
|---|---|
| `staticfiles.json` generated | yes |
| `ui/...` entries in manifest | **0** |
| `admin/css/base.css` → `admin/css/base.96c479cedf7a.css` | yes |
| `ui/assets/entry.client-B8yIs_ty.js` kept Vite-hashed only | yes, no Django suffix |
| `ui/` files with `.<12hex>.` pattern | **0** of 29 |
| `.gz` companions under `admin/` | yes |
| `.gz` companions under `ui/` | **0** (expected; CloudFront edge-gzip handles it) |

`uv run poe check` passes. `commons.tests.test_storage` (3 cases) passes.

## Files

- `kippo/commons/storage.py` *(new)* — `KippoStaticFilesStorage`.
- `kippo/commons/tests/test_storage.py` *(new)* — unit tests asserting `hashed_name("ui/...")` returns verbatim and `hashed_name("admin/...")` is content-hashed.
- `kippo/kippo/settings.py` — line 97 replaced with the `STORAGES` dict.

## Test plan

- [ ] CI passes (Django 5.2 test suite).
- [ ] Post-merge: deploy and verify
  - [ ] `curl https://.../prod/admin/login/` → admin asset URLs are content-hashed.
  - [ ] `curl https://.../prod/ui/weekly-effort` → SPA loads, every `<script src>`/`<link href>` returns 200.
  - [ ] Real-browser mount via the procedure in `CLAUDE.md → Frontend UI benchmarking procedure` — no console 404s.

## References

- Closes #262.
- Supersedes the non-manifest framing initially proposed in this issue.
- Supersedes PR #259 (manifest-without-subclass attempt that broke the SPA).
- Builds on the kippo-ui static-files context documented in #260 / #261.
