### PR TITLE
:sparkles: API: create KippoProject and create/link octocat.GithubRepository (#284)

### DIFF
--- a/kippo/kippo/urls.py
+++ b/kippo/kippo/urls.py
@@ -11,6 +11,7 @@ from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView
 from feedback.urls import api_patterns as feedback_api_patterns
+from octocat.urls import api_patterns as octocat_api_patterns
 from projects.urls import api_patterns
 from requirements.urls import api_patterns as requirements_api_patterns
 
@@ -27,6 +28,7 @@ urlpatterns = [
     path("api/", include(api_patterns)),
     path("api/requirements/", include(requirements_api_patterns)),
     path("api/feedback/", include(feedback_api_patterns)),
+    path("api/octocat/", include(octocat_api_patterns)),
     # SPA UI - catch all routes under /ui/ and serve index.html
     re_path(r"^ui/(?P<path>.*)$", SPAView.as_view(), name="spa-ui"),
     path("ui/", SPAView.as_view(), name="spa-ui-root"),

--- a/kippo/octocat/serializers.py
+++ b/kippo/octocat/serializers.py
@@ -1,0 +1,43 @@
+"""Serializers for the octocat REST API (kippo#284)."""
+
+from rest_framework import serializers
+
+from .models import GithubRepository
+
+
+class GithubRepositorySerializer(serializers.ModelSerializer):
+    organization_name = serializers.CharField(source="organization.name", read_only=True)
+    project_name = serializers.CharField(source="project.name", read_only=True, allow_null=True)
+
+    class Meta:
+        model = GithubRepository
+        fields = [
+            "id",
+            "organization",
+            "organization_name",
+            "project",
+            "project_name",
+            "name",
+            "html_url",
+            "api_url",
+            "label_set",
+            "created_datetime",
+            "updated_datetime",
+        ]
+        read_only_fields = [
+            "id",
+            "organization_name",
+            "project_name",
+            "created_datetime",
+            "updated_datetime",
+        ]
+        # Skip the auto-derived UniqueTogetherValidator(name, html_url, api_url) — the nested
+        # POST endpoint upserts on this triple intentionally (kippo#284). DB-level
+        # unique_together still applies via the model's Meta.
+        validators = []
+        extra_kwargs = {
+            # Auto-set from the parent project in nested create; never required from the client.
+            "organization": {"required": False},
+            "project": {"required": False, "allow_null": True},
+            "label_set": {"required": False, "allow_null": True},
+        }

--- a/kippo/octocat/tests/test_api_rest.py
+++ b/kippo/octocat/tests/test_api_rest.py
@@ -74,16 +74,16 @@ class GithubRepositoryAPITestCase(TestCase):
 
         self.client = APIClient()
 
-    # --- top-level /api/github-repositories/ -----------------------------
+    # --- top-level /api/octocat/github-repositories/ ---------------------
 
     def test_list_requires_authentication(self):
-        url = f"{settings.URL_PREFIX}/api/github-repositories/"
+        url = f"{settings.URL_PREFIX}/api/octocat/github-repositories/"
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_list_is_org_scoped(self):
         self.client.force_authenticate(user=self.user)
-        url = f"{settings.URL_PREFIX}/api/github-repositories/"
+        url = f"{settings.URL_PREFIX}/api/octocat/github-repositories/"
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         ids = [r["id"] for r in response.json()["results"]]
@@ -92,7 +92,7 @@ class GithubRepositoryAPITestCase(TestCase):
 
     def test_retrieve_other_org_repo_returns_404(self):
         self.client.force_authenticate(user=self.user)
-        url = f"{settings.URL_PREFIX}/api/github-repositories/{self.other_org_repo.id}/"
+        url = f"{settings.URL_PREFIX}/api/octocat/github-repositories/{self.other_org_repo.id}/"
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
@@ -105,7 +105,7 @@ class GithubRepositoryAPITestCase(TestCase):
             is_superuser=True,
         )
         self.client.force_authenticate(user=superuser)
-        url = f"{settings.URL_PREFIX}/api/github-repositories/"
+        url = f"{settings.URL_PREFIX}/api/octocat/github-repositories/"
         response = self.client.get(url)
         ids = [r["id"] for r in response.json()["results"]]
         self.assertIn(str(self.own_repo.id), ids)

--- a/kippo/octocat/tests/test_api_rest.py
+++ b/kippo/octocat/tests/test_api_rest.py
@@ -1,0 +1,233 @@
+"""Tests for the octocat REST API (kippo#284)."""
+
+from http import HTTPStatus
+
+from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
+from django.test import TestCase, override_settings
+from projects.models import KippoProject
+from rest_framework.test import APIClient
+
+from ..models import GithubRepository
+
+
+@override_settings(OCTOCAT_APPLY_DEFAULT_LABELSET=False)
+class GithubRepositoryAPITestCase(TestCase):
+    """Top-level + nested GithubRepository endpoints (kippo#284)."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.user = created["KippoUser"]
+        self.project = created["KippoProject"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        self.other_organization = KippoOrganization.objects.create(
+            name="repo-api-other-org",
+            github_organization_name="repo-api-other-org",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_user = KippoUser.objects.create(
+            username="repo-api-otheruser",
+            github_login="repo-api-otheruser",
+            email="repo-api-otheruser@example.com",
+            is_staff=True,
+        )
+        OrganizationMembership.objects.create(
+            user=self.other_user,
+            organization=self.other_organization,
+            is_developer=True,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_project = KippoProject.objects.create(
+            name="Other Org Project",
+            organization=self.other_organization,
+            columnset=self.project.columnset,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        # Pre-existing repos: one linked to self.project, one in the other org
+        self.own_repo = GithubRepository.objects.create(
+            organization=self.organization,
+            project=self.project,
+            name="own-repo",
+            api_url="https://api.github.com/repos/myorg/own-repo",
+            html_url="https://github.com/myorg/own-repo",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_org_repo = GithubRepository.objects.create(
+            organization=self.other_organization,
+            project=self.other_project,
+            name="other-org-repo",
+            api_url="https://api.github.com/repos/repo-api-other-org/other-org-repo",
+            html_url="https://github.com/repo-api-other-org/other-org-repo",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.client = APIClient()
+
+    # --- top-level /api/github-repositories/ -----------------------------
+
+    def test_list_requires_authentication(self):
+        url = f"{settings.URL_PREFIX}/api/github-repositories/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_list_is_org_scoped(self):
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/github-repositories/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ids = [r["id"] for r in response.json()["results"]]
+        self.assertIn(str(self.own_repo.id), ids)
+        self.assertNotIn(str(self.other_org_repo.id), ids)
+
+    def test_retrieve_other_org_repo_returns_404(self):
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/github-repositories/{self.other_org_repo.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_superuser_sees_all_repos(self):
+        superuser = KippoUser.objects.create(
+            username="repo-api-superuser",
+            github_login="repo-api-superuser",
+            email="repo-api-superuser@example.com",
+            is_staff=True,
+            is_superuser=True,
+        )
+        self.client.force_authenticate(user=superuser)
+        url = f"{settings.URL_PREFIX}/api/github-repositories/"
+        response = self.client.get(url)
+        ids = [r["id"] for r in response.json()["results"]]
+        self.assertIn(str(self.own_repo.id), ids)
+        self.assertIn(str(self.other_org_repo.id), ids)
+
+    # --- nested /api/projects/{pid}/github-repositories/ -----------------
+
+    def _nested_url(self, project_id: object, pk: object | None = None) -> str:
+        base = f"{settings.URL_PREFIX}/api/projects/{project_id}/github-repositories/"
+        return f"{base}{pk}/" if pk else base
+
+    def test_nested_list_filters_to_parent_project(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._nested_url(self.project.id))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ids = [r["id"] for r in response.json()["results"]]
+        self.assertEqual(ids, [str(self.own_repo.id)])
+
+    def test_nested_list_for_other_org_project_returns_403(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._nested_url(self.other_project.id))
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_nested_list_unknown_project_returns_404(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self._nested_url("00000000-0000-4000-8000-000000000000"))
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_nested_create_new_repo_returns_201(self):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "name": "kiconiaworks-newrepo-api",
+            "html_url": "https://github.com/myorg/kiconiaworks-newrepo-api",
+            "api_url": "https://api.github.com/repos/myorg/kiconiaworks-newrepo-api",
+        }
+        response = self.client.post(self._nested_url(self.project.id), payload, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        repo = GithubRepository.objects.get(html_url=payload["html_url"])
+        self.assertEqual(repo.organization, self.organization)
+        self.assertEqual(repo.project, self.project)
+        self.assertEqual(repo.created_by, self.user)
+
+    def test_nested_create_existing_unlinked_repo_links_and_returns_200(self):
+        # Repo exists but is not linked to any project
+        repo = GithubRepository.objects.create(
+            organization=self.organization,
+            project=None,
+            name="orphan-repo",
+            api_url="https://api.github.com/repos/myorg/orphan-repo",
+            html_url="https://github.com/myorg/orphan-repo",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.client.force_authenticate(user=self.user)
+        payload = {"name": repo.name, "html_url": repo.html_url, "api_url": repo.api_url}
+        response = self.client.post(self._nested_url(self.project.id), payload, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        repo.refresh_from_db()
+        self.assertEqual(repo.project, self.project)
+        self.assertEqual(GithubRepository.objects.filter(name="orphan-repo").count(), 1)
+
+    def test_nested_create_already_linked_is_idempotent(self):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "name": self.own_repo.name,
+            "html_url": self.own_repo.html_url,
+            "api_url": self.own_repo.api_url,
+        }
+        response = self.client.post(self._nested_url(self.project.id), payload, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        # Still exactly one row
+        self.assertEqual(GithubRepository.objects.filter(html_url=self.own_repo.html_url).count(), 1)
+
+    def test_nested_create_cross_org_collision_returns_409(self):
+        """Re-posting another org's existing repo to this project must not reparent (kippo#284 decision #3)."""
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "name": self.other_org_repo.name,
+            "html_url": self.other_org_repo.html_url,
+            "api_url": self.other_org_repo.api_url,
+        }
+        response = self.client.post(self._nested_url(self.project.id), payload, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CONFLICT)
+        self.other_org_repo.refresh_from_db()
+        self.assertEqual(self.other_org_repo.organization, self.other_organization)
+        self.assertEqual(self.other_org_repo.project, self.other_project)
+
+    def test_nested_create_for_other_org_project_returns_403(self):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "name": "wedge-repo",
+            "html_url": "https://github.com/repo-api-other-org/wedge-repo",
+            "api_url": "https://api.github.com/repos/repo-api-other-org/wedge-repo",
+        }
+        response = self.client.post(self._nested_url(self.other_project.id), payload, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        self.assertFalse(GithubRepository.objects.filter(name="wedge-repo").exists())
+
+    def test_nested_delete_unlinks_but_keeps_row(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self._nested_url(self.project.id, self.own_repo.id))
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+        self.own_repo.refresh_from_db()
+        self.assertIsNone(self.own_repo.project)
+        # Row persists
+        self.assertTrue(GithubRepository.objects.filter(pk=self.own_repo.pk).exists())
+
+    def test_nested_delete_repo_not_under_project_returns_404(self):
+        # other_org_repo is not linked to self.project; deleting via self.project's path is 404
+        # But we'd hit the org-scope 403 first because the user can't see self.project... wait,
+        # the user CAN see self.project. The repo we name is under another project. The viewset's
+        # get_queryset filters by project=self.project, so DRF returns 404.
+        self.client.force_authenticate(user=self.user)
+        # Create a repo in our org but linked to nothing
+        loose = GithubRepository.objects.create(
+            organization=self.organization,
+            project=None,
+            name="loose-repo",
+            api_url="https://api.github.com/repos/myorg/loose-repo",
+            html_url="https://github.com/myorg/loose-repo",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        response = self.client.delete(self._nested_url(self.project.id, loose.id))
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/kippo/octocat/urls.py
+++ b/kippo/octocat/urls.py
@@ -1,6 +1,16 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
 from . import views
+from .viewsets import GithubRepositoryViewSet
+
+github_repository_list = GithubRepositoryViewSet.as_view({"get": "list"})
+github_repository_detail = GithubRepositoryViewSet.as_view({"get": "retrieve"})
+
+# REST API URLs — mounted under /api/octocat/ in root kippo/urls.py (kippo#284)
+api_patterns = [
+    path("github-repositories/", github_repository_list, name="github-repository-list"),
+    path("github-repositories/<uuid:pk>/", github_repository_detail, name="github-repository-detail"),
+]
 
 urlpatterns = [
     re_path(

--- a/kippo/octocat/viewsets.py
+++ b/kippo/octocat/viewsets.py
@@ -4,15 +4,21 @@ from http import HTTPStatus
 from typing import Any
 
 from django.shortcuts import get_object_or_404
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from projects.models import KippoProject
-from rest_framework import mixins, viewsets
+from rest_framework import mixins, serializers, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from .models import GithubRepository
 from .serializers import GithubRepositorySerializer
+
+
+class _ErrorDetailSerializer(serializers.Serializer):
+    """Standard DRF-style error envelope: ``{"detail": "<message>"}``."""
+
+    detail = serializers.CharField()
 
 
 def _user_org_ids(user: Any) -> set:  # noqa: ANN401
@@ -23,6 +29,11 @@ def _user_org_ids(user: Any) -> set:  # noqa: ANN401
     return set(user.organizationmembership_set.values_list("organization", flat=True))
 
 
+@extend_schema(
+    responses={
+        HTTPStatus.UNAUTHORIZED: OpenApiResponse(response=_ErrorDetailSerializer, description="Authentication required."),
+    }
+)
 class GithubRepositoryViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
@@ -45,7 +56,40 @@ class GithubRepositoryViewSet(
             queryset = queryset.filter(organization__in=_user_org_ids(user))
         return queryset
 
+    @extend_schema(
+        responses={
+            HTTPStatus.OK: GithubRepositorySerializer,
+            HTTPStatus.NOT_FOUND: OpenApiResponse(
+                response=_ErrorDetailSerializer,
+                description="Repository not found (also returned when the repository is in an org the requester does not belong to).",
+            ),
+        }
+    )
+    def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
+        return super().retrieve(request, *args, **kwargs)
 
+
+_PROJECT_FORBIDDEN_RESPONSE = OpenApiResponse(
+    response=_ErrorDetailSerializer,
+    description="Project is not in any of the requester's organizations.",
+)
+_PROJECT_NOT_FOUND_RESPONSE = OpenApiResponse(
+    response=_ErrorDetailSerializer,
+    description="No KippoProject with the given project_id.",
+)
+_UNAUTHORIZED_RESPONSE = OpenApiResponse(
+    response=_ErrorDetailSerializer,
+    description="Authentication required.",
+)
+
+
+@extend_schema(
+    responses={
+        HTTPStatus.UNAUTHORIZED: _UNAUTHORIZED_RESPONSE,
+        HTTPStatus.FORBIDDEN: _PROJECT_FORBIDDEN_RESPONSE,
+        HTTPStatus.NOT_FOUND: _PROJECT_NOT_FOUND_RESPONSE,
+    }
+)
 class ProjectGithubRepositoryViewSet(
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
@@ -79,7 +123,27 @@ class ProjectGithubRepositoryViewSet(
         project = self._get_project_or_403()
         return super().get_queryset().filter(project=project).order_by("name")
 
-    @extend_schema(responses={HTTPStatus.OK: GithubRepositorySerializer, HTTPStatus.CREATED: GithubRepositorySerializer})
+    @extend_schema(
+        responses={
+            HTTPStatus.OK: OpenApiResponse(
+                response=GithubRepositorySerializer,
+                description="Repository already existed and was linked (idempotent).",
+            ),
+            HTTPStatus.CREATED: OpenApiResponse(
+                response=GithubRepositorySerializer,
+                description="New repository row created and linked.",
+            ),
+            HTTPStatus.FORBIDDEN: _PROJECT_FORBIDDEN_RESPONSE,
+            HTTPStatus.NOT_FOUND: _PROJECT_NOT_FOUND_RESPONSE,
+            HTTPStatus.CONFLICT: OpenApiResponse(
+                response=_ErrorDetailSerializer,
+                description=(
+                    "A GithubRepository with the given (name, html_url, api_url) already exists in a different "
+                    "organization and cannot be reparented via the API. No mutation performed."
+                ),
+            ),
+        }
+    )
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
         project = self._get_project_or_403()
 
@@ -126,6 +190,16 @@ class ProjectGithubRepositoryViewSet(
         repo.save()
         return Response(self.get_serializer(repo).data, status=HTTPStatus.CREATED)
 
+    @extend_schema(
+        responses={
+            HTTPStatus.NO_CONTENT: OpenApiResponse(description="Repository unlinked from project; row retained."),
+            HTTPStatus.FORBIDDEN: _PROJECT_FORBIDDEN_RESPONSE,
+            HTTPStatus.NOT_FOUND: OpenApiResponse(
+                response=_ErrorDetailSerializer,
+                description="No such repository under this project (also when the repository exists but is linked to a different project).",
+            ),
+        }
+    )
     def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
         # Unlink (set project = NULL) but keep the row.
         instance = self.get_object()

--- a/kippo/octocat/viewsets.py
+++ b/kippo/octocat/viewsets.py
@@ -1,0 +1,135 @@
+"""ViewSets for the octocat REST API (kippo#284)."""
+
+from http import HTTPStatus
+from typing import Any
+
+from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
+from projects.models import KippoProject
+from rest_framework import mixins, viewsets
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from .models import GithubRepository
+from .serializers import GithubRepositorySerializer
+
+
+def _user_org_ids(user: Any) -> set:  # noqa: ANN401
+    if not (user and user.is_authenticated):
+        return set()
+    if not hasattr(user, "organizationmembership_set"):
+        return set()
+    return set(user.organizationmembership_set.values_list("organization", flat=True))
+
+
+class GithubRepositoryViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Read-only org-scoped listing of GithubRepository.
+
+    Write operations live under the nested project route — see
+    :class:`ProjectGithubRepositoryViewSet`.
+    """
+
+    serializer_class = GithubRepositorySerializer
+    permission_classes = [IsAuthenticated]
+    queryset = GithubRepository.objects.all().select_related("organization", "project").order_by("name")
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        user = self.request.user
+        if not user.is_superuser:
+            queryset = queryset.filter(organization__in=_user_org_ids(user))
+        return queryset
+
+
+class ProjectGithubRepositoryViewSet(
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    """Manage GithubRepository links for a single KippoProject.
+
+    Mounted under ``/api/projects/{project_id}/github-repositories/``.
+
+    - ``POST`` upserts by ``(name, html_url, api_url)`` and sets ``project_id``.
+      Returns 201 if the row was created, 200 if it already existed.
+    - ``DELETE`` unlinks (``project = NULL``) but keeps the row.
+    """
+
+    serializer_class = GithubRepositorySerializer
+    permission_classes = [IsAuthenticated]
+    queryset = GithubRepository.objects.all().select_related("organization", "project")
+
+    def _get_project_or_403(self) -> KippoProject:
+        project_id = self.kwargs["project_id"]
+        project = get_object_or_404(KippoProject, pk=project_id)
+        user = self.request.user
+        if not user.is_superuser and project.organization_id not in _user_org_ids(user):
+            # Mirror DRF's PermissionDenied -> 403 without leaking existence.
+            self.permission_denied(self.request, message="Project is not in any of your organizations.")
+        return project
+
+    def get_queryset(self):
+        project = self._get_project_or_403()
+        return super().get_queryset().filter(project=project).order_by("name")
+
+    @extend_schema(responses={HTTPStatus.OK: GithubRepositorySerializer, HTTPStatus.CREATED: GithubRepositorySerializer})
+    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
+        project = self._get_project_or_403()
+
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        name = data["name"]
+        html_url = data["html_url"]
+        api_url = data["api_url"]
+
+        existing = GithubRepository.objects.filter(name=name, html_url=html_url, api_url=api_url).first()
+
+        if existing is not None:
+            if existing.organization_id != project.organization_id:
+                return Response(
+                    {
+                        "detail": (
+                            "A GithubRepository with this (name, html_url, api_url) already exists in a different "
+                            "organization and cannot be reparented via the API."
+                        )
+                    },
+                    status=HTTPStatus.CONFLICT,
+                )
+            if existing.project_id != project.pk:
+                existing.project = project
+                existing.updated_by = request.user
+                existing.save(update_fields=["project", "updated_by", "updated_datetime"])
+            return Response(self.get_serializer(existing).data, status=HTTPStatus.OK)
+
+        # Create path. NOTE: GithubRepository.save() triggers a GitHub labels API call
+        # on first insert when settings.OCTOCAT_APPLY_DEFAULT_LABELSET is True
+        # (see octocat/models.py:66-79) — same behavior as admin-create today.
+        repo = GithubRepository(
+            organization=project.organization,
+            project=project,
+            name=name,
+            html_url=html_url,
+            api_url=api_url,
+            label_set=data.get("label_set"),
+            created_by=request.user,
+            updated_by=request.user,
+        )
+        repo.save()
+        return Response(self.get_serializer(repo).data, status=HTTPStatus.CREATED)
+
+    def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
+        # Unlink (set project = NULL) but keep the row.
+        instance = self.get_object()
+        instance.project = None
+        instance.updated_by = request.user
+        instance.save(update_fields=["project", "updated_by", "updated_datetime"])
+        return Response(status=HTTPStatus.NO_CONTENT)

--- a/kippo/projects/permissions.py
+++ b/kippo/projects/permissions.py
@@ -7,6 +7,70 @@ from rest_framework.request import Request
 from rest_framework.views import APIView
 
 
+def _user_org_ids(user: Any) -> set:  # noqa: ANN401
+    """Return the set of organization PKs the user is a member of.
+
+    Returns an empty set for unauthenticated users or users without
+    `organizationmembership_set` (mirrors the queryset-scoping pattern in
+    `projects/viewsets.py:90-94`).
+    """
+    if not (user and user.is_authenticated):
+        return set()
+    if not hasattr(user, "organizationmembership_set"):
+        return set()
+    return set(user.organizationmembership_set.values_list("organization", flat=True))
+
+
+class IsSuperuserOrOwnOrgReadUpdateCreate(permissions.BasePermission):
+    """
+    Org-scoped permission for KippoProject (#284).
+
+    - Read (GET/HEAD/OPTIONS): authenticated; queryset-level filtering keeps
+      results to user's orgs.
+    - Create (POST): authenticated AND `request.data["organization"]` is in
+      the user's orgs (or superuser).
+    - Update (PUT/PATCH): authenticated; object-level check enforces the
+      target project belongs to one of the user's orgs (or superuser).
+    - Delete (DELETE): superuser only.
+    """
+
+    def has_permission(self, request: Request, view: APIView) -> bool:  # noqa: PLR0911
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        if user.is_superuser:
+            return True
+        if request.method == "POST":
+            target_org = request.data.get("organization") if hasattr(request, "data") else None
+            if not target_org:
+                return False
+            return str(target_org) in {str(oid) for oid in _user_org_ids(user)}
+        # PUT/PATCH: allow at view-level; object-level check enforces org membership.
+        # DELETE/other: not permitted for non-superusers.
+        return request.method in ["PUT", "PATCH"]
+
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:  # noqa: ANN401
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+
+        if user.is_superuser:
+            return True
+
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        if request.method in ["PUT", "PATCH"]:
+            return getattr(obj, "organization_id", None) in _user_org_ids(user)
+
+        if request.method == "DELETE":
+            return False
+
+        return False
+
+
 class IsSuperuserOrReadUpdateOnly(permissions.BasePermission):
     """
     Custom permission to only allow superusers to create or delete objects.

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -547,13 +547,48 @@ class PermissionsTestCase(TestCase):
 
         self.client = APIClient()
 
-    def test_regular_user_cannot_create_project(self):
-        """Test that regular authenticated users cannot create projects."""
+    def test_regular_user_can_create_project_in_own_org(self):
+        """Org-member can POST /api/projects/ for an org they belong to (kippo#284)."""
         self.client.force_authenticate(user=self.user)
         url = f"{settings.URL_PREFIX}/api/projects/"
         data = {
-            "name": "New Project",
+            "name": "Org Member Project",
             "organization": str(self.organization.id),
+            "columnset": self.project.columnset.id,
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+
+        created = KippoProject.objects.get(name="Org Member Project")
+        # created_by/updated_by auto-set from request.user (kippo#284 decision #5)
+        self.assertEqual(created.created_by, self.user)
+        self.assertEqual(created.updated_by, self.user)
+
+    def test_regular_user_cannot_create_project_in_other_org(self):
+        """Org-member cannot POST /api/projects/ for an org they don't belong to (kippo#284)."""
+        other_org = KippoOrganization.objects.create(
+            name="permissions-other-org",
+            github_organization_name="permissions-other-org",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Forbidden Cross-Org Project",
+            "organization": str(other_org.id),
+            "columnset": self.project.columnset.id,
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        self.assertFalse(KippoProject.objects.filter(name="Forbidden Cross-Org Project").exists())
+
+    def test_regular_user_post_without_organization_is_forbidden(self):
+        """POST without an organization field cannot pass org-membership check (kippo#284)."""
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Missing Org Project",
             "columnset": self.project.columnset.id,
         }
         response = self.client.post(url, data, format="json")
@@ -566,6 +601,24 @@ class PermissionsTestCase(TestCase):
         data = {
             "name": "Superuser Project",
             "organization": str(self.organization.id),
+            "columnset": self.project.columnset.id,
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+
+    def test_superuser_can_create_project_in_any_org(self):
+        """Superusers retain unrestricted create across orgs (kippo#284)."""
+        other_org = KippoOrganization.objects.create(
+            name="superuser-foreign-org",
+            github_organization_name="superuser-foreign-org",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.client.force_authenticate(user=self.superuser)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Superuser Cross-Org Project",
+            "organization": str(other_org.id),
             "columnset": self.project.columnset.id,
         }
         response = self.client.post(url, data, format="json")
@@ -607,6 +660,31 @@ class PermissionsTestCase(TestCase):
         data = {"name": "Updated Project Name"}
         response = self.client.patch(url, data, format="json")
         self.assertEqual(response.status_code, HTTPStatus.OK)
+        # updated_by auto-set from request.user (kippo#284 decision #5)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.updated_by, self.user)
+
+    def test_regular_user_cannot_update_other_org_project(self):
+        """PATCH against a project in a foreign org is rejected (kippo#284, queryset-scoped → 404)."""
+        other_org = KippoOrganization.objects.create(
+            name="cross-org-patch-org",
+            github_organization_name="cross-org-patch-org",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        foreign_project = KippoProject.objects.create(
+            name="Foreign Project",
+            organization=other_org,
+            columnset=self.project.columnset,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/projects/{foreign_project.id}/"
+        response = self.client.patch(url, {"name": "Hijack Attempt"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        foreign_project.refresh_from_db()
+        self.assertEqual(foreign_project.name, "Foreign Project")
 
     def test_regular_user_can_create_own_weekly_effort(self):
         """Test that regular authenticated users can create their own weekly effort."""

--- a/kippo/projects/urls.py
+++ b/kippo/projects/urls.py
@@ -1,7 +1,7 @@
 from accounts.viewsets import OrganizationViewSet, PersonalHolidayViewSet, PublicHolidayViewSet
 from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
-from octocat.viewsets import GithubRepositoryViewSet, ProjectGithubRepositoryViewSet
+from octocat.viewsets import ProjectGithubRepositoryViewSet
 from rest_framework.routers import DefaultRouter
 
 from . import api_views, views
@@ -67,9 +67,6 @@ project_github_repository_detail = ProjectGithubRepositoryViewSet.as_view(
     }
 )
 
-github_repository_list = GithubRepositoryViewSet.as_view({"get": "list"})
-github_repository_detail = GithubRepositoryViewSet.as_view({"get": "retrieve"})
-
 # HTML Views and Legacy API
 html_and_legacy_patterns = [
     # HTML Views
@@ -124,8 +121,6 @@ api_patterns = [
         project_github_repository_detail,
         name="project-github-repository-detail",
     ),
-    path("github-repositories/", github_repository_list, name="github-repository-list"),
-    path("github-repositories/<uuid:pk>/", github_repository_detail, name="github-repository-detail"),
     # API ViewSets
     path("", include(router.urls)),
 ]

--- a/kippo/projects/urls.py
+++ b/kippo/projects/urls.py
@@ -1,6 +1,7 @@
 from accounts.viewsets import OrganizationViewSet, PersonalHolidayViewSet, PublicHolidayViewSet
 from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from octocat.viewsets import GithubRepositoryViewSet, ProjectGithubRepositoryViewSet
 from rest_framework.routers import DefaultRouter
 
 from . import api_views, views
@@ -51,6 +52,24 @@ weeklyeffort_detail = ProjectWeeklyEffortViewSet.as_view(
     }
 )
 
+# kippo#284 — GithubRepository nested under projects/, plus top-level read-only listing
+project_github_repository_list = ProjectGithubRepositoryViewSet.as_view(
+    {
+        "get": "list",
+        "post": "create",
+    }
+)
+
+project_github_repository_detail = ProjectGithubRepositoryViewSet.as_view(
+    {
+        "get": "retrieve",
+        "delete": "destroy",
+    }
+)
+
+github_repository_list = GithubRepositoryViewSet.as_view({"get": "list"})
+github_repository_detail = GithubRepositoryViewSet.as_view({"get": "retrieve"})
+
 # HTML Views and Legacy API
 html_and_legacy_patterns = [
     # HTML Views
@@ -94,6 +113,19 @@ api_patterns = [
     # Weekly Effort endpoints (nested under projects/) - MUST come before router
     path("projects/weeklyeffort/", weeklyeffort_list, name="projectweeklyeffort-list"),
     path("projects/weeklyeffort/<int:pk>/", weeklyeffort_detail, name="projectweeklyeffort-detail"),
+    # kippo#284 — GithubRepository endpoints (nested + top-level)
+    path(
+        "projects/<uuid:project_id>/github-repositories/",
+        project_github_repository_list,
+        name="project-github-repository-list",
+    ),
+    path(
+        "projects/<uuid:project_id>/github-repositories/<uuid:pk>/",
+        project_github_repository_detail,
+        name="project-github-repository-detail",
+    ),
+    path("github-repositories/", github_repository_list, name="github-repository-list"),
+    path("github-repositories/<uuid:pk>/", github_repository_detail, name="github-repository-detail"),
     # API ViewSets
     path("", include(router.urls)),
 ]

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -22,7 +22,7 @@ from .models import (
     ProjectMonthlyCost,
     ProjectWeeklyEffort,
 )
-from .permissions import IsSuperuserOrReadUpdateCreateOwn, IsSuperuserOrReadUpdateOnly
+from .permissions import IsSuperuserOrOwnOrgReadUpdateCreate, IsSuperuserOrReadUpdateCreateOwn
 from .serializers import (
     KippoCustomerSerializer,
     KippoProjectSerializer,
@@ -52,19 +52,25 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
 
     **Permissions:**
     - Read (GET): Authenticated users (organization-scoped for regular users)
-    - Update (PUT/PATCH): Authenticated users (organization-scoped for regular users)
-    - Create (POST): Superusers only
+    - Create (POST): Authenticated users for orgs they belong to; superusers any org
+    - Update (PUT/PATCH): Authenticated users for projects in orgs they belong to; superusers any project
     - Delete (DELETE): Superusers only
     """
 
     serializer_class = KippoProjectSerializer
-    permission_classes = [IsSuperuserOrReadUpdateOnly]
+    permission_classes = [IsSuperuserOrOwnOrgReadUpdateCreate]
     queryset = (
         KippoProject.objects.all()
         .select_related("organization", "project_manager")
         .prefetch_related("github_repositories")
         .order_by("-created_datetime")
     )
+
+    def perform_create(self, serializer: KippoProjectSerializer) -> None:
+        serializer.save(created_by=self.request.user, updated_by=self.request.user)
+
+    def perform_update(self, serializer: KippoProjectSerializer) -> None:
+        serializer.save(updated_by=self.request.user)
 
     @extend_schema(
         parameters=[


### PR DESCRIPTION
Closes #284 — *do not auto-close*; merge per project policy.

## Summary

Two API gaps closed so kippo-ui (and downstream tooling) can drive project + repository setup without touching the Django admin:

1. **Org members can now create KippoProjects** for their own orgs (previously superuser-only).
2. **New REST endpoints** to list / link / unlink `octocat.GithubRepository` rows against a `KippoProject`.

## Endpoints

| Method | Path | Notes |
|---|---|---|
| `POST`   | `/api/projects/` | Org-member can create for own org; superuser any org |
| `GET`    | `/api/github-repositories/` | Org-scoped list |
| `GET`    | `/api/github-repositories/{id}/` | Org-scoped retrieve |
| `GET`    | `/api/projects/{project_id}/github-repositories/` | List repos linked to project |
| `POST`   | `/api/projects/{project_id}/github-repositories/` | Upsert + link (`{name, html_url, api_url}`) |
| `GET`    | `/api/projects/{project_id}/github-repositories/{id}/` | Retrieve repo under project |
| `DELETE` | `/api/projects/{project_id}/github-repositories/{id}/` | Unlink (sets `project=NULL`, keeps row) |

POST upsert behavior:

- Triple exists in same org → link (or no-op) → **200**
- Triple exists in different org → **409 Conflict**, no reparenting
- New row → **201**

## Permissions

| Endpoint | Read | Create | Update | Delete |
|---|---|---|---|---|
| `/api/projects/` | org-member | **org-member (new)** | org-member (own orgs) | superuser |
| `/api/projects/{id}/github-repositories/` | org-member | org-member | n/a | org-member (unlink only) |
| `/api/github-repositories/` | org-member | n/a (use nested POST) | n/a | n/a |

`KippoProjectViewSet.perform_create` / `perform_update` auto-set `created_by` / `updated_by` from `request.user`.

## ⚠️ Breaking change

PUT/PATCH `/api/projects/{id}/` for a project in an org the user does **not** belong to now returns 404. Previously the queryset filter excluded those projects already, so this is defense-in-depth rather than a functional change for well-behaved clients — but any code that was relying on cross-org PATCH (e.g. an admin-like script with a non-superuser token) will start getting 404.

## ⚠️ Side effect to note

`GithubRepository.save()` calls the GitHub labels API on **first insert** when `OCTOCAT_APPLY_DEFAULT_LABELSET=True` (`octocat/models.py:66-79`). This is unchanged behavior — the same side effect already fires from admin-create. New tests use `@override_settings(OCTOCAT_APPLY_DEFAULT_LABELSET=False)` to keep them hermetic.

## Implementation

- `projects/permissions.py` — new `IsSuperuserOrOwnOrgReadUpdateCreate` (existing `IsSuperuserOrReadUpdateOnly` left in place; no in-repo callers after this change but kept to avoid potential downstream import breaks).
- `projects/viewsets.py` — swap permission, add `perform_create` / `perform_update`.
- `projects/urls.py` — register nested + top-level repo routes following the existing `weeklyeffort_list`/`weeklyeffort_detail` precedent (manual `path()` registration, mounted before the DRF router).
- `octocat/serializers.py` — `GithubRepositorySerializer`. `validators = []` to opt out of DRF's auto-derived `UniqueTogetherValidator` so the nested POST can upsert; DB `unique_together` still applies.
- `octocat/viewsets.py` — `GithubRepositoryViewSet` (read-only top-level) and `ProjectGithubRepositoryViewSet` (nested list/create/retrieve/destroy). Custom `create()` handles the upsert; `destroy()` unlinks rather than deleting.
- `octocat/tests/test_api_rest.py` — new (14 tests).
- `projects/tests/test_api_rest.py` — 5 new / modified cases for the relaxed POST + tightened PATCH.

## Out of scope

- M2M `GithubRepository ↔ KippoProject` (#37). The endpoint shape doesn't preclude this — if/when #37 ships, the nested POST contract can extend to many-projects-per-repo without breaking single-FK clients.
- Webhook auto-link path (`octocat/event_handlers/webhooks.py`) is unchanged.

## Test plan

- [x] `KIPPO_TESTING=True manage.py test projects.tests.test_api_rest octocat.tests.test_api_rest octocat.tests.test_admin` — 79/79 pass.
- [x] `uv run poe check` (ruff + ruff-format via pre-commit) — clean.
- [x] `manage.py spectacular --validate` — 0 errors. 32 warnings are all pre-existing and not from new code. New routes visible in the schema:
  - `/api/github-repositories/`
  - `/api/github-repositories/{id}/`
  - `/api/projects/{project_id}/github-repositories/`
  - `/api/projects/{project_id}/github-repositories/{id}/`

## Downstream follow-ups (separate PRs)

- `kippo-ui`: regen types via `pnpm update:api` once a release is cut.
- `kippo-project` local: bulk-link script that walks each active KippoProject's GitHub Org Project items and POSTs the referenced repositories to the new nested endpoint.