### PR TITLE
:sparkles: MTG calendar link: pin a Slack message instead of a channel bookmark

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -593,7 +593,7 @@ reopen_kippoproject_action.short_description = _("Re-open Project(s)")  # noqa: 
 
 
 def add_calendar_links_to_slack_channels_action(modeladmin: admin.ModelAdmin, request: DjangoRequest, queryset: models.QuerySet):
-    """Add each selected project's MTG calendar-template URL as a Slack channel bookmark ('tab' link).
+    """Add each selected project's MTG calendar-template URL as a pinned message on its Slack conversation channel.
 
     Skips projects without a Slack conversation channel (or whose organization has no Slack API token)
     and reports them as errors. See kiconiaworks/kippo#13.
@@ -617,7 +617,7 @@ def add_calendar_links_to_slack_channels_action(modeladmin: admin.ModelAdmin, re
             manager = ProjectCalendarLinkManager(organization)
             managers[organization.id] = manager
         try:
-            result = manager.set_calendar_bookmark(project)
+            result = manager.set_calendar_pinned_message(project)
         except SlackChannelNotFoundError:
             errors.append(
                 _("%(name)s: Slack channel '%(channel)s' was not found in the workspace.")

--- a/kippo/projects/slackcommand/managers.py
+++ b/kippo/projects/slackcommand/managers.py
@@ -197,18 +197,18 @@ class ProjectSlackManager:
 
 
 class ProjectCalendarLinkManager:
-    """Manage a project's MTG calendar-template URL as a Slack channel bookmark ('tab' link).
+    """Manage a project's MTG calendar-template URL as a pinned Slack message.
 
     See kiconiaworks/kippo#13.
     """
 
-    CALENDAR_BOOKMARK_TITLE = "MTG カレンダー作成"
-    CALENDAR_BOOKMARK_EMOJI = ":calendar:"
+    CALENDAR_MESSAGE_TITLE = "MTG カレンダー作成"
+    CALENDAR_MESSAGE_EMOJI = ":calendar:"
     _CONVERSATIONS_PAGE_LIMIT = 200
 
     def __init__(self, organization: KippoOrganization) -> None:
         if not organization.slack_api_token:
-            raise ValueError("organization.slack_api_token is not set; cannot manage Slack channel bookmarks.")
+            raise ValueError("organization.slack_api_token is not set; cannot manage Slack channel messages.")
         self.organization = organization
         self.client = WebClient(token=organization.slack_api_token)
 
@@ -231,8 +231,19 @@ class ProjectCalendarLinkManager:
             if not cursor:
                 return None
 
-    def set_calendar_bookmark(self, project: KippoProject) -> str:
-        """Add (or update) the project's MTG calendar-template URL bookmark on its Slack conversation channel.
+    def _find_calendar_message_ts(self, channel_id: str) -> str | None:
+        """Return the ts of an already-pinned MTG calendar message in the channel, or None."""
+        pinned_items: list = self.client.pins_list(channel=channel_id).get("items") or []
+        for item in pinned_items:
+            if item.get("type") != "message":
+                continue
+            message = item.get("message") or {}
+            if self.CALENDAR_MESSAGE_TITLE in message.get("text", ""):
+                return message.get("ts")
+        return None
+
+    def set_calendar_pinned_message(self, project: KippoProject) -> str:
+        """Post (or update) the project's MTG calendar-template URL as a pinned message on its Slack conversation channel.
 
         Returns ``"added"`` or ``"updated"``.
         Raises ``ValueError`` if the project has no ``slack_channel_name`` and
@@ -245,16 +256,12 @@ class ProjectCalendarLinkManager:
             raise SlackChannelNotFoundError(f"Slack channel not found: {project.slack_channel_name}")
 
         url = project.get_meeting_calendar_template_url()
-        existing_bookmarks: list = self.client.bookmarks_list(channel_id=channel_id).get("bookmarks") or []
-        for bookmark in existing_bookmarks:
-            if bookmark.get("title") == self.CALENDAR_BOOKMARK_TITLE:
-                self.client.bookmarks_edit(bookmark_id=bookmark["id"], channel_id=channel_id, link=url)
-                return "updated"
-        self.client.bookmarks_add(
-            channel_id=channel_id,
-            title=self.CALENDAR_BOOKMARK_TITLE,
-            type="link",
-            link=url,
-            emoji=self.CALENDAR_BOOKMARK_EMOJI,
-        )
+        text = f"{self.CALENDAR_MESSAGE_EMOJI} <{url}|{self.CALENDAR_MESSAGE_TITLE}>"
+
+        existing_ts = self._find_calendar_message_ts(channel_id)
+        if existing_ts:
+            self.client.chat_update(channel=channel_id, ts=existing_ts, text=text)
+            return "updated"
+        response = self.client.chat_postMessage(channel=channel_id, text=text)
+        self.client.pins_add(channel=channel_id, timestamp=response["ts"])
         return "added"

--- a/kippo/projects/tests/test_admin_meeting_calendar.py
+++ b/kippo/projects/tests/test_admin_meeting_calendar.py
@@ -18,7 +18,7 @@ from projects.exceptions import SlackChannelNotFoundError
 from projects.models import KippoProject
 from projects.tests.test_admin import KippoProjectAdminFixtureTestCaseBase
 
-SET_BOOKMARK_PATH = "projects.slackcommand.managers.ProjectCalendarLinkManager.set_calendar_bookmark"
+SET_PINNED_MESSAGE_PATH = "projects.slackcommand.managers.ProjectCalendarLinkManager.set_calendar_pinned_message"
 
 
 def _request_with_messages(user: KippoUser) -> HttpRequest:
@@ -88,7 +88,7 @@ class AddCalendarLinksActionTestCase(TestCase):
         add_calendar_links_to_slack_channels_action(self.admin, request, queryset)
         return list(request._messages)
 
-    @mock.patch(SET_BOOKMARK_PATH, return_value="added")
+    @mock.patch(SET_PINNED_MESSAGE_PATH, return_value="added")
     def test_action_adds_link_success(self, mock_set: mock.MagicMock):
         self.organization.slack_api_token = "xoxb-test"  # noqa: S105
         self.organization.save()
@@ -117,7 +117,7 @@ class AddCalendarLinksActionTestCase(TestCase):
         assert messages[0].level == message_constants.ERROR
         assert "no Slack API token" in messages[0].message
 
-    @mock.patch(SET_BOOKMARK_PATH, side_effect=SlackChannelNotFoundError("nope"))
+    @mock.patch(SET_PINNED_MESSAGE_PATH, side_effect=SlackChannelNotFoundError("nope"))
     def test_action_reports_channel_not_found(self, mock_set: mock.MagicMock):
         self.organization.slack_api_token = "xoxb-test"  # noqa: S105
         self.organization.save()
@@ -128,7 +128,7 @@ class AddCalendarLinksActionTestCase(TestCase):
         assert messages[0].level == message_constants.ERROR
         assert "was not found in the workspace" in messages[0].message
 
-    @mock.patch(SET_BOOKMARK_PATH, side_effect=SlackApiError("err", {"error": "missing_scope"}))
+    @mock.patch(SET_PINNED_MESSAGE_PATH, side_effect=SlackApiError("err", {"error": "missing_scope"}))
     def test_action_reports_slack_api_error(self, mock_set: mock.MagicMock):
         self.organization.slack_api_token = "xoxb-test"  # noqa: S105
         self.organization.save()

--- a/kippo/projects/tests/test_managers_projectcalendarlinkmanager.py
+++ b/kippo/projects/tests/test_managers_projectcalendarlinkmanager.py
@@ -1,4 +1,4 @@
-"""Tests for ProjectCalendarLinkManager Slack channel bookmark management (kiconiaworks/kippo#13)."""
+"""Tests for ProjectCalendarLinkManager Slack pinned-message management (kiconiaworks/kippo#13)."""
 
 from unittest import mock
 
@@ -32,43 +32,61 @@ class ProjectCalendarLinkManagerTestCase(TestCase):
         with self.assertRaises(ValueError):
             ProjectCalendarLinkManager(self.organization)
 
-    @mock.patch("projects.slackcommand.managers.WebClient.bookmarks_add", return_value={"ok": True})
-    @mock.patch("projects.slackcommand.managers.WebClient.bookmarks_list", return_value={"bookmarks": []})
+    @mock.patch("projects.slackcommand.managers.WebClient.pins_add", return_value={"ok": True})
+    @mock.patch("projects.slackcommand.managers.WebClient.chat_postMessage", return_value={"ok": True, "ts": "1700000000.000100"})
+    @mock.patch("projects.slackcommand.managers.WebClient.pins_list", return_value={"items": []})
     @mock.patch("projects.slackcommand.managers.WebClient.conversations_list", return_value=CHANNELS_RESPONSE)
-    def test_set_calendar_bookmark_adds_new(self, mock_conversations: mock.MagicMock, mock_list: mock.MagicMock, mock_add: mock.MagicMock):
+    def test_set_calendar_pinned_message_adds_new(
+        self,
+        mock_conversations: mock.MagicMock,
+        mock_pins_list: mock.MagicMock,
+        mock_post: mock.MagicMock,
+        mock_pins_add: mock.MagicMock,
+    ):
         manager = ProjectCalendarLinkManager(self.organization)
-        result = manager.set_calendar_bookmark(self.project)
+        result = manager.set_calendar_pinned_message(self.project)
         assert result == "added"
-        mock_add.assert_called_once()
-        _, kwargs = mock_add.call_args
-        assert kwargs["channel_id"] == "C0ALPHA"
-        assert kwargs["link"] == self.project.get_meeting_calendar_template_url()
-        assert kwargs["title"] == ProjectCalendarLinkManager.CALENDAR_BOOKMARK_TITLE
+        mock_post.assert_called_once()
+        _, post_kwargs = mock_post.call_args
+        assert post_kwargs["channel"] == "C0ALPHA"
+        assert self.project.get_meeting_calendar_template_url() in post_kwargs["text"]
+        assert ProjectCalendarLinkManager.CALENDAR_MESSAGE_TITLE in post_kwargs["text"]
+        mock_pins_add.assert_called_once()
+        _, pin_kwargs = mock_pins_add.call_args
+        assert pin_kwargs["channel"] == "C0ALPHA"
+        assert pin_kwargs["timestamp"] == "1700000000.000100"
 
-    @mock.patch("projects.slackcommand.managers.WebClient.bookmarks_edit", return_value={"ok": True})
-    @mock.patch("projects.slackcommand.managers.WebClient.bookmarks_list")
+    @mock.patch("projects.slackcommand.managers.WebClient.chat_update", return_value={"ok": True})
+    @mock.patch("projects.slackcommand.managers.WebClient.pins_list")
     @mock.patch("projects.slackcommand.managers.WebClient.conversations_list", return_value=CHANNELS_RESPONSE)
-    def test_set_calendar_bookmark_updates_existing(self, mock_conversations: mock.MagicMock, mock_list: mock.MagicMock, mock_edit: mock.MagicMock):
-        mock_list.return_value = {"bookmarks": [{"id": "Bk1", "title": ProjectCalendarLinkManager.CALENDAR_BOOKMARK_TITLE}]}
+    def test_set_calendar_pinned_message_updates_existing(
+        self,
+        mock_conversations: mock.MagicMock,
+        mock_pins_list: mock.MagicMock,
+        mock_update: mock.MagicMock,
+    ):
+        existing_text = f":calendar: <https://calendar.google.com/old|{ProjectCalendarLinkManager.CALENDAR_MESSAGE_TITLE}>"
+        mock_pins_list.return_value = {"items": [{"type": "message", "message": {"ts": "1699999999.000200", "text": existing_text}}]}
         manager = ProjectCalendarLinkManager(self.organization)
-        result = manager.set_calendar_bookmark(self.project)
+        result = manager.set_calendar_pinned_message(self.project)
         assert result == "updated"
-        mock_edit.assert_called_once()
-        _, kwargs = mock_edit.call_args
-        assert kwargs["bookmark_id"] == "Bk1"
-        assert kwargs["link"] == self.project.get_meeting_calendar_template_url()
+        mock_update.assert_called_once()
+        _, kwargs = mock_update.call_args
+        assert kwargs["channel"] == "C0ALPHA"
+        assert kwargs["ts"] == "1699999999.000200"
+        assert self.project.get_meeting_calendar_template_url() in kwargs["text"]
 
     @mock.patch("projects.slackcommand.managers.WebClient.conversations_list", return_value=CHANNELS_RESPONSE)
-    def test_set_calendar_bookmark_channel_not_found(self, mock_conversations: mock.MagicMock):
+    def test_set_calendar_pinned_message_channel_not_found(self, mock_conversations: mock.MagicMock):
         self.project.slack_channel_name = "nonexistent-channel"
         self.project.save()
         manager = ProjectCalendarLinkManager(self.organization)
         with self.assertRaises(SlackChannelNotFoundError):
-            manager.set_calendar_bookmark(self.project)
+            manager.set_calendar_pinned_message(self.project)
 
-    def test_set_calendar_bookmark_requires_channel_name(self):
+    def test_set_calendar_pinned_message_requires_channel_name(self):
         self.project.slack_channel_name = ""
         self.project.save()
         manager = ProjectCalendarLinkManager(self.organization)
         with self.assertRaises(ValueError):
-            manager.set_calendar_bookmark(self.project)
+            manager.set_calendar_pinned_message(self.project)


### PR DESCRIPTION
## Summary

The "Add MTG calendar link to Slack channel" admin action previously added the calendar-template URL as a **channel bookmark**. Slack has since rolled out a layout change that collapses *every* channel bookmark into a single "Bookmarks" folder/dropdown in the channel header, with no API option to opt out. This switches the action to post the URL as a **pinned message**, which surfaces it as a standalone link in the channel's pinned items.

## Changes

- `ProjectCalendarLinkManager.set_calendar_bookmark` → **`set_calendar_pinned_message`**: locates an existing pinned MTG calendar message via `pins.list` and updates it with `chat.update`, or posts a new message and pins it (`chat.postMessage` + `pins.add`).
- Message text renders the URL as a clickable link: `:calendar: <url|MTG カレンダー作成>`.
- Constants `CALENDAR_BOOKMARK_*` → `CALENDAR_MESSAGE_*`.
- Admin action docstring updated; the action's behaviour, error handling, and add/update reporting are unchanged.

## ⚠️ Required Slack scopes change

The bot token no longer needs `bookmarks:write`. It now needs **`chat:write`**, **`pins:read`**, and **`pins:write`** (plus the existing `channels:read` / `groups:read`). Without these the action surfaces a Slack API error per project.

## Note on existing channels

Channels where the action already ran have an MTG calendar **bookmark**. Re-running now posts a **pinned message** and does not touch the old bookmark — those channels will have both. The stale bookmarks must be removed manually in Slack.

## Test plan

- `projects.tests.test_managers_projectcalendarlinkmanager` + `test_admin_meeting_calendar` — 15 tests pass
- `ruff check` clean

Refs kiconiaworks/kippo#13.