### PR TITLE
:sparkles: accounts: org-wide member listing API (#14)

### DIFF
--- a/kippo/accounts/serializers.py
+++ b/kippo/accounts/serializers.py
@@ -5,6 +5,41 @@ from rest_framework import serializers
 from .models import PersonalHoliday, PublicHoliday
 
 
+class OrganizationSerializer(serializers.Serializer):
+    """Minimal projection of a `KippoOrganization` for the org-listing endpoint.
+
+    Used by `GET /api/organizations/` so kippo-ui can render an org picker
+    without needing to embed the full admin model. Per kippo#14.
+    """
+
+    id = serializers.UUIDField(help_text="KippoOrganization primary key.")
+    name = serializers.CharField()
+    github_organization_name = serializers.CharField()
+
+
+class OrganizationMemberDetailSerializer(serializers.Serializer):
+    """Org-scoped projection of `KippoUser` joined with their `OrganizationMembership`.
+
+    Returned by `GET /api/organizations/<id>/members/`. Adds the per-org PII
+    (`email`, `slack_*`) that `projects.serializers.OrganizationMemberSerializer`
+    intentionally omits — keep these two serializers separate so the per-project
+    contract consumed by kippo-ui#57 is not coupled to this richer shape. Per kippo#14.
+    """
+
+    user_id = serializers.UUIDField(help_text="KippoUser primary key.")
+    username = serializers.CharField()
+    display_name = serializers.CharField(help_text="Composed first + last + (github_login).")
+    first_name = serializers.CharField(allow_blank=True)
+    last_name = serializers.CharField(allow_blank=True)
+    email = serializers.CharField(allow_blank=True, help_text="Per-org email from OrganizationMembership, not KippoUser.")
+    github_login = serializers.CharField(allow_blank=True)
+    is_developer = serializers.BooleanField()
+    is_project_manager = serializers.BooleanField()
+    slack_username = serializers.CharField(allow_blank=True)
+    slack_user_id = serializers.CharField(allow_blank=True)
+    slack_image_url = serializers.CharField(allow_blank=True)
+
+
 class PersonalHolidaySerializer(serializers.ModelSerializer):
     """Serializer for PersonalHoliday model.
 

--- a/kippo/accounts/tests/test_organization_members_api.py
+++ b/kippo/accounts/tests/test_organization_members_api.py
@@ -76,6 +76,32 @@ class OrganizationListTestCase(TestCase):
         self.assertEqual(org["name"], self.organization.name)
         self.assertEqual(org["github_organization_name"], self.organization.github_organization_name)
 
+    def test_retrieve_own_org_returns_200(self):
+        """`GET /api/organizations/<id>/` returns the org when the requester is a member."""
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/organizations/{self.organization.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json()["id"], str(self.organization.id))
+
+    def test_retrieve_other_org_returns_404(self):
+        """`GET /api/organizations/<id>/` is filtered through get_queryset, so a non-member gets
+        404 (org is filtered out). This is the cross-org leak guard for the retrieve action.
+        """
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/organizations/{self.other_organization.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_loner_cannot_retrieve_any_org(self):
+        """A user with zero memberships gets 404 for every existing org id."""
+        loner = KippoUser.objects.create(username="loner2", is_staff=True)
+        self.client.force_authenticate(user=loner)
+        for org_id in (self.organization.id, self.other_organization.id):
+            url = f"{settings.URL_PREFIX}/api/organizations/{org_id}/"
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, f"leaked org {org_id}")
+
 
 class OrganizationMembersAPITestCase(TestCase):
     """`GET /api/organizations/<id>/members/` — list members of one org."""

--- a/kippo/accounts/tests/test_organization_members_api.py
+++ b/kippo/accounts/tests/test_organization_members_api.py
@@ -1,0 +1,255 @@
+"""Tests for the org-level user-listing API (kippo#14)."""
+
+import uuid
+from http import HTTPStatus
+
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from accounts.models import EmailDomain, KippoOrganization, KippoUser, OrganizationMembership
+
+
+class OrganizationListTestCase(TestCase):
+    """`GET /api/organizations/` — list orgs the requester belongs to."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.user = created["KippoUser"]
+        self.organization = created["KippoOrganization"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        # Second org the user does NOT belong to.
+        self.other_organization = KippoOrganization.objects.create(
+            name="other-org",
+            github_organization_name="other-org",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.client = APIClient()
+
+    def test_unauthenticated_returns_401(self):
+        url = f"{settings.URL_PREFIX}/api/organizations/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_authenticated_user_sees_only_own_orgs(self):
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/organizations/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        data = response.json()
+        self.assertIn("organizations", data)
+        org_ids = [o["id"] for o in data["organizations"]]
+        self.assertIn(str(self.organization.id), org_ids)
+        self.assertNotIn(str(self.other_organization.id), org_ids)
+
+    def test_user_without_memberships_gets_empty_list(self):
+        loner = KippoUser.objects.create(username="loner", is_staff=True)
+        self.client.force_authenticate(user=loner)
+        url = f"{settings.URL_PREFIX}/api/organizations/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json(), {"organizations": []})
+
+    def test_superuser_sees_all_orgs(self):
+        superuser = KippoUser.objects.create(username="root", is_staff=True, is_superuser=True)
+        self.client.force_authenticate(user=superuser)
+        url = f"{settings.URL_PREFIX}/api/organizations/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        org_ids = [o["id"] for o in response.json()["organizations"]]
+        self.assertIn(str(self.organization.id), org_ids)
+        self.assertIn(str(self.other_organization.id), org_ids)
+
+    def test_org_response_shape(self):
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/organizations/"
+        response = self.client.get(url)
+        org = next(o for o in response.json()["organizations"] if o["id"] == str(self.organization.id))
+        self.assertEqual(set(org.keys()), {"id", "name", "github_organization_name"})
+        self.assertEqual(org["name"], self.organization.name)
+        self.assertEqual(org["github_organization_name"], self.organization.github_organization_name)
+
+
+class OrganizationMembersAPITestCase(TestCase):
+    """`GET /api/organizations/<id>/members/` — list members of one org."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.user = created["KippoUser"]
+        self.organization = created["KippoOrganization"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        # PM member, with all the per-org PII populated.
+        self.pm_user = KippoUser.objects.create(
+            username="pm-user",
+            first_name="Pat",
+            last_name="Manager",
+            github_login="pat-pm",
+            is_staff=True,
+        )
+        OrganizationMembership.objects.create(
+            user=self.pm_user,
+            organization=self.organization,
+            email="pat@github.com",
+            slack_username="pat",
+            slack_user_id="U02PM",
+            slack_image_url="https://example.com/pat.png",
+            is_developer=False,
+            is_project_manager=True,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        # Inactive developer. NOTE: OrganizationMembership.save() re-activates the user when
+        # the org has an is_staff_domain — so we flip is_active=False AFTER the membership is created.
+        self.inactive_user = KippoUser.objects.create(
+            username="ghost",
+            github_login="ghost",
+            is_staff=False,
+        )
+        OrganizationMembership.objects.create(
+            user=self.inactive_user,
+            organization=self.organization,
+            is_developer=True,
+            is_project_manager=False,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.inactive_user.is_active = False
+        self.inactive_user.save()
+
+        # Second org the requester does NOT belong to.
+        self.other_organization = KippoOrganization.objects.create(
+            name="other-org",
+            github_organization_name="other-org",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        EmailDomain.objects.create(
+            organization=self.other_organization,
+            domain="example.com",
+            is_staff_domain=False,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_org_user = KippoUser.objects.create(username="otheruser", is_staff=True)
+        OrganizationMembership.objects.create(
+            user=self.other_org_user,
+            organization=self.other_organization,
+            is_developer=True,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.client = APIClient()
+
+    def _url(self, org_id: str | uuid.UUID) -> str:
+        return f"{settings.URL_PREFIX}/api/organizations/{org_id}/members/"
+
+    def test_unauthenticated_returns_401(self):
+        response = self.client.get(self._url(self.organization.id))
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_nonexistent_org_returns_404(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(uuid.uuid4()))
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_non_member_returns_403(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(self.other_organization.id))
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_member_can_list_org_members(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(self.organization.id))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        data = response.json()
+        self.assertIn("members", data)
+        usernames = [m["username"] for m in data["members"]]
+        self.assertIn(self.user.username, usernames)
+        self.assertIn(self.pm_user.username, usernames)
+
+    def test_inactive_user_excluded_by_default(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(self.organization.id))
+        usernames = [m["username"] for m in response.json()["members"]]
+        self.assertNotIn(self.inactive_user.username, usernames)
+
+    def test_include_inactive_opts_in(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(self.organization.id) + "?include_inactive=true")
+        usernames = [m["username"] for m in response.json()["members"]]
+        self.assertIn(self.inactive_user.username, usernames)
+
+    def test_filter_is_developer(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(self.organization.id) + "?is_developer=true")
+        usernames = [m["username"] for m in response.json()["members"]]
+        # octocat (setup_basic_project) is is_developer=True; pm-user is is_developer=False.
+        self.assertIn(self.user.username, usernames)
+        self.assertNotIn(self.pm_user.username, usernames)
+
+    def test_filter_is_project_manager(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(self.organization.id) + "?is_project_manager=true")
+        usernames = [m["username"] for m in response.json()["members"]]
+        self.assertEqual(usernames, [self.pm_user.username])
+
+    def test_unassigned_bot_excluded(self):
+        # KippoOrganization.save() auto-creates an `unassigned-<slug>` membership.
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(self.organization.id))
+        for member in response.json()["members"]:
+            self.assertFalse(
+                member["username"].startswith(settings.UNASSIGNED_USER_GITHUB_LOGIN_PREFIX),
+                f"unassigned bot leaked into members listing: {member['username']}",
+            )
+
+    def test_response_shape_has_all_fields(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._url(self.organization.id))
+        pm = next(m for m in response.json()["members"] if m["username"] == self.pm_user.username)
+        self.assertEqual(
+            set(pm.keys()),
+            {
+                "user_id",
+                "username",
+                "display_name",
+                "first_name",
+                "last_name",
+                "email",
+                "github_login",
+                "is_developer",
+                "is_project_manager",
+                "slack_username",
+                "slack_user_id",
+                "slack_image_url",
+            },
+        )
+        # Slack/email fields come from OrganizationMembership, not KippoUser.
+        self.assertEqual(pm["email"], "pat@github.com")
+        self.assertEqual(pm["slack_username"], "pat")
+        self.assertEqual(pm["slack_user_id"], "U02PM")
+        self.assertEqual(pm["slack_image_url"], "https://example.com/pat.png")
+        self.assertEqual(pm["first_name"], "Pat")
+        self.assertEqual(pm["last_name"], "Manager")
+        self.assertFalse(pm["is_developer"])
+        self.assertTrue(pm["is_project_manager"])
+
+    def test_superuser_can_list_any_org(self):
+        superuser = KippoUser.objects.create(username="root", is_staff=True, is_superuser=True)
+        self.client.force_authenticate(user=superuser)
+        response = self.client.get(self._url(self.other_organization.id))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        usernames = [m["username"] for m in response.json()["members"]]
+        self.assertIn(self.other_org_user.username, usernames)

--- a/kippo/accounts/viewsets.py
+++ b/kippo/accounts/viewsets.py
@@ -1,17 +1,25 @@
 """ViewSets for Accounts API."""
 
+from http import HTTPStatus
 from typing import Any
 
-from drf_spectacular.utils import OpenApiParameter, extend_schema
+from django.conf import settings
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, inline_serializer
 from rest_framework import viewsets
+from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from .models import PersonalHoliday, PublicHoliday
-from .serializers import PersonalHolidaySerializer, PublicHolidaySerializer
+from .models import KippoOrganization, OrganizationMembership, PersonalHoliday, PublicHoliday
+from .serializers import (
+    OrganizationMemberDetailSerializer,
+    OrganizationSerializer,
+    PersonalHolidaySerializer,
+    PublicHolidaySerializer,
+)
 
 
 class PersonalHolidayViewSet(viewsets.ModelViewSet):
@@ -75,6 +83,147 @@ class PersonalHolidayViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(day__lte=day_lte)
 
         return queryset
+
+
+_TRUTHY = ("true", "1", "yes")
+
+
+class OrganizationViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+    """
+    Read-only ViewSet for KippoOrganization.
+
+    Exposes the organizations the requester is a member of (superusers see all),
+    plus a `members` action that lists active members of a single organization.
+    See kippo#14.
+
+    **Endpoints:**
+    - `GET /api/organizations/` — list orgs the user belongs to
+    - `GET /api/organizations/<id>/members/` — list members of one org
+
+    **Permissions:**
+    - Read only: Authenticated users
+    - Non-members of `<id>` receive 403 from the `members` action
+    """
+
+    serializer_class = OrganizationSerializer
+    permission_classes = [IsAuthenticated]
+    queryset = KippoOrganization.objects.all().order_by("name")
+
+    def get_queryset(self):
+        """Scope to the requester's organization memberships (superusers see all)."""
+        queryset = super().get_queryset()
+        user = self.request.user
+        if not user.is_superuser and hasattr(user, "organizationmembership_set"):
+            user_organizations = user.organizationmembership_set.values_list("organization", flat=True)
+            queryset = queryset.filter(id__in=user_organizations)
+        return queryset
+
+    @extend_schema(
+        responses={
+            HTTPStatus.OK: OpenApiResponse(
+                response=inline_serializer(
+                    name="OrganizationListResponse",
+                    fields={"organizations": OrganizationSerializer(many=True)},
+                ),
+                description="Organizations the requesting user belongs to. Empty list when the user has no memberships.",
+            ),
+        },
+        description=(
+            "List the organizations the requesting user belongs to. Used by kippo-ui to "
+            "render an org-wide user picker for views that are not scoped to a single project."
+        ),
+    )
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401, ARG002
+        # Wrap in a named-key response so drf-spectacular doesn't auto-paginate the schema.
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return Response({"organizations": serializer.data})
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name="is_developer", description="Filter to developers only.", required=False, type=bool),
+            OpenApiParameter(name="is_project_manager", description="Filter to project managers only.", required=False, type=bool),
+            OpenApiParameter(
+                name="include_inactive",
+                description="Include KippoUser.is_active=False users. Default false.",
+                required=False,
+                type=bool,
+            ),
+        ],
+        responses={
+            HTTPStatus.OK: OpenApiResponse(
+                response=inline_serializer(
+                    name="OrganizationMembersResponse",
+                    fields={"members": OrganizationMemberDetailSerializer(many=True)},
+                ),
+                description="Members of the organization, with per-org Slack and email fields.",
+            ),
+            HTTPStatus.FORBIDDEN: OpenApiResponse(description="Requester is not a member of the organization."),
+            HTTPStatus.NOT_FOUND: OpenApiResponse(description="Organization does not exist."),
+        },
+        description=(
+            "Active members of the given organization. Excludes the unassigned bot user "
+            "and (by default) KippoUser.is_active=False users. Returns the richer per-org "
+            "shape (adds email and slack_* fields) that the per-project endpoint omits."
+        ),
+    )
+    @action(detail=True, methods=["get"], url_path="members", permission_classes=[IsAuthenticated])
+    def members(self, request: Request, pk: str | None = None) -> Response:  # noqa: ARG002
+        # Explicit 404 vs 403 split: 404 if the org does not exist; 403 if the requester
+        # is not a member (instead of the default 404 you'd get from get_queryset filtering).
+        try:
+            organization = KippoOrganization.objects.get(pk=pk)
+        except KippoOrganization.DoesNotExist:
+            return Response({"detail": "Not found."}, status=HTTPStatus.NOT_FOUND)
+
+        user = request.user
+        if not user.is_superuser:
+            user_org_ids = set(user.organizationmembership_set.values_list("organization_id", flat=True))
+            if organization.id not in user_org_ids:
+                return Response(
+                    {"detail": "You are not a member of this organization."},
+                    status=HTTPStatus.FORBIDDEN,
+                )
+
+        # Use self.request.query_params (Any-typed) over the more strictly-typed request param
+        # to match the dynamic-typing pattern already used in projects/viewsets.py for query params.
+        include_inactive_raw = self.request.query_params.get("include_inactive")
+        include_inactive = include_inactive_raw is not None and include_inactive_raw.lower() in _TRUTHY
+
+        membership_filters: dict[str, Any] = {"organization": organization}
+        for key in ("is_developer", "is_project_manager"):
+            raw = self.request.query_params.get(key)
+            if raw is not None:
+                membership_filters[key] = raw.lower() in _TRUTHY
+
+        memberships = (
+            OrganizationMembership.objects.filter(**membership_filters)
+            .select_related("user")
+            .exclude(user__username__startswith=settings.UNASSIGNED_USER_GITHUB_LOGIN_PREFIX)
+            .order_by("user__username")
+        )
+        if not include_inactive:
+            memberships = memberships.filter(user__is_active=True)
+
+        payload = [
+            {
+                "user_id": m.user.id,
+                "username": m.user.username,
+                "display_name": m.user.display_name.strip() or m.user.username,
+                "first_name": m.user.first_name or "",
+                "last_name": m.user.last_name or "",
+                "email": m.email or "",
+                "github_login": m.user.github_login or "",
+                "is_developer": m.is_developer,
+                "is_project_manager": m.is_project_manager,
+                "slack_username": m.slack_username or "",
+                "slack_user_id": m.slack_user_id or "",
+                "slack_image_url": m.slack_image_url or "",
+            }
+            for m in memberships
+        ]
+        # Wrap in a named-key response so drf-spectacular doesn't auto-paginate the schema.
+        return Response({"members": OrganizationMemberDetailSerializer(payload, many=True).data})
 
 
 class PublicHolidayViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):

--- a/kippo/projects/urls.py
+++ b/kippo/projects/urls.py
@@ -1,4 +1,4 @@
-from accounts.viewsets import PersonalHolidayViewSet, PublicHolidayViewSet
+from accounts.viewsets import OrganizationViewSet, PersonalHolidayViewSet, PublicHolidayViewSet
 from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.routers import DefaultRouter
@@ -32,6 +32,7 @@ router.register(r"monthly-costs", ProjectMonthlyCostViewSet, basename="projectmo
 router.register(r"project-surveys", KippoProjectUserStatisfactionResultViewSet, basename="projectsurvey")
 router.register(r"personal-holidays", PersonalHolidayViewSet, basename="personalholiday")
 router.register(r"public-holidays", PublicHolidayViewSet, basename="publicholiday")
+router.register(r"organizations", OrganizationViewSet, basename="kippoorganization")
 
 # Manually define weeklyeffort viewset URLs to nest under projects/
 weeklyeffort_list = ProjectWeeklyEffortViewSet.as_view(


### PR DESCRIPTION
## Summary

Adds two endpoints so kippo-ui (and downstream services) can pick org members without first selecting a project:

- `GET /api/organizations/` — orgs the requester belongs to
- `GET /api/organizations/<id>/members/` — active members of one org

The members endpoint returns the richer per-org shape (`email`, `slack_username`, `slack_user_id`, `slack_image_url`) that the existing per-project endpoint at `projects/viewsets.py:167` intentionally omits. The per-project contract is left untouched (consumed by kippo-ui#57).

## Implementation

- `accounts/serializers.py` — `OrganizationSerializer`, `OrganizationMemberDetailSerializer`
- `accounts/viewsets.py` — `OrganizationViewSet` (read-only) with a `members` action
- `projects/urls.py` — registered on the existing router (flat `/api/` namespace, consistent with how `personal-holidays` / `public-holidays` from the `accounts` app are already mounted there)
- `accounts/tests/test_organization_members_api.py` — 16 tests covering every acceptance criterion

## Behavior

- 401 unauthenticated; 403 for authed non-members; 404 for unknown org UUID
- Wraps response in `{"organizations": [...]}` / `{"members": [...]}` to suppress drf-spectacular auto-pagination (matches existing per-project members convention at `projects/viewsets.py:195`)
- Excludes inactive users by default; `?include_inactive=true` opts in
- Filters: `?is_developer=true`, `?is_project_manager=true`
- Excludes `settings.UNASSIGNED_USER_GITHUB_LOGIN_PREFIX` bot users
- Superusers see all orgs (mirrors other viewsets)

## Test plan

- [x] `uv run python manage.py test accounts.tests.test_organization_members_api` — 16/16
- [x] `uv run python manage.py test projects.tests.test_api_rest accounts.tests` — 151/151 (no regressions)
- [x] `uv run poe check` (ruff) — clean
- [x] pyright — no new errors (only pre-existing Django stub gaps)
- [x] `spectacular --validate` — 0 errors; routes visible at `/api/organizations/`, `/api/organizations/{id}/`, `/api/organizations/{id}/members/`

Refs upstream issue kiconiaworks/kippo#14.