### PR TITLE
:lipstick: Customer admin column header + MTG bookmark title cleanup

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -695,7 +695,7 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     )
     list_display = (
         "id",
-        "customer__name",
+        "get_customer_name",
         "name",
         "phase",
         "category",
@@ -839,6 +839,10 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         return result
 
     get_updated_by_display.short_description = "updated by"
+
+    @admin.display(description=KippoCustomer._meta.verbose_name, ordering="customer__name")
+    def get_customer_name(self, obj: KippoProject) -> str:
+        return obj.customer.name if obj.customer else ""
 
     @admin.display(description=_("confidence"), ordering="confidence")
     def get_confidence_display(self, obj: KippoProject):
@@ -1184,7 +1188,7 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
 class ActiveKippoProjectAdmin(KippoProjectAdmin):
     list_display = (
         "id",
-        "customer__name",
+        "get_customer_name",
         "name",
         "get_confidence_display",
         "get_projectstatus_display",

--- a/kippo/projects/slackcommand/managers.py
+++ b/kippo/projects/slackcommand/managers.py
@@ -202,7 +202,7 @@ class ProjectCalendarLinkManager:
     See kiconiaworks/kippo#13.
     """
 
-    CALENDAR_BOOKMARK_TITLE = "MTG カレンダー作成 URL"
+    CALENDAR_BOOKMARK_TITLE = "MTG カレンダー作成"
     CALENDAR_BOOKMARK_EMOJI = ":calendar:"
     _CONVERSATIONS_PAGE_LIMIT = 200
 


### PR DESCRIPTION
## Summary

Two small admin / Slack display tweaks.

### 1. Customer column header uses the Customer model's translated name
`KippoProjectAdmin` / `ActiveKippoProjectAdmin` listed `customer__name` directly in `list_display`, so the column header rendered as the auto-derived `customer name`. Replaced it with a `get_customer_name` display method whose header is `KippoCustomer._meta.verbose_name` (顧客). Column sorting is preserved via `ordering="customer__name"`, and `customer` is already in `list_select_related` so there is no N+1.

### 2. Drop "URL" from the MTG calendar Slack bookmark title
`ProjectCalendarLinkManager.CALENDAR_BOOKMARK_TITLE`: `"MTG カレンダー作成 URL"` → `"MTG カレンダー作成"`.

**Note:** the add-vs-update logic matches existing bookmarks by exact title, so channels that already have the old `"MTG カレンダー作成 URL"` bookmark will get a second bookmark if the admin action is re-run. Existing duplicates must be removed manually in Slack.

## Test plan
- `projects.tests.test_admin` — 72 tests pass
- `projects.tests.test_managers_projectcalendarlinkmanager` + `test_admin_meeting_calendar` — 15 tests pass
- `ruff check` clean