### PR TITLE
:recycle: Unify KippoProjectAdmin fieldsets with ActiveKippoProjectAdmin sections

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -618,18 +618,6 @@ class KippoProjectAdminForm(forms.ModelForm):
         return cleaned_data
 
 
-def _insert_field_after(fields: list[str], target: str, reference: str) -> list[str]:
-    """Return a new list with `target` placed immediately after `reference`. No-op if reference is missing.
-
-    If `target` already exists elsewhere in `fields`, it is moved (not duplicated).
-    """
-    if reference not in fields:
-        return list(fields)
-    rebuilt = [f for f in fields if f != target]
-    rebuilt.insert(rebuilt.index(reference) + 1, target)
-    return rebuilt
-
-
 def _format_estimated_completion(result: "ForecastResult") -> str:
     """Render the forecast result as a one-line admin display string."""
     date = result.estimated_completion_date
@@ -686,6 +674,61 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         "export_kippoprojectstatus_comments_csv",
     ]
     exclude = ("is_closed", "actual_date", "display_as_active", "display_in_project_report")
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": (
+                    "name",
+                    "confidence",
+                    "project_manager",
+                )
+            },
+        ),
+        (
+            _("Dates & Estimates"),
+            {
+                "classes": ("collapse",),
+                "fields": (
+                    "start_date",
+                    "target_date",
+                    "allocated_staff_days",
+                    "estimated_completion_date",
+                ),
+            },
+        ),
+        (
+            _("Details"),
+            {
+                "classes": ("collapse",),
+                "fields": (
+                    "organization",
+                    "phase",
+                    "category",
+                    "parent_project",
+                    "slack_channel_name",
+                    "slack_notification_channel_name",
+                    "columnset",
+                    "enable_cost_report",
+                    "document_folder_url",
+                    "github_project_html_url",
+                    "github_project_api_nodeid",
+                    "docbase_tag",
+                    "problem_definition",
+                ),
+            },
+        ),
+        (
+            _("Closure & Survey"),
+            {
+                "classes": ("collapse",),
+                "fields": (
+                    "survey_issued",
+                    "close_comment",
+                ),
+            },
+        ),
+    ]
     inlines = [
         # Milestones not used atm, commenting out.
         # KippoMilestoneReadOnlyInline,
@@ -721,17 +764,15 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             excluded.append("github_project_api_nodeid")
         return tuple(excluded)
 
-    def get_fields(self, request: DjangoRequest, obj: KippoProject | None = None):
-        fields = list(super().get_fields(request, obj))
-        if "close_comment" in fields:
-            fields.remove("close_comment")
-            fields.append("close_comment")
-        # On add, surface parent_project right after category (the upsell category drives whether
-        # parent_project is required). The close-action upsell flow prefills it via GET;
-        # manual users see it as optional.
-        if obj is None:
-            fields = _insert_field_after(fields, "parent_project", "category")
-        return fields
+    def get_fieldsets(self, request: DjangoRequest, obj: KippoProject | None = None):
+        fieldsets = super().get_fieldsets(request, obj)
+        excluded: set[str] = set(self.get_exclude(request, obj) or ())
+        # estimated_completion_date is a computed readonly field, only surfaced for open projects on edit
+        if obj is None or obj.is_closed:
+            excluded.add("estimated_completion_date")
+        if not excluded:
+            return fieldsets
+        return [(label, {**opts, "fields": tuple(f for f in opts.get("fields", ()) if f not in excluded)}) for label, opts in fieldsets]
 
     def get_updated_by_display(self, obj: KippoProject) -> str:
         result = ""
@@ -1050,79 +1091,22 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
     # Override parent ordering to match UI: confidence desc, target_date asc, name asc
     ordering = ("-confidence", "target_date", "name")
 
-    # is_closed/actual_date/display_as_active/display_in_project_report are excluded by KippoProjectAdmin and must not appear here
-    fieldsets = [
-        (
-            None,
-            {
-                "fields": (
-                    "name",
-                    "confidence",
-                    "project_manager",
-                )
-            },
-        ),
-        (
-            _("Dates & Estimates"),
-            {
-                "classes": ("collapse",),
-                "fields": (
-                    "start_date",
-                    "target_date",
-                    "allocated_staff_days",
-                ),
-            },
-        ),
-        (
-            _("Details"),
-            {
-                "classes": ("collapse",),
-                "fields": (
-                    "organization",
-                    "phase",
-                    "category",
-                    "slack_channel_name",
-                    "slack_notification_channel_name",
-                    "columnset",
-                    "enable_cost_report",
-                    "document_folder_url",
-                    "github_project_html_url",
-                    "github_project_api_nodeid",
-                    "docbase_tag",
-                    "problem_definition",
-                ),
-            },
-        ),
-    ]
-
     def has_delete_permission(self, request: DjangoRequest, obj: Model | None = None):
         """Remove delete button from details/change page"""
         if "/change/" in request.path:
             return False
         return super().has_delete_permission(request, obj)
 
-    def get_fieldsets(self, request: DjangoRequest, obj: KippoProject | None = None):
-        # On add, expose optional parent_project in Details after `category` for manual creation.
-        # The close-project upsell flow redirects to KippoProjectAdmin (not this admin), so this
-        # branch only fires for users initiating creation directly.
-        fieldsets = super().get_fieldsets(request, obj)
-        if obj is None:
-            rebuilt = []
-            for label, opts in fieldsets:
-                fields = list(opts.get("fields", ()))
-                if "category" in fields:
-                    new_fields = _insert_field_after(fields, "parent_project", "category")
-                    rebuilt.append((label, {**opts, "fields": tuple(new_fields)}))
-                else:
-                    rebuilt.append((label, opts))
-            fieldsets = rebuilt
-        # github_project_api_nodeid is excluded from the form for non-superusers; mirror that here
-        # so AdminForm rendering doesn't try to look up a field that isn't in the form.
-        if not request.user.is_superuser:
-            fieldsets = [
-                (label, {**opts, "fields": tuple(f for f in opts.get("fields", ()) if f != "github_project_api_nodeid")}) for label, opts in fieldsets
-            ]
-        return fieldsets
+    def get_exclude(self, request: DjangoRequest, obj: KippoProject | None = None):
+        excluded: list[str] = list(super().get_exclude(request, obj) or ())
+        # Active projects are never closed (filtered by ActiveKippoProjectManager); hide closure fields
+        for field in ("close_comment", "survey_issued"):
+            if field not in excluded:
+                excluded.append(field)
+        # parent_project is only relevant on add (manual upsell creation); hide on change
+        if obj is not None and "parent_project" not in excluded:
+            excluded.append("parent_project")
+        return tuple(excluded)
 
     def get_queryset(self, request: DjangoRequest):
         """Custom ordering: anon-projects first, then by confidence (desc), target_date (asc), name (asc)."""

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -989,11 +989,15 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
         self.assertNotIn("parent_project", details_fields)
 
     def test_class_fieldsets_attribute_unchanged_after_get_fieldsets(self):
-        # get_fieldsets must not mutate the class attribute (would persist across requests)
+        # get_fieldsets must not mutate the (inherited) class attribute — exclusions are applied
+        # to a copy, otherwise mutations would persist across requests.
+        from copy import deepcopy
+
+        before = deepcopy(ActiveKippoProjectAdmin.fieldsets)
         modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
         modeladmin.get_fieldsets(self.super_user_request, obj=None)
-        for _label, opts in ActiveKippoProjectAdmin.fieldsets:
-            self.assertNotIn("parent_project", opts["fields"])
+        modeladmin.get_fieldsets(self.super_user_request, obj=self.existing_project)
+        self.assertEqual(ActiveKippoProjectAdmin.fieldsets, before)
 
     def test_add_view_renders_parent_project_select(self):
         url = reverse("admin:projects_activekippoproject_add")
@@ -1038,9 +1042,9 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
         self.assertIn("parent_project", ordered)
         self.assertEqual(ordered[ordered.index("category") + 1], "parent_project")
 
-    def test_kippoproject_change_view_does_not_reorder_parent_project_after_category(self):
-        # On change view we don't reposition parent_project — it stays in its model-declaration slot
-        # (which is several rows down, after project_manager).
+    def test_kippoproject_change_view_places_parent_project_after_category(self):
+        # parent_project is statically slotted after `category` in the Details fieldset, so the
+        # ordering is consistent across add and change views.
         existing = self.make_project("ordering-change-target")
         url = reverse("admin:projects_kippoproject_change", args=[existing.id])
         response = self.client.get(url)
@@ -1048,7 +1052,7 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
         ordered = self._ordered_form_field_names(response.context["adminform"])
         self.assertIn("category", ordered)
         self.assertIn("parent_project", ordered)
-        self.assertNotEqual(ordered[ordered.index("category") + 1], "parent_project")
+        self.assertEqual(ordered[ordered.index("category") + 1], "parent_project")
 
 
 class KippoProjectAdminSingleOrgHidesOrganizationFieldTestCase(KippoProjectAdminFixtureTestCaseBase):


### PR DESCRIPTION
## Summary

`KippoProjectAdmin` (the base) now declares the same 4-section fieldset layout used by `ActiveKippoProjectAdmin` — `(None) / Dates & Estimates / Details / Closure & Survey` — instead of relying on `get_fields()` + Django's default field ordering.

- `parent_project` lives in **Details** immediately after `category` on both add and change views (previously: only on add, via `get_fields`)
- `close_comment` and `survey_issued` move into a new collapsed **Closure & Survey** section
- `estimated_completion_date` is surfaced in **Dates & Estimates** for open projects on edit (stripped from fieldsets on add and for closed projects, matching the existing `readonly_fields` logic)

`ActiveKippoProjectAdmin` no longer declares its own `fieldsets` — it inherits the base layout and overrides `get_exclude()` to always hide `close_comment`/`survey_issued` (active projects are never closed) and to hide `parent_project` on change (preserving the previous upsell-on-add-only UX).

The new `get_fieldsets()` in the base strips whatever `get_exclude()` returns, which also subsumes the non-superuser `github_project_api_nodeid` filtering that previously needed its own pass.

Removed the now-unused `_insert_field_after` helper and `get_fields` override. Updated the two tests that depended on the old per-form layout.

## Test plan

- [x] `uv run python manage.py test projects.tests.test_admin` — all 68 tests pass
- [x] `uv run python manage.py test projects` — same 5 pre-existing AWS-S3-credential errors as `main`; no new regressions
- [x] `uv run poe check` (ruff) — clean
- [x] `uv run pyright kippo/projects/admin.py` — 235 errors (2 fewer than baseline; no new errors from this change)
- [ ] Visual smoke: open `/admin/projects/kippoproject/<id>/change/` and `/admin/projects/activekippoproject/<id>/change/` and confirm the four sections render as expected
- [ ] Visual smoke: open both admins' `/add/` pages and confirm `parent_project` appears immediately after `category` in Details