### PR TITLE
:sparkles: kippo-cli: key TOON output by name(id) instead of [N] array marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ kippo/zappa_settings.orig
 old-packages/
 ts-client/
 openapi.yaml
+# kippo-cli (scripts/) is consumed via uvx — uv.lock is a local-only artifact
+scripts/uv.lock
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,4 +77,7 @@ uvx --from git+https://github.com/monkut/kippo.git#subdirectory=scripts \
 ```
 
 TOON encoding uses [python-toon](https://github.com/xaviviro/python-toon) for a
-more token-efficient representation when feeding the data to LLMs.
+more token-efficient representation when feeding the data to LLMs. The TOON
+output keys each project by `"{name}({id})"` at the top level (rather than the
+default `[N]:` array marker), making individual projects directly addressable;
+`id` and `name` are not duplicated inside the body.

--- a/scripts/kippo.py
+++ b/scripts/kippo.py
@@ -142,7 +142,11 @@ def default_output_path(fmt: str) -> Path:
 def serialize(projects: list[dict[str, Any]], fmt: str) -> str:
     if fmt == "json":
         return json.dumps(projects, indent=2, ensure_ascii=False, default=str)
-    return toon_encode(projects)
+    # TOON: key each project by "{name}({id})" instead of the default [N] array marker,
+    # so each project is directly addressable. id and name are dropped from the body
+    # since they're now in the key.
+    keyed = {f"{p['name']}({p['id']})": {k: v for k, v in p.items() if k not in ("id", "name")} for p in projects}
+    return toon_encode(keyed)
 
 
 def handle_project_details(args: argparse.Namespace) -> int:

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kippo-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Operator CLI for interacting with a running kippo instance via its REST API."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Changes the TOON output structure so each project is keyed by `"{name}({id})":` at the top level instead of being a positional list under a `[36]:` count marker. Each project is now directly addressable in the output, which is more useful when feeding the file to an LLM. `id` and `name` are dropped from each project's body since they're encoded in the key.

JSON output is unchanged.

Before:
```
[36]:
  - id: a7689112-604d-4dc0-87a5-d0b99bf7a643
    name: TStech_設計部門LLM追加開発_202606-202610
    organization: 227e0fc5-...
    ...
```

After:
```
"TStech_設計部門LLM追加開発_202606-202610(a7689112-604d-4dc0-87a5-d0b99bf7a643)":
  organization: 227e0fc5-...
  ...
```

Project `name` has a `unique=True` model constraint, so the key is collision-free.

Bumps `kippo-cli` to **0.2.0**.

## Test plan

- [x] `uv run ruff check scripts/kippo.py` clean
- [x] Pre-commit passes
- [x] End-to-end fetch against the live API: 36 projects → 77,988 bytes (down from 82,084 with the array marker form; JSON baseline is 126,459).
- [ ] Reviewer eyeball-check on the keyed format