### PR TITLE
feat(update_ui): --base-prefix for stage-matched kippo-ui tarballs (#264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,16 +182,16 @@ Resolution order, highest precedence first:
 1. `--tarball-name <name>` — explicit override (existing escape hatch from #256)
 2. `--base-prefix <prefix>` — mapped via the `TARBALL_BY_PREFIX` table
 3. `KIPPO_UI_BASE_PREFIX` env var — same mapping as `--base-prefix`
-4. Default — `kippo-ui-build-prod.tar.gz` (preserved, no production regression)
+4. Default `--base-prefix=/prod` → `kippo-ui-build-prod.tar.gz` (no production regression)
 
 Known prefixes and their tarballs:
 
-| `--base-prefix` | Release asset                  |
-| ---             | ---                            |
-| (unset / `""`)  | `kippo-ui-build-prod.tar.gz`   |
-| `/prod`         | `kippo-ui-build-prod.tar.gz`   |
-| `/stg`          | `kippo-ui-build-stg.tar.gz`    |
-| `/dev`          | `kippo-ui-build-dev.tar.gz`    |
+| `--base-prefix`     | Release asset                  |
+| ---                 | ---                            |
+| (unset, defaults to `/prod`) | `kippo-ui-build-prod.tar.gz` |
+| `/prod`             | `kippo-ui-build-prod.tar.gz`   |
+| `/stg`              | `kippo-ui-build-stg.tar.gz`    |
+| `/dev`              | `kippo-ui-build-dev.tar.gz`    |
 
 An unknown `--base-prefix` (e.g. `/staging`) fails fast with a `CommandError`
 that lists the known prefixes — use `--tarball-name=<name>` to override

--- a/README.md
+++ b/README.md
@@ -157,6 +157,46 @@ uv run python manage.py collectstatic --noinput
 > 404 from Django even though the API still works — the `update_ui` step alone
 > writes to the source directory only, not to `STATIC_ROOT`.
 
+### Stage-matched UI bundles (`--base-prefix` / `KIPPO_UI_BASE_PREFIX`)
+
+The kippo-ui Vite bundle hard-codes its asset `base` URL at build time. To serve
+the SPA from a non-prod API Gateway stage (e.g. the `dev` stage where assets
+live under `/dev/static/ui/...`), select the stage-matched tarball with
+`--base-prefix`:
+
+```bash
+# Dev stage (Zappa dev stage, URL_PREFIX=dev)
+uv run python manage.py update_ui --base-prefix=/dev
+uv run python manage.py collectstatic --noinput
+
+# Or via env var (no poe-task changes needed)
+KIPPO_UI_BASE_PREFIX=/dev uv run poe update-ui
+```
+
+Resolution order, highest precedence first:
+
+1. `--tarball-name <name>` — explicit override (existing escape hatch from #256)
+2. `--base-prefix <prefix>` — mapped via the `TARBALL_BY_PREFIX` table
+3. `KIPPO_UI_BASE_PREFIX` env var — same mapping as `--base-prefix`
+4. Default — `kippo-ui-build-prod.tar.gz` (preserved, no production regression)
+
+Known prefixes and their tarballs:
+
+| `--base-prefix` | Release asset                  |
+| ---             | ---                            |
+| (unset / `""`)  | `kippo-ui-build-prod.tar.gz`   |
+| `/prod`         | `kippo-ui-build-prod.tar.gz`   |
+| `/dev`          | `kippo-ui-build-dev.tar.gz`    |
+
+An unknown `--base-prefix` (e.g. `/staging`) fails fast with a `CommandError`
+that lists the known prefixes — use `--tarball-name=<name>` to override
+explicitly when needed.
+
+> **Note**: the `/dev` path requires the matching `monkut/kippo-ui` CI change
+> that publishes `kippo-ui-build-dev.tar.gz` alongside the existing prod tarball
+> to be merged and a release cut. Until then, `--base-prefix=/dev` will fail at
+> the asset-lookup step with "tarball not found in release".
+
 ### GitHub API rate limits
 
 `update_ui` calls the unauthenticated GitHub API. If you hit a 403 rate-limit,

--- a/README.md
+++ b/README.md
@@ -160,13 +160,17 @@ uv run python manage.py collectstatic --noinput
 ### Stage-matched UI bundles (`--base-prefix` / `KIPPO_UI_BASE_PREFIX`)
 
 The kippo-ui Vite bundle hard-codes its asset `base` URL at build time. To serve
-the SPA from a non-prod API Gateway stage (e.g. the `dev` stage where assets
-live under `/dev/static/ui/...`), select the stage-matched tarball with
-`--base-prefix`:
+the SPA from a non-prod API Gateway stage (e.g. the `dev` or `stg` stage where
+assets live under `/dev/static/ui/...` or `/stg/static/ui/...`), select the
+stage-matched tarball with `--base-prefix`:
 
 ```bash
 # Dev stage (Zappa dev stage, URL_PREFIX=dev)
 uv run python manage.py update_ui --base-prefix=/dev
+uv run python manage.py collectstatic --noinput
+
+# Staging stage (Zappa stg stage, URL_PREFIX=stg)
+uv run python manage.py update_ui --base-prefix=/stg
 uv run python manage.py collectstatic --noinput
 
 # Or via env var (no poe-task changes needed)
@@ -186,16 +190,18 @@ Known prefixes and their tarballs:
 | ---             | ---                            |
 | (unset / `""`)  | `kippo-ui-build-prod.tar.gz`   |
 | `/prod`         | `kippo-ui-build-prod.tar.gz`   |
+| `/stg`          | `kippo-ui-build-stg.tar.gz`    |
 | `/dev`          | `kippo-ui-build-dev.tar.gz`    |
 
 An unknown `--base-prefix` (e.g. `/staging`) fails fast with a `CommandError`
 that lists the known prefixes — use `--tarball-name=<name>` to override
 explicitly when needed.
 
-> **Note**: the `/dev` path requires the matching `monkut/kippo-ui` CI change
-> that publishes `kippo-ui-build-dev.tar.gz` alongside the existing prod tarball
-> to be merged and a release cut. Until then, `--base-prefix=/dev` will fail at
-> the asset-lookup step with "tarball not found in release".
+> **Note**: the `/dev` and `/stg` paths require the matching `monkut/kippo-ui`
+> CI change that publishes per-stage tarballs alongside the existing prod
+> tarball to be merged and a release cut. Until then, `--base-prefix=/dev` or
+> `--base-prefix=/stg` will fail at the asset-lookup step with "tarball not
+> found in release".
 
 ### GitHub API rate limits
 

--- a/kippo/commons/management/commands/update_ui.py
+++ b/kippo/commons/management/commands/update_ui.py
@@ -11,11 +11,16 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandParser
+from django.core.management.base import BaseCommand, CommandError, CommandParser
 
 KIPPO_UI_REPO = "monkut/kippo-ui"
 GITHUB_API_URL = f"https://api.github.com/repos/{KIPPO_UI_REPO}/releases/latest"
 DEFAULT_TARBALL_NAME = "kippo-ui-build-prod.tar.gz"
+TARBALL_BY_PREFIX = {
+    "": "kippo-ui-build.tar.gz",
+    "/prod": "kippo-ui-build-prod.tar.gz",
+    "/dev": "kippo-ui-build-dev.tar.gz",
+}
 MAX_RETRIES = 3
 RETRY_DELAY_SECONDS = 2
 HTTP_STATUS_SERVER_ERROR = 500
@@ -38,8 +43,23 @@ class Command(BaseCommand):
         parser.add_argument(
             "--tarball-name",
             type=str,
-            default=DEFAULT_TARBALL_NAME,
-            help=f"Name of the release asset tarball to download (default: {DEFAULT_TARBALL_NAME})",
+            default=None,
+            help=(
+                f"Name of the release asset tarball to download. "
+                f"Overrides --base-prefix when set. "
+                f"(default: derived from --base-prefix, falling back to {DEFAULT_TARBALL_NAME})"
+            ),
+        )
+        parser.add_argument(
+            "--base-prefix",
+            type=str,
+            default=os.environ.get("KIPPO_UI_BASE_PREFIX", ""),
+            help=(
+                "URL prefix the kippo-ui bundle was built for "
+                "(e.g. '/prod', '/dev'). Used to pick the matching release "
+                "tarball. Ignored if --tarball-name is given. "
+                f"Defaults to KIPPO_UI_BASE_PREFIX env var or '' (uses {DEFAULT_TARBALL_NAME})."
+            ),
         )
         parser.add_argument(
             "--dry-run",
@@ -51,7 +71,7 @@ class Command(BaseCommand):
         """Execute the command."""
         output_dir = options["output_dir"]
         dry_run = options["dry_run"]
-        tarball_name = options["tarball_name"]
+        tarball_name = self._resolve_tarball_name(options["tarball_name"], options["base_prefix"])
 
         # Determine output path (source directory, not STATIC_ROOT)
         if output_dir:
@@ -63,6 +83,7 @@ class Command(BaseCommand):
             ui_path = base_dir / "static" / "ui"
 
         if dry_run:
+            self.stdout.write(f"Would download tarball: {tarball_name}")
             self.stdout.write(f"Would install UI to: {ui_path}")
             self.stdout.write("Dry run - no changes made")
             return
@@ -97,6 +118,27 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"UI installed successfully to: {ui_path}"))
         self._show_configuration_help(ui_path)
+
+    @staticmethod
+    def _resolve_tarball_name(tarball_name: str | None, base_prefix: str) -> str:
+        """Resolve which release asset tarball to download.
+
+        Resolution order (highest precedence first):
+            1. Explicit --tarball-name
+            2. --base-prefix (or KIPPO_UI_BASE_PREFIX env var) mapped via TARBALL_BY_PREFIX
+            3. DEFAULT_TARBALL_NAME
+        """
+        if tarball_name:
+            return tarball_name
+        normalized_prefix = (base_prefix or "").rstrip("/")
+        if not normalized_prefix:
+            return DEFAULT_TARBALL_NAME
+        try:
+            return TARBALL_BY_PREFIX[normalized_prefix]
+        except KeyError:
+            known = sorted(p for p in TARBALL_BY_PREFIX if p)
+            msg = f"No tarball mapping for --base-prefix={normalized_prefix!r}. Known prefixes: {known}. Use --tarball-name to override explicitly."
+            raise CommandError(msg) from None
 
     def _fetch_latest_release(self) -> dict | None:
         """Fetch the latest release info from GitHub API with retry logic."""

--- a/kippo/commons/management/commands/update_ui.py
+++ b/kippo/commons/management/commands/update_ui.py
@@ -54,12 +54,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--base-prefix",
             type=str,
-            default=os.environ.get("KIPPO_UI_BASE_PREFIX", ""),
+            default=os.environ.get("KIPPO_UI_BASE_PREFIX", "/prod"),
             help=(
                 "URL prefix the kippo-ui bundle was built for "
                 "(e.g. '/prod', '/stg', '/dev'). Used to pick the matching release "
                 "tarball. Ignored if --tarball-name is given. "
-                f"Defaults to KIPPO_UI_BASE_PREFIX env var or '' (uses {DEFAULT_TARBALL_NAME})."
+                f"Defaults to KIPPO_UI_BASE_PREFIX env var or '/prod' (uses {DEFAULT_TARBALL_NAME})."
             ),
         )
         parser.add_argument(

--- a/kippo/commons/management/commands/update_ui.py
+++ b/kippo/commons/management/commands/update_ui.py
@@ -19,6 +19,7 @@ DEFAULT_TARBALL_NAME = "kippo-ui-build-prod.tar.gz"
 TARBALL_BY_PREFIX = {
     "": "kippo-ui-build.tar.gz",
     "/prod": "kippo-ui-build-prod.tar.gz",
+    "/stg": "kippo-ui-build-stg.tar.gz",
     "/dev": "kippo-ui-build-dev.tar.gz",
 }
 MAX_RETRIES = 3
@@ -56,7 +57,7 @@ class Command(BaseCommand):
             default=os.environ.get("KIPPO_UI_BASE_PREFIX", ""),
             help=(
                 "URL prefix the kippo-ui bundle was built for "
-                "(e.g. '/prod', '/dev'). Used to pick the matching release "
+                "(e.g. '/prod', '/stg', '/dev'). Used to pick the matching release "
                 "tarball. Ignored if --tarball-name is given. "
                 f"Defaults to KIPPO_UI_BASE_PREFIX env var or '' (uses {DEFAULT_TARBALL_NAME})."
             ),

--- a/kippo/commons/tests/test_update_ui.py
+++ b/kippo/commons/tests/test_update_ui.py
@@ -29,6 +29,11 @@ class ResolveTarballNameTestCase(SimpleTestCase):
         resolved = Command._resolve_tarball_name(tarball_name=None, base_prefix="/prod")
         self.assertEqual(resolved, "kippo-ui-build-prod.tar.gz")
 
+    def test_base_prefix_stg_derives_stg_tarball(self):
+        """--base-prefix=/stg maps to kippo-ui-build-stg.tar.gz."""
+        resolved = Command._resolve_tarball_name(tarball_name=None, base_prefix="/stg")
+        self.assertEqual(resolved, "kippo-ui-build-stg.tar.gz")
+
     def test_base_prefix_accepts_trailing_slash(self):
         """--base-prefix=/dev/ resolves identically to --base-prefix=/dev."""
         resolved = Command._resolve_tarball_name(tarball_name=None, base_prefix="/dev/")
@@ -42,6 +47,7 @@ class ResolveTarballNameTestCase(SimpleTestCase):
         self.assertIn("/staging", message)
         # Known non-empty prefixes should be surfaced to the operator
         self.assertIn("/dev", message)
+        self.assertIn("/stg", message)
         self.assertIn("/prod", message)
 
     def test_explicit_tarball_overrides_base_prefix(self):

--- a/kippo/commons/tests/test_update_ui.py
+++ b/kippo/commons/tests/test_update_ui.py
@@ -1,0 +1,95 @@
+"""Tests for the update_ui management command, focused on tarball-name resolution."""
+
+import os
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import SimpleTestCase
+
+from commons.management.commands.update_ui import Command
+
+
+class ResolveTarballNameTestCase(SimpleTestCase):
+    """Unit tests for the tarball-name resolver helper."""
+
+    def test_no_args_uses_prod_tarball(self):
+        """Default resolution returns the prod tarball name (regression guard for #256)."""
+        resolved = Command._resolve_tarball_name(tarball_name=None, base_prefix="")
+        self.assertEqual(resolved, "kippo-ui-build-prod.tar.gz")
+
+    def test_base_prefix_dev_derives_dev_tarball(self):
+        """--base-prefix=/dev maps to kippo-ui-build-dev.tar.gz."""
+        resolved = Command._resolve_tarball_name(tarball_name=None, base_prefix="/dev")
+        self.assertEqual(resolved, "kippo-ui-build-dev.tar.gz")
+
+    def test_base_prefix_prod_derives_prod_tarball(self):
+        """--base-prefix=/prod maps to kippo-ui-build-prod.tar.gz."""
+        resolved = Command._resolve_tarball_name(tarball_name=None, base_prefix="/prod")
+        self.assertEqual(resolved, "kippo-ui-build-prod.tar.gz")
+
+    def test_base_prefix_accepts_trailing_slash(self):
+        """--base-prefix=/dev/ resolves identically to --base-prefix=/dev."""
+        resolved = Command._resolve_tarball_name(tarball_name=None, base_prefix="/dev/")
+        self.assertEqual(resolved, "kippo-ui-build-dev.tar.gz")
+
+    def test_base_prefix_unknown_raises_with_known_list(self):
+        """An unmapped --base-prefix raises CommandError listing the known prefixes."""
+        with self.assertRaises(CommandError) as ctx:
+            Command._resolve_tarball_name(tarball_name=None, base_prefix="/staging")
+        message = str(ctx.exception)
+        self.assertIn("/staging", message)
+        # Known non-empty prefixes should be surfaced to the operator
+        self.assertIn("/dev", message)
+        self.assertIn("/prod", message)
+
+    def test_explicit_tarball_overrides_base_prefix(self):
+        """--tarball-name takes precedence over --base-prefix."""
+        resolved = Command._resolve_tarball_name(tarball_name="custom.tar.gz", base_prefix="/dev")
+        self.assertEqual(resolved, "custom.tar.gz")
+
+
+class UpdateUiDryRunTestCase(SimpleTestCase):
+    """Integration tests for the dry-run resolution path (no network)."""
+
+    def test_dry_run_default_reports_prod_tarball(self):
+        """Dry run with no args prints the prod tarball name and makes no network calls."""
+        stdout = StringIO()
+        call_command("update_ui", "--dry-run", stdout=stdout)
+        output = stdout.getvalue()
+        self.assertIn("kippo-ui-build-prod.tar.gz", output)
+        self.assertIn("Dry run - no changes made", output)
+
+    def test_dry_run_base_prefix_dev_reports_dev_tarball(self):
+        """Dry run with --base-prefix=/dev prints the dev tarball name."""
+        stdout = StringIO()
+        call_command("update_ui", "--dry-run", "--base-prefix=/dev", stdout=stdout)
+        self.assertIn("kippo-ui-build-dev.tar.gz", stdout.getvalue())
+
+    def test_dry_run_explicit_tarball_overrides_base_prefix(self):
+        """--tarball-name overrides --base-prefix in the resolved tarball name."""
+        stdout = StringIO()
+        call_command(
+            "update_ui",
+            "--dry-run",
+            "--tarball-name=explicit.tar.gz",
+            "--base-prefix=/dev",
+            stdout=stdout,
+        )
+        output = stdout.getvalue()
+        self.assertIn("explicit.tar.gz", output)
+        self.assertNotIn("kippo-ui-build-dev.tar.gz", output)
+
+    def test_env_var_kippo_ui_base_prefix_resolves_dev_tarball(self):
+        """KIPPO_UI_BASE_PREFIX=/dev with no flag picks the dev tarball."""
+        stdout = StringIO()
+        with mock.patch.dict(os.environ, {"KIPPO_UI_BASE_PREFIX": "/dev"}):
+            call_command("update_ui", "--dry-run", stdout=stdout)
+        self.assertIn("kippo-ui-build-dev.tar.gz", stdout.getvalue())
+
+    def test_unknown_base_prefix_raises_command_error(self):
+        """Unknown --base-prefix surfaces a CommandError instead of silent fallback."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command("update_ui", "--dry-run", "--base-prefix=/staging")
+        self.assertIn("/staging", str(ctx.exception))


### PR DESCRIPTION
## Summary

Closes #264.

Adds `--base-prefix` (and `KIPPO_UI_BASE_PREFIX` env-var fallback) to the `update_ui` management command so non-prod deploys can pull the kippo-ui bundle that matches their API Gateway stage prefix (e.g. `/dev/static/ui/...`) without having to remember the release-asset filename.

## What changed

- `kippo/commons/management/commands/update_ui.py`
  - `TARBALL_BY_PREFIX` maps `""` / `/prod` / `/dev` → the matching release asset names.
  - `--tarball-name` default flips from `kippo-ui-build-prod.tar.gz` to `None`; the prod-default behaviour is now enforced inside the resolver instead.
  - New `--base-prefix` flag, defaulting to `KIPPO_UI_BASE_PREFIX` env var or `""`. Accepts `/dev` or `/dev/`.
  - New `_resolve_tarball_name` helper centralises the resolution order:
    1. explicit `--tarball-name` (existing #256 escape hatch, unchanged)
    2. `--base-prefix`
    3. `KIPPO_UI_BASE_PREFIX` env var
    4. `kippo-ui-build-prod.tar.gz` (default, no production regression)
  - Unknown prefixes raise `CommandError` listing the known mappings.
  - `--dry-run` now prints the resolved tarball name.

- `kippo/commons/tests/test_update_ui.py` (new)
  - 11 tests covering every branch of the resolver (no network, `SimpleTestCase`):
    default → prod, `/dev` → dev, `/prod` → prod, trailing-slash normalisation, unknown-prefix error path, `--tarball-name` override beats `--base-prefix`, `KIPPO_UI_BASE_PREFIX` env-var fallback, and three `call_command` dry-run integrations.

- `README.md`
  - New "Stage-matched UI bundles" subsection under "Deploying the kippo-ui SPA" documenting `--base-prefix` / `KIPPO_UI_BASE_PREFIX`, the prefix→tarball mapping, and the resolution order, plus a note that the `/dev` path is blocked on the matching `monkut/kippo-ui` CI change.

## Acceptance criteria

- [x] `update_ui --base-prefix=/dev` resolves to `kippo-ui-build-dev.tar.gz`.
- [x] `update_ui` with no args still resolves to `kippo-ui-build-prod.tar.gz` (no production regression).
- [x] `update_ui --tarball-name=<name>` continues to override (existing #256 behaviour preserved).
- [x] `KIPPO_UI_BASE_PREFIX` env var honoured when `--base-prefix` not passed.
- [x] Unknown `--base-prefix` fails fast with a `CommandError` listing known prefixes.
- [x] New tests cover every resolution-order branch, run without network access.
- [x] README documents the new flag, env var, and a worked dev-deploy example.
- [ ] Cross-link the matching `monkut/kippo-ui` PR — TBD; until it lands and a release is cut, `--base-prefix=/dev` fails at the asset-lookup step.

## Test plan

- [x] `uv run python manage.py test commons.tests.test_update_ui` → 11/11 passing.
- [x] `uv run poe check` (ruff) → clean.
- [x] Pyright on `update_ui.py`: 7 pre-existing `style.SUCCESS`/`ERROR`/`WARNING` errors (Django stub gaps, identical count before and after this PR — no new regressions).
- [ ] End-to-end dev-stage verification deferred until the kippo-ui PR publishes `kippo-ui-build-dev.tar.gz`.

## Out of scope (per issue)

- Building from kippo's deploy pipeline (we still consume CI artifacts).
- Renaming `VITE_URL_PREFIX` in kippo-ui.
- Changing the Vite default away from `""` (prod-default is satisfied at the management-command layer).