### PR TITLE
:sparkles: KippoCustomerAdmin: list related projects in a read-only inline (#280)

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1236,6 +1236,30 @@ class ActiveKippoProjectAdmin(KippoProjectAdmin):
         return qs
 
 
+class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
+    """Read-only list of projects linked to a KippoCustomer (managed via KippoProjectAdmin)."""
+
+    model = KippoProject
+    fk_name = "customer"
+    extra = 0
+    can_delete = False
+    verbose_name = _("プロジェクト")
+    verbose_name_plural = _("プロジェクト")
+    fields = ("get_project_link", "start_date", "target_date", "billing_date")
+    readonly_fields = ("get_project_link", "start_date", "target_date", "billing_date")
+
+    def has_add_permission(self, request: DjangoRequest, obj: models.Model | None = None) -> bool:  # No Add button
+        return False
+
+    def get_queryset(self, request: DjangoRequest):
+        # earliest target_date first
+        return super().get_queryset(request).order_by("target_date")
+
+    @admin.display(description=KippoProject._meta.get_field("name").verbose_name)
+    def get_project_link(self, obj: KippoProject):
+        return format_html('<a href="{}">{}</a>', obj.get_admin_url(), obj.name)
+
+
 @admin.register(KippoCustomer)
 class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     list_display = ("name", "organization", "email", "display_as_active", "updated_datetime")
@@ -1244,6 +1268,7 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     search_fields = ("name", "email")
     ordering = ("organization", "-display_as_active", "name")
     fields = ("organization", "name", "email", "phone", "website", "document_url", "notes", "display_as_active")
+    inlines = (KippoProjectReadOnlyInline,)
 
     def get_queryset(self, request: DjangoRequest):
         qs = super().get_queryset(request)

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -25,6 +25,7 @@ from projects.admin import (
     KippoMilestoneAdmin,
     KippoProjectAdmin,
     KippoProjectAdminForm,
+    KippoProjectReadOnlyInline,
     ProjectAssignmentRateInline,
     ProjectWeeklyEffortAdminInline,
     _next_upsell_project_name,
@@ -1365,6 +1366,73 @@ class IsStaffOrganizationKippoCustomerAdminTestCase(IsStaffModelAdminTestCaseBas
         ids = set(qs.values_list("id", flat=True))
         self.assertIn(self.customer_in_org.id, ids)
         self.assertNotIn(self.customer_in_other_org.id, ids)
+
+
+class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """KippoCustomerAdmin shows a read-only inline listing the customer's related projects."""
+
+    def setUp(self):
+        super().setUp()
+        self.customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="Acme",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="Globex",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+    def _make_customer_project(self, name: str, customer: KippoCustomer, target_date: date, billing_date: date) -> KippoProject:
+        return KippoProject.objects.create(
+            organization=self.organization,
+            name=name,
+            category="poc",
+            columnset=self.columnset,
+            customer=customer,
+            target_date=target_date,
+            billing_date=billing_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+    def test_inline_registered_and_read_only(self):
+        self.assertIn(KippoProjectReadOnlyInline, KippoCustomerAdmin.inlines)
+        inline = KippoProjectReadOnlyInline(KippoCustomer, self.site)
+        self.assertFalse(inline.has_add_permission(self.staff_user_request))
+        self.assertFalse(inline.can_delete)
+        # every displayed field is read-only
+        self.assertEqual(set(inline.fields), set(inline.readonly_fields))
+        for fieldname in ("get_project_link", "start_date", "target_date", "billing_date"):
+            self.assertIn(fieldname, inline.fields)
+
+    def test_change_view_lists_related_project_with_admin_link_and_billing_date(self):
+        project = self._make_customer_project("acme-alpha", self.customer, date(2026, 6, 1), date(2026, 6, 15))
+        url = reverse("admin:projects_kippocustomer_change", args=[self.customer.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.content.decode()
+        self.assertIn(project.name, content)
+        self.assertIn(project.get_admin_url(), content)
+        self.assertIn("2026-06-15", content)  # billing_date rendered
+
+    def test_change_view_orders_projects_by_target_date_ascending(self):
+        later = self._make_customer_project("acme-later", self.customer, date(2026, 9, 1), date(2026, 9, 1))
+        earlier = self._make_customer_project("acme-earlier", self.customer, date(2026, 3, 1), date(2026, 3, 1))
+        url = reverse("admin:projects_kippocustomer_change", args=[self.customer.id])
+        content = self.client.get(url).content.decode()
+        self.assertLess(content.index(earlier.name), content.index(later.name))
+
+    def test_change_view_excludes_other_customers_projects(self):
+        mine = self._make_customer_project("acme-mine", self.customer, date(2026, 6, 1), date(2026, 6, 1))
+        theirs = self._make_customer_project("globex-theirs", self.other_customer, date(2026, 6, 1), date(2026, 6, 1))
+        url = reverse("admin:projects_kippocustomer_change", args=[self.customer.id])
+        content = self.client.get(url).content.decode()
+        self.assertIn(mine.name, content)
+        self.assertNotIn(theirs.name, content)
 
 
 class KippoCustomerAdminOrganizationFieldTestCase(IsStaffModelAdminTestCaseBase):


### PR DESCRIPTION
Closes #280 — *do not auto-close*; merge per project policy.

## Summary

Adds `KippoProjectReadOnlyInline` to `KippoCustomerAdmin` so a customer's project portfolio is visible directly on the customer admin change page.

- Each row: **project name** (linked to its `KippoProjectAdmin` change page via the existing `KippoProject.get_admin_url()`), `start_date`, `target_date`, `billing_date`.
- Rows ordered **ascending by `target_date`** (earliest first; `target_date`-less projects sort according to the DB default).
- Fully read-only: `has_add_permission → False`, `can_delete = False`, every field in `readonly_fields`. Projects are still created/edited via `KippoProjectAdmin`.
- Modeled on the existing `KippoMilestoneReadOnlyInline` pattern in the same file.

Admin-only change — **no migration**.

## Branching note

Cut from `main`, which already contains both dependencies (`KippoCustomer` #273/#274, `KippoProject.billing_date` #279). `master` is stale and was not used.

## Tests

`kippo/projects/tests/test_admin.py` — new `KippoCustomerAdminProjectsInlineTestCase` (4 tests): inline registered + read-only config, change view renders the project link and `billing_date`, ordering by `target_date`, and other customers' projects excluded.

- `projects.tests.test_admin` — 76 tests pass.
- `ruff` check + format clean.
- `makemigrations projects --check` — no changes.