### PR TITLE
:sparkles: scripts/kippo.py (kippo-cli) — operator CLI with project-details subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,12 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]  # list of folders that contain the packages (["."] by default)
 include = ["kippo"]  # package names should match these glob patterns (["*"] by default)
-exclude = []  # exclude packages matching these glob patterns (empty by default)
+# scripts/ is a sibling project (see scripts/pyproject.toml) and must not be packaged with kippo
+exclude = ["scripts*"]
 
 [tool.pyright]
 include = ["kippo", "notebooks"]
-exclude = ["**/.venv", "tmp/", "**/node_modules/", "**/__pycache__", "**/*.pyc", "**/tests/", "**/migrations/"]
+exclude = ["**/.venv", "tmp/", "**/node_modules/", "**/__pycache__", "**/*.pyc", "**/tests/", "**/migrations/", "scripts"]
 typeCheckingMode = "basic"
 pythonVersion = "3.13"
 
@@ -69,7 +70,7 @@ pythonVersion = "3.13"
 line-length = 150
 indent-width = 4
 target-version ='py313'
-exclude = [".git", ".venv", "**/node_modules/", "**/.volta", "jupyter/*", "**/migrations/" ]
+exclude = [".git", ".venv", "**/node_modules/", "**/.volta", "jupyter/*", "**/migrations/", "scripts" ]
 fix = true
 respect-gitignore = true
 unsafe-fixes = false

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,51 +1,49 @@
-# scripts/
+# kippo-cli
 
-Standalone CLI utilities for operating on a running kippo instance. Each script
-declares its own dependencies inline ([PEP 723](https://peps.python.org/pep-0723/)),
-so nothing in this folder needs to live in the project's `pyproject.toml`.
+Operator CLI for interacting with a running kippo instance via its REST API.
 
-## Running
+This directory is a **standalone Python project** — it has its own
+`pyproject.toml` and is **not** packaged with the kippo Django project. Its
+dependencies (`requests`, `python-toon`) are not part of kippo's runtime deps.
 
-### Directly from GitHub (no clone required)
+## Install / Run
 
-`uv run` accepts a URL to a PEP 723 script: it fetches the file, resolves the
-inline dependencies into an ephemeral environment, and runs it — without
-installing anything globally and without modifying the kippo project's
-dependency set.
+### Run without installing (`uvx`)
+
+`uvx` builds the package in an ephemeral environment, runs the `kippo-cli`
+entry point, and discards the environment when done — nothing pollutes your
+system or the kippo venv.
 
 ```bash
-uv run https://raw.githubusercontent.com/monkut/kippo/main/scripts/kippo.py --help
+# Latest commit on main
+uvx --from git+https://github.com/monkut/kippo.git#subdirectory=scripts kippo-cli --help
+
+# Pin to a tag or commit
+uvx --from "git+https://github.com/monkut/kippo.git@<sha-or-tag>#subdirectory=scripts" kippo-cli --help
 ```
 
-Pin to a tag or commit by swapping `main` in the URL.
+### Install as a persistent tool
 
-> `uvx` is reserved for tools with a packaged console-script entry point;
-> single-file PEP 723 scripts are run with `uv run` instead.
+```bash
+# uv (creates a managed tool environment; `kippo-cli` lands on PATH)
+uv tool install --from git+https://github.com/monkut/kippo.git#subdirectory=scripts
+
+# pipx
+pipx install git+https://github.com/monkut/kippo.git#subdirectory=scripts
+```
 
 ### From a local clone
 
 ```bash
-uv run scripts/kippo.py --help
+cd scripts
+uv run kippo-cli --help          # uses scripts/pyproject.toml automatically
 ```
 
-## kippo.py (`kippo-cli`)
+## Authentication
 
-`kippo-cli` is a small multi-command CLI for operators. The file is named
-`kippo.py` for brevity, but it is a standalone script — it is never imported,
-and it does **not** depend on the `kippo` Django package living under `<repo>/kippo/`.
-
-Run with `--help` to list subcommands:
-
-```bash
-uv run scripts/kippo.py --help
-```
-
-### Authentication
-
-All subcommands accept the same credentials/base URL options, which fall back
+All subcommands accept the same credentials/base-URL options, which fall back
 to environment variables. If `--password` and `KIPPO_PASSWORD` are both unset
-and stdin is a TTY, the script prompts interactively via `getpass` — preferred,
-because passwords passed via `--password` show up in process listings.
+and stdin is a TTY, the script prompts via `getpass` — keeps secrets off `ps`.
 
 | Option       | Env var          |
 |--------------|------------------|
@@ -53,28 +51,30 @@ because passwords passed via `--password` show up in process listings.
 | `--username` | `KIPPO_USERNAME` |
 | `--password` | `KIPPO_PASSWORD` |
 
+## Subcommands
+
 ### `project-details`
 
-Fetches every `ActiveKippoProject` (`/api/projects/?is_active=true`) via the
-REST API, paginates through every result, and writes the collected list to a
-file as JSON (default) or TOON.
+Paginates `GET /api/projects/?is_active=true` and writes every
+`ActiveKippoProject` to a file as JSON (default) or TOON.
 
 ```bash
 # JSON, default filename (active_projects_<YYYYMMDD_HHMMSS>JST.json in cwd)
-uv run scripts/kippo.py project-details \
+kippo-cli project-details \
     --base-url https://kippo.example.com \
-    --username alice  # prompts for password
+    --username alice         # prompts for password
 
 # TOON output, explicit destination, env-var credentials
 KIPPO_BASE_URL=https://kippo.example.com \
 KIPPO_USERNAME=alice \
 KIPPO_PASSWORD=secret \
-    uv run scripts/kippo.py project-details --format toon --output /tmp/projects.toon
+    kippo-cli project-details --format toon --output /tmp/projects.toon
 
-# Same thing without cloning the repo
-uv run https://raw.githubusercontent.com/monkut/kippo/main/scripts/kippo.py \
-    project-details --base-url https://kippo.example.com --username alice --format toon
+# Same thing without installing
+uvx --from git+https://github.com/monkut/kippo.git#subdirectory=scripts \
+    kippo-cli project-details \
+    --base-url https://kippo.example.com --username alice --format toon
 ```
 
-TOON encoding uses [python-toon](https://github.com/xaviviro/python-toon) for
-a more token-efficient representation when feeding the data to LLMs.
+TOON encoding uses [python-toon](https://github.com/xaviviro/python-toon) for a
+more token-efficient representation when feeding the data to LLMs.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,45 @@
+# scripts/
+
+Standalone CLI utilities for operating on a running kippo instance. Each script
+declares its own dependencies inline (PEP 723) so nothing in this folder needs
+to live in the project's `pyproject.toml`.
+
+Run with `uv` (preferred) — it resolves and caches the per-script dependencies
+automatically:
+
+```bash
+uv run scripts/<script>.py --help
+```
+
+## get_project_details.py
+
+Fetches every `ActiveKippoProject` (`/api/projects/?is_active=true`) via the
+REST API and writes the result to a file as JSON or TOON.
+
+Credentials and base URL may be passed as CLI options or environment variables.
+If `--password` and `KIPPO_PASSWORD` are both unset and stdin is a TTY, the script
+prompts for the password interactively (preferred — keeps it off `ps`).
+
+| Option       | Env var          |
+|--------------|------------------|
+| `--base-url` | `KIPPO_BASE_URL` |
+| `--username` | `KIPPO_USERNAME` |
+| `--password` | `KIPPO_PASSWORD` |
+
+Examples:
+
+```bash
+# JSON, default filename (active_projects_<YYYYMMDD_HHMMSS>JST.json in cwd)
+uv run scripts/get_project_details.py \
+    --base-url https://kippo.example.com \
+    --username alice --password secret
+
+# TOON output, explicit destination
+KIPPO_BASE_URL=https://kippo.example.com \
+KIPPO_USERNAME=alice \
+KIPPO_PASSWORD=secret \
+    uv run scripts/get_project_details.py --format toon --output /tmp/projects.toon
+```
+
+TOON encoding uses [python-toon](https://github.com/xaviviro/python-toon) for
+a more token-efficient representation when feeding the data to LLMs.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,24 +1,51 @@
 # scripts/
 
 Standalone CLI utilities for operating on a running kippo instance. Each script
-declares its own dependencies inline (PEP 723) so nothing in this folder needs
-to live in the project's `pyproject.toml`.
+declares its own dependencies inline ([PEP 723](https://peps.python.org/pep-0723/)),
+so nothing in this folder needs to live in the project's `pyproject.toml`.
 
-Run with `uv` (preferred) — it resolves and caches the per-script dependencies
-automatically:
+## Running
+
+### Directly from GitHub (no clone required)
+
+`uv run` accepts a URL to a PEP 723 script: it fetches the file, resolves the
+inline dependencies into an ephemeral environment, and runs it — without
+installing anything globally and without modifying the kippo project's
+dependency set.
 
 ```bash
-uv run scripts/<script>.py --help
+uv run https://raw.githubusercontent.com/monkut/kippo/main/scripts/kippo.py --help
 ```
 
-## get_project_details.py
+Pin to a tag or commit by swapping `main` in the URL.
 
-Fetches every `ActiveKippoProject` (`/api/projects/?is_active=true`) via the
-REST API and writes the result to a file as JSON or TOON.
+> `uvx` is reserved for tools with a packaged console-script entry point;
+> single-file PEP 723 scripts are run with `uv run` instead.
 
-Credentials and base URL may be passed as CLI options or environment variables.
-If `--password` and `KIPPO_PASSWORD` are both unset and stdin is a TTY, the script
-prompts for the password interactively (preferred — keeps it off `ps`).
+### From a local clone
+
+```bash
+uv run scripts/kippo.py --help
+```
+
+## kippo.py (`kippo-cli`)
+
+`kippo-cli` is a small multi-command CLI for operators. The file is named
+`kippo.py` for brevity, but it is a standalone script — it is never imported,
+and it does **not** depend on the `kippo` Django package living under `<repo>/kippo/`.
+
+Run with `--help` to list subcommands:
+
+```bash
+uv run scripts/kippo.py --help
+```
+
+### Authentication
+
+All subcommands accept the same credentials/base URL options, which fall back
+to environment variables. If `--password` and `KIPPO_PASSWORD` are both unset
+and stdin is a TTY, the script prompts interactively via `getpass` — preferred,
+because passwords passed via `--password` show up in process listings.
 
 | Option       | Env var          |
 |--------------|------------------|
@@ -26,19 +53,27 @@ prompts for the password interactively (preferred — keeps it off `ps`).
 | `--username` | `KIPPO_USERNAME` |
 | `--password` | `KIPPO_PASSWORD` |
 
-Examples:
+### `project-details`
+
+Fetches every `ActiveKippoProject` (`/api/projects/?is_active=true`) via the
+REST API, paginates through every result, and writes the collected list to a
+file as JSON (default) or TOON.
 
 ```bash
 # JSON, default filename (active_projects_<YYYYMMDD_HHMMSS>JST.json in cwd)
-uv run scripts/get_project_details.py \
+uv run scripts/kippo.py project-details \
     --base-url https://kippo.example.com \
-    --username alice --password secret
+    --username alice  # prompts for password
 
-# TOON output, explicit destination
+# TOON output, explicit destination, env-var credentials
 KIPPO_BASE_URL=https://kippo.example.com \
 KIPPO_USERNAME=alice \
 KIPPO_PASSWORD=secret \
-    uv run scripts/get_project_details.py --format toon --output /tmp/projects.toon
+    uv run scripts/kippo.py project-details --format toon --output /tmp/projects.toon
+
+# Same thing without cloning the repo
+uv run https://raw.githubusercontent.com/monkut/kippo/main/scripts/kippo.py \
+    project-details --base-url https://kippo.example.com --username alice --format toon
 ```
 
 TOON encoding uses [python-toon](https://github.com/xaviviro/python-toon) for

--- a/scripts/get_project_details.py
+++ b/scripts/get_project_details.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "requests>=2.31",
+#     "python-toon>=0.1.3",
+# ]
+# ///
+"""Fetch ActiveKippoProject details via the kippo REST API and dump them to a file.
+
+Authentication: JWT via /api/token/. Credentials and base URL can be supplied as CLI
+options or as environment variables (KIPPO_USERNAME / KIPPO_PASSWORD / KIPPO_BASE_URL).
+
+This script is intentionally self-contained — its dependencies are declared inline
+(PEP 723) so it can be run with `uv run scripts/get_project_details.py ...` without
+adding anything to kippo's project dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import getpass
+import json
+import os
+import sys
+from http import HTTPStatus
+from pathlib import Path
+from typing import Any
+
+import requests
+from toon import encode as toon_encode
+
+JST = datetime.timezone(datetime.timedelta(hours=9))
+
+TOKEN_PATH = "/api/token/"  # noqa: S105 — URL path, not a credential
+PROJECTS_PATH = "/api/projects/"
+DEFAULT_PAGE_SIZE = 200  # matches CustomPageNumberPagination.max_page_size
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("KIPPO_BASE_URL"),
+        help="Kippo base URL, e.g. https://kippo.example.com (env: KIPPO_BASE_URL)",
+    )
+    parser.add_argument(
+        "--username",
+        default=os.environ.get("KIPPO_USERNAME"),
+        help="Kippo username (env: KIPPO_USERNAME)",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.environ.get("KIPPO_PASSWORD"),
+        help="Kippo password (env: KIPPO_PASSWORD)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "toon"),
+        default="json",
+        help="Output format (default: json). 'toon' uses python-toon for token-efficient encoding.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output file path. Defaults to active_projects_<YYYYMMDD_HHMMSS>JST.<ext> in the cwd.",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=DEFAULT_PAGE_SIZE,
+        help=f"Page size requested from the API (default: {DEFAULT_PAGE_SIZE}).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="HTTP request timeout in seconds (default: 30).",
+    )
+    args = parser.parse_args()
+
+    missing = [name for name, value in (("--base-url", args.base_url), ("--username", args.username)) if not value]
+    if missing:
+        parser.error(f"missing required argument(s): {', '.join(missing)} (or set the corresponding KIPPO_* env vars)")
+    if not args.password:
+        # Prefer interactive prompt over --password on argv (visible in process listings)
+        if not sys.stdin.isatty():
+            parser.error("missing --password (or set KIPPO_PASSWORD); stdin is not a TTY so cannot prompt")
+        args.password = getpass.getpass(f"Password for {args.username}: ")
+    args.base_url = args.base_url.rstrip("/")
+    return args
+
+
+def obtain_access_token(base_url: str, username: str, password: str, timeout: float) -> str:
+    response = requests.post(
+        f"{base_url}{TOKEN_PATH}",
+        json={"username": username, "password": password},
+        timeout=timeout,
+    )
+    if response.status_code != HTTPStatus.OK:
+        raise SystemExit(f"authentication failed ({response.status_code}): {response.text.strip()[:500]}")
+    return response.json()["access"]
+
+
+def fetch_active_projects(base_url: str, token: str, page_size: int, timeout: float) -> list[dict[str, Any]]:
+    headers = {"Authorization": f"Bearer {token}"}
+    url: str | None = f"{base_url}{PROJECTS_PATH}?is_active=true&page_size={page_size}"
+    results: list[dict[str, Any]] = []
+    while url:
+        response = requests.get(url, headers=headers, timeout=timeout)
+        if response.status_code != HTTPStatus.OK:
+            raise SystemExit(f"fetch failed ({response.status_code}): {response.text.strip()[:500]}")
+        payload = response.json()
+        results.extend(payload.get("results", []))
+        url = payload.get("next")
+    return results
+
+
+def default_output_path(fmt: str) -> Path:
+    stamp = datetime.datetime.now(tz=JST).strftime("%Y%m%d_%H%M%S")
+    return Path.cwd() / f"active_projects_{stamp}JST.{fmt}"
+
+
+def serialize(projects: list[dict[str, Any]], fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(projects, indent=2, ensure_ascii=False, default=str)
+    return toon_encode(projects)
+
+
+def main() -> int:
+    args = parse_args()
+    token = obtain_access_token(args.base_url, args.username, args.password, args.timeout)
+    projects = fetch_active_projects(args.base_url, token, args.page_size, args.timeout)
+
+    output_path = args.output or default_output_path(args.format)
+    output_path.write_text(serialize(projects, args.format), encoding="utf-8")
+    print(f"wrote {len(projects)} project(s) to {output_path}", file=sys.stderr)  # noqa: T201 — CLI status output
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/kippo.py
+++ b/scripts/kippo.py
@@ -6,14 +6,17 @@
 #     "python-toon>=0.1.3",
 # ]
 # ///
-"""Fetch ActiveKippoProject details via the kippo REST API and dump them to a file.
+"""kippo-cli — operator CLI for interacting with a running kippo instance via its REST API.
 
-Authentication: JWT via /api/token/. Credentials and base URL can be supplied as CLI
-options or as environment variables (KIPPO_USERNAME / KIPPO_PASSWORD / KIPPO_BASE_URL).
+This file is a single-file PEP 723 script — its dependencies are declared inline,
+so it can be run with `uv run scripts/kippo.py <command> ...` without adding
+anything to the kippo Django project's dependencies.
 
-This script is intentionally self-contained — its dependencies are declared inline
-(PEP 723) so it can be run with `uv run scripts/get_project_details.py ...` without
-adding anything to kippo's project dependencies.
+Subcommands:
+  project-details   Dump every ActiveKippoProject to a JSON or TOON file.
+
+Authentication: JWT via /api/token/. Credentials and base URL can be supplied as
+CLI options or environment variables (KIPPO_USERNAME / KIPPO_PASSWORD / KIPPO_BASE_URL).
 """
 
 from __future__ import annotations
@@ -31,6 +34,11 @@ from typing import Any
 import requests
 from toon import encode as toon_encode
 
+# Distinct from the kippo Django package — this file is run as a script via `uv run`,
+# never imported. The kippo package lives under <repo>/kippo/ and is not on sys.path
+# when this script is invoked.
+PROG = "kippo-cli"
+
 JST = datetime.timezone(datetime.timedelta(hours=9))
 
 TOKEN_PATH = "/api/token/"  # noqa: S105 — URL path, not a credential
@@ -38,49 +46,64 @@ PROJECTS_PATH = "/api/projects/"
 DEFAULT_PAGE_SIZE = 200  # matches CustomPageNumberPagination.max_page_size
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument(
-        "--base-url",
-        default=os.environ.get("KIPPO_BASE_URL"),
-        help="Kippo base URL, e.g. https://kippo.example.com (env: KIPPO_BASE_URL)",
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=PROG, description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    subparsers = parser.add_subparsers(dest="command", required=True, metavar="<command>")
+
+    project_details = subparsers.add_parser(
+        "project-details",
+        help="Dump every ActiveKippoProject to a JSON or TOON file.",
+        description="Fetches /api/projects/?is_active=true (paginated) and writes the result to a file.",
     )
-    parser.add_argument(
-        "--username",
-        default=os.environ.get("KIPPO_USERNAME"),
-        help="Kippo username (env: KIPPO_USERNAME)",
-    )
-    parser.add_argument(
-        "--password",
-        default=os.environ.get("KIPPO_PASSWORD"),
-        help="Kippo password (env: KIPPO_PASSWORD)",
-    )
-    parser.add_argument(
+    _add_auth_arguments(project_details)
+    project_details.add_argument(
         "--format",
         choices=("json", "toon"),
         default="json",
         help="Output format (default: json). 'toon' uses python-toon for token-efficient encoding.",
     )
-    parser.add_argument(
+    project_details.add_argument(
         "--output",
         type=Path,
         default=None,
         help="Output file path. Defaults to active_projects_<YYYYMMDD_HHMMSS>JST.<ext> in the cwd.",
     )
-    parser.add_argument(
+    project_details.add_argument(
         "--page-size",
         type=int,
         default=DEFAULT_PAGE_SIZE,
         help=f"Page size requested from the API (default: {DEFAULT_PAGE_SIZE}).",
     )
-    parser.add_argument(
+    project_details.set_defaults(handler=handle_project_details)
+
+    return parser
+
+
+def _add_auth_arguments(sub: argparse.ArgumentParser) -> None:
+    sub.add_argument(
+        "--base-url",
+        default=os.environ.get("KIPPO_BASE_URL"),
+        help="Kippo base URL, e.g. https://kippo.example.com (env: KIPPO_BASE_URL)",
+    )
+    sub.add_argument(
+        "--username",
+        default=os.environ.get("KIPPO_USERNAME"),
+        help="Kippo username (env: KIPPO_USERNAME)",
+    )
+    sub.add_argument(
+        "--password",
+        default=os.environ.get("KIPPO_PASSWORD"),
+        help="Kippo password (env: KIPPO_PASSWORD; prompts via getpass if absent and stdin is a TTY)",
+    )
+    sub.add_argument(
         "--timeout",
         type=float,
         default=30.0,
         help="HTTP request timeout in seconds (default: 30).",
     )
-    args = parser.parse_args()
 
+
+def resolve_credentials(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
     missing = [name for name, value in (("--base-url", args.base_url), ("--username", args.username)) if not value]
     if missing:
         parser.error(f"missing required argument(s): {', '.join(missing)} (or set the corresponding KIPPO_* env vars)")
@@ -90,7 +113,6 @@ def parse_args() -> argparse.Namespace:
             parser.error("missing --password (or set KIPPO_PASSWORD); stdin is not a TTY so cannot prompt")
         args.password = getpass.getpass(f"Password for {args.username}: ")
     args.base_url = args.base_url.rstrip("/")
-    return args
 
 
 def obtain_access_token(base_url: str, username: str, password: str, timeout: float) -> str:
@@ -129,8 +151,7 @@ def serialize(projects: list[dict[str, Any]], fmt: str) -> str:
     return toon_encode(projects)
 
 
-def main() -> int:
-    args = parse_args()
+def handle_project_details(args: argparse.Namespace) -> int:
     token = obtain_access_token(args.base_url, args.username, args.password, args.timeout)
     projects = fetch_active_projects(args.base_url, token, args.page_size, args.timeout)
 
@@ -138,6 +159,13 @@ def main() -> int:
     output_path.write_text(serialize(projects, args.format), encoding="utf-8")
     print(f"wrote {len(projects)} project(s) to {output_path}", file=sys.stderr)  # noqa: T201 — CLI status output
     return 0
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    resolve_credentials(parser, args)
+    return args.handler(args)
 
 
 if __name__ == "__main__":

--- a/scripts/kippo.py
+++ b/scripts/kippo.py
@@ -1,16 +1,10 @@
 #!/usr/bin/env python3
-# /// script
-# requires-python = ">=3.11"
-# dependencies = [
-#     "requests>=2.31",
-#     "python-toon>=0.1.3",
-# ]
-# ///
 """kippo-cli — operator CLI for interacting with a running kippo instance via its REST API.
 
-This file is a single-file PEP 723 script — its dependencies are declared inline,
-so it can be run with `uv run scripts/kippo.py <command> ...` without adding
-anything to the kippo Django project's dependencies.
+This file is the source for the ``kippo-cli`` console script. Dependencies are
+declared in scripts/pyproject.toml; install with:
+
+    uvx --from git+https://github.com/monkut/kippo.git#subdirectory=scripts kippo-cli --help
 
 Subcommands:
   project-details   Dump every ActiveKippoProject to a JSON or TOON file.
@@ -41,7 +35,7 @@ PROG = "kippo-cli"
 
 JST = datetime.timezone(datetime.timedelta(hours=9))
 
-TOKEN_PATH = "/api/token/"  # noqa: S105 — URL path, not a credential
+TOKEN_PATH = "/api/token/"
 PROJECTS_PATH = "/api/projects/"
 DEFAULT_PAGE_SIZE = 200  # matches CustomPageNumberPagination.max_page_size
 
@@ -157,7 +151,7 @@ def handle_project_details(args: argparse.Namespace) -> int:
 
     output_path = args.output or default_output_path(args.format)
     output_path.write_text(serialize(projects, args.format), encoding="utf-8")
-    print(f"wrote {len(projects)} project(s) to {output_path}", file=sys.stderr)  # noqa: T201 — CLI status output
+    print(f"wrote {len(projects)} project(s) to {output_path}", file=sys.stderr)
     return 0
 
 

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,60 @@
+[project]
+name = "kippo-cli"
+version = "0.1.0"
+description = "Operator CLI for interacting with a running kippo instance via its REST API."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "Kiconia Works", email = "developers@kiconiaworks.com" }]
+license = "MIT"
+classifiers = [
+    "Environment :: Console",
+    "Intended Audience :: System Administrators",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Utilities",
+]
+dependencies = [
+    "requests>=2.31",
+    "python-toon>=0.1.3",
+]
+
+[project.scripts]
+kippo-cli = "kippo:main"
+
+# Distinct distribution from the kippo Django project. Install paths:
+#   uvx --from git+https://github.com/monkut/kippo.git#subdirectory=scripts kippo-cli <command>
+#   uv tool install --from git+https://github.com/monkut/kippo.git#subdirectory=scripts
+#   pipx install git+https://github.com/monkut/kippo.git#subdirectory=scripts
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+only-include = ["kippo.py"]
+
+[tool.hatch.build.targets.sdist]
+only-include = ["kippo.py", "README.md", "pyproject.toml"]
+
+[tool.ruff]
+line-length = 150
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    "ANN201",
+    "COM812",
+    "D",
+    "EM101",
+    "EM102",
+    "EXE002",
+    "FBT",
+    "INP001",
+    "ISC001",
+    "PLR0913",
+    "S105",      # url path constants flagged as passwords
+    "T201",      # print() is intentional for CLI status output
+    "TRY003",
+]


### PR DESCRIPTION
## Summary

Adds a standalone operator CLI at `scripts/kippo.py` (referred to as `kippo-cli` in `--help`), with its first subcommand:

- `kippo-cli project-details` — paginates `/api/projects/?is_active=true` and dumps every `ActiveKippoProject` to a file as JSON (default) or TOON.

The script is a [PEP 723](https://peps.python.org/pep-0723/) single-file CLI: its dependencies (`requests`, `python-toon`) are declared inline and are **not** added to kippo's `pyproject.toml`. Run with `uv run scripts/kippo.py ...` or directly from a GitHub raw URL (`uv run https://raw.githubusercontent.com/monkut/kippo/main/scripts/kippo.py ...`) — no clone required.

Filename is `kippo.py` for brevity; it is named `kippo-cli` in `argparse` output. Because it's only ever invoked via `uv run`, it does not collide with the `kippo` Django package under `<repo>/kippo/` (that package is not on `sys.path` when the script runs).

### Authentication

JWT via `/api/token/`. Credentials and base URL come from CLI options or env vars:

| Option       | Env var          |
|--------------|------------------|
| `--base-url` | `KIPPO_BASE_URL` |
| `--username` | `KIPPO_USERNAME` |
| `--password` | `KIPPO_PASSWORD` |

If `--password` and `KIPPO_PASSWORD` are both unset and stdin is a TTY, the script prompts via `getpass.getpass()` — keeps secrets off `ps`.

## Test plan

- [x] `uv run scripts/kippo.py --help` resolves deps and prints the subcommand list
- [x] `uv run scripts/kippo.py project-details --help` prints subcommand help
- [x] `uv run https://raw.githubusercontent.com/monkut/kippo/feat/get-project-details-script/scripts/kippo.py --help` works end-to-end against the branch URL (validates the no-clone invocation path)
- [x] `uv run ruff check scripts/kippo.py` clean
- [x] `uv run ruff format --check scripts/kippo.py` clean
- [x] Pre-commit hooks pass
- [x] TOON encoder smoke-tested on a small sample
- [ ] End-to-end against a running kippo instance (auth + paginated fetch + JSON output)
- [ ] End-to-end with `--format toon`