### PR TITLE
:sparkles: projects: load ProjectMonthlyAssignment rows from Google Sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ EVALUATION_LLM_SERVICE.md
 EVALUATION_RECOMMENDED_MODELS_CC.md
 EVALUATION_TEST_DATA.json
 
+# Local mapping for load_monthly_assignments_from_sheet — contains org user data
+monthly_assignment_mapping*.json
+

--- a/kippo/projects/management/commands/load_monthly_assignments_from_sheet.py
+++ b/kippo/projects/management/commands/load_monthly_assignments_from_sheet.py
@@ -1,0 +1,381 @@
+"""Load ProjectMonthlyAssignment rows from a Google Sheet.
+
+Reads a sheet whose columns encode per-user workload percentages for projects in
+a single month, and upserts matching `ProjectMonthlyAssignment` rows scoped to a
+KippoOrganization.
+
+The mapping file (Kanji column → KippoUser, sheet alias → KippoCustomer,
+sheet alias → KippoProject) is supplied locally via ``--mapping`` and MUST NOT
+be committed; it contains org-specific people data.
+
+Sheet layout (rows are 1-indexed):
+    row 1: title row (ignored)
+    row 2: header — col A blank, B=No., C=顧客, D=プロジェクト内容, E=売上,
+           F.. = per-user single-Kanji column code
+    row 3: per-user availability % (ignored — header metadata)
+    row 4+: data — col A '確' = confirmed, C/D customer+project, F+ workload %
+
+Project cell text supports three forms (loader recognises all three):
+    "<description> (<KippoProject canonical name>)"  → uses parenthesized hint
+    "<KippoProject canonical name>"                  → used directly
+    "<description>"                                  → must be in project_aliases
+
+Fetching the sheet:
+    Default path uses HTTP against the Sheets API; export an OAuth2 access token
+    in ``GOOGLE_SHEETS_OAUTH_TOKEN`` first (e.g. via ``gws auth print-token``
+    or ``gcloud auth print-access-token``). For repeat runs or testing, pre-export
+    the sheet to JSON and pass ``--input-json <path>``.
+
+Example:
+    GOOGLE_SHEETS_OAUTH_TOKEN=$(gws auth print-token) \
+    uv run python manage.py load_monthly_assignments_from_sheet \
+        --spreadsheet-id 16TVnGPMse7AHQT1oX-aqRDW9y3UIaZadstH36TOVAxk \
+        --sheet 202606 \
+        --organization KiconiaWorks \
+        --mapping ~/.kippo/monthly_assignment_mapping.json \
+        --dry-run
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import requests
+from accounts.models import KippoOrganization, KippoUser
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from projects.models import KippoCustomer, KippoProject, ProjectMonthlyAssignment
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+logger = logging.getLogger(__name__)
+
+SHEET_API_URL_TEMPLATE = "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet_id}/values/{range}"
+SHEET_RANGE_TEMPLATE = "{sheet}!A1:AB1000"
+SHEET_NAME_DATE_FORMAT = "%Y%m"
+CONFIRMED_MARKER = "確"
+HEADER_ROW_COUNT = 3  # rows 1-3 are headers; data starts at row 4
+USER_COLUMN_START_INDEX = 5  # col F (0-indexed)
+CUSTOMER_COL_INDEX = 2
+PROJECT_COL_INDEX = 3
+CONFIRMED_COL_INDEX = 0
+
+
+@dataclass
+class LoadStats:
+    matched: int = 0
+    created: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    skipped_cells: int = 0
+    unresolved_customer: list[str] = field(default_factory=list)
+    unresolved_project: list[str] = field(default_factory=list)
+    unresolved_user: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Mapping:
+    user_columns: dict[str, str]  # kanji → KippoUser.username
+    customer_aliases: dict[str, str | None]  # sheet 顧客 → KippoCustomer.name (or None to skip customer scope)
+    project_aliases: dict[str, str]  # "顧客|project_text" → KippoProject.name
+
+
+def _load_mapping(path: Path) -> Mapping:
+    if not path.exists():
+        raise CommandError(f"Mapping file not found: {path}")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if "user_columns" not in raw or not isinstance(raw["user_columns"], dict):
+        raise CommandError("Mapping file must contain a 'user_columns' object")
+    return Mapping(
+        user_columns=raw["user_columns"],
+        customer_aliases=raw.get("customer_aliases", {}) or {},
+        project_aliases=raw.get("project_aliases", {}) or {},
+    )
+
+
+def _fetch_sheet_values(spreadsheet_id: str, sheet: str, oauth_token: str) -> list[list[str]]:
+    url = SHEET_API_URL_TEMPLATE.format(
+        spreadsheet_id=spreadsheet_id,
+        range=SHEET_RANGE_TEMPLATE.format(sheet=sheet),
+    )
+    resp = requests.get(url, headers={"Authorization": f"Bearer {oauth_token}"}, timeout=30)
+    if resp.status_code != requests.codes.ok:
+        raise CommandError(f"Sheets API error {resp.status_code}: {resp.text}")
+    return resp.json().get("values", []) or []
+
+
+def _parse_month_from_sheet_name(sheet: str) -> datetime.date:
+    try:
+        return datetime.datetime.strptime(sheet, SHEET_NAME_DATE_FORMAT).replace(day=1).date()  # noqa: DTZ007
+    except ValueError as exc:
+        raise CommandError(f"--sheet must be in YYYYMM format, got: {sheet}") from exc
+
+
+def _extract_project_name_hint(cell_text: str) -> str | None:
+    """Pull a parenthesized KippoProject canonical name out of a project cell, if present.
+
+    Sheet authors mark explicit mappings as ``<description> (<KippoProject name>)``;
+    this returns the inner name or None.
+    """
+    stripped = cell_text.strip()
+    if stripped.endswith(")") and "(" in stripped:
+        open_idx = stripped.rfind("(")
+        return stripped[open_idx + 1 : -1].strip()
+    return None
+
+
+def _parse_percentage(raw: str) -> int | None:
+    """Parse a sheet cell into a percentage integer; returns None for blank / non-numeric."""
+    value = (raw or "").strip().rstrip("%").strip()
+    if not value:
+        return None
+    try:
+        return int(round(float(value)))
+    except ValueError:
+        return None
+
+
+def _resolve_user_columns(header_row: list[str], mapping: Mapping) -> dict[int, KippoUser]:
+    """Return {column_index: KippoUser} for every mapped user column present in the sheet."""
+    resolved: dict[int, KippoUser] = {}
+    unresolved: list[tuple[int, str]] = []
+    for col_idx in range(USER_COLUMN_START_INDEX, len(header_row)):
+        kanji = (header_row[col_idx] or "").strip()
+        if not kanji:
+            continue
+        username = mapping.user_columns.get(kanji)
+        if not username:
+            unresolved.append((col_idx, kanji))
+            continue
+        try:
+            resolved[col_idx] = KippoUser.objects.get(username=username)
+        except KippoUser.DoesNotExist:
+            unresolved.append((col_idx, f"{kanji} → {username}"))
+    if unresolved:
+        for col_idx, label in unresolved:
+            logger.warning("user column %s (%s) not resolvable", col_idx, label)
+    return resolved
+
+
+def _resolve_project(
+    raw_customer: str,
+    raw_project: str,
+    mapping: Mapping,
+    organization: KippoOrganization,
+) -> KippoProject | None:
+    """Resolve a (顧客, project_text) sheet pair to a KippoProject within `organization`.
+
+    Lookup precedence:
+    1. project_aliases by "raw_customer|raw_project" key
+    2. parenthesized hint inside the project cell text
+    3. bare project cell text
+    """
+    raw_customer = raw_customer.strip()
+    raw_project = raw_project.strip()
+    alias_key = f"{raw_customer}|{raw_project}"
+    candidate_name = mapping.project_aliases.get(alias_key) or _extract_project_name_hint(raw_project) or raw_project
+    if not candidate_name:
+        return None
+    try:
+        return KippoProject.objects.get(organization=organization, name=candidate_name)
+    except KippoProject.DoesNotExist:
+        return None
+
+
+def _resolve_customer(raw_customer: str, mapping: Mapping, organization: KippoOrganization) -> KippoCustomer | None:
+    """Resolve sheet 顧客 to a KippoCustomer; returns None if the alias maps to None (no customer scope)."""
+    raw_customer = raw_customer.strip()
+    if raw_customer in mapping.customer_aliases:
+        aliased = mapping.customer_aliases[raw_customer]
+        if aliased is None:
+            return None
+        raw_customer = aliased
+    return KippoCustomer.objects.filter(organization=organization, name=raw_customer).first()
+
+
+class Command(BaseCommand):
+    help = __doc__
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--spreadsheet-id",
+            default="16TVnGPMse7AHQT1oX-aqRDW9y3UIaZadstH36TOVAxk",
+            help="Google Sheets spreadsheet ID (default: 第9期 アサイン表)",
+        )
+        parser.add_argument(
+            "--sheet",
+            required=True,
+            help="Sheet tab name in YYYYMM format (e.g. 202606)",
+        )
+        parser.add_argument(
+            "--organization",
+            default="KiconiaWorks",
+            help="KippoOrganization.name to scope all lookups to",
+        )
+        parser.add_argument(
+            "--mapping",
+            required=True,
+            type=Path,
+            help="Path to local mapping JSON (NOT committed; see module docstring for schema)",
+        )
+        parser.add_argument(
+            "--input-json",
+            type=Path,
+            default=None,
+            help="Optional: load pre-exported sheet values from a JSON file instead of fetching via API",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Parse + resolve only; do not write to the database",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:  # noqa: ANN401, ARG002
+        sheet: str = options["sheet"]
+        organization_name: str = options["organization"]
+        dry_run: bool = options["dry_run"]
+
+        try:
+            organization = KippoOrganization.objects.get(name=organization_name)
+        except KippoOrganization.DoesNotExist as exc:
+            raise CommandError(f"KippoOrganization not found: {organization_name}") from exc
+
+        try:
+            cli_user = KippoUser.objects.get(username=settings.CLI_MANAGER_USERNAME)
+        except KippoUser.DoesNotExist as exc:
+            raise CommandError(f"CLI_MANAGER_USERNAME user not found: {settings.CLI_MANAGER_USERNAME}") from exc
+
+        mapping = _load_mapping(options["mapping"])
+        month = _parse_month_from_sheet_name(sheet)
+
+        rows = self._load_rows(options, sheet)
+        if len(rows) <= HEADER_ROW_COUNT:
+            self.stdout.write(self.style.WARNING(f"sheet {sheet} has no data rows"))
+            return
+
+        user_columns = _resolve_user_columns(rows[1], mapping)
+        if not user_columns:
+            raise CommandError("no user columns resolved from sheet header — check --mapping user_columns")
+
+        stats = LoadStats()
+        with transaction.atomic():
+            for row_idx, raw_row in enumerate(rows[HEADER_ROW_COUNT:], start=HEADER_ROW_COUNT + 1):
+                self._process_row(raw_row, row_idx, mapping, organization, month, user_columns, cli_user, stats, dry_run)
+            if dry_run:
+                transaction.set_rollback(True)
+
+        self._print_summary(stats, dry_run, sheet)
+
+    def _load_rows(self, options: dict[str, Any], sheet: str) -> list[list[str]]:
+        if options.get("input_json"):
+            data = json.loads(Path(options["input_json"]).read_text(encoding="utf-8"))
+            return data.get("values", []) or []
+        token = os.environ.get("GOOGLE_SHEETS_OAUTH_TOKEN")
+        if not token:
+            raise CommandError("set GOOGLE_SHEETS_OAUTH_TOKEN env var or use --input-json")
+        return _fetch_sheet_values(options["spreadsheet_id"], sheet, token)
+
+    def _process_row(
+        self,
+        raw_row: list[str],
+        row_idx: int,
+        mapping: Mapping,
+        organization: KippoOrganization,
+        month: datetime.date,
+        user_columns: dict[int, KippoUser],
+        cli_user: KippoUser,
+        stats: LoadStats,
+        dry_run: bool,
+    ) -> None:
+        # Pad the row so customer/project indices don't blow up on short rows
+        row = list(raw_row) + [""] * (max(USER_COLUMN_START_INDEX, max(user_columns) + 1) - len(raw_row))
+        raw_customer = (row[CUSTOMER_COL_INDEX] or "").strip()
+        raw_project = (row[PROJECT_COL_INDEX] or "").strip()
+        if not raw_customer and not raw_project:
+            return  # genuinely blank row
+
+        is_confirmed = (row[CONFIRMED_COL_INDEX] or "").strip() == CONFIRMED_MARKER
+
+        # Resolve customer first (logging only — project lookup is independent of customer FK)
+        if _resolve_customer(raw_customer, mapping, organization) is None and raw_customer not in mapping.customer_aliases:
+            stats.unresolved_customer.append(f"row {row_idx}: '{raw_customer}'")
+            return
+
+        project = _resolve_project(raw_customer, raw_project, mapping, organization)
+        if project is None:
+            stats.unresolved_project.append(f"row {row_idx}: ({raw_customer}, '{raw_project}')")
+            return
+
+        stats.matched += 1
+        for col_idx, user in user_columns.items():
+            percentage = _parse_percentage(row[col_idx] if col_idx < len(row) else "")
+            if percentage is None or percentage == 0:
+                stats.skipped_cells += 1
+                continue
+            self._upsert_assignment(project, user, month, percentage, is_confirmed, cli_user, stats, dry_run)
+
+    @staticmethod
+    def _upsert_assignment(
+        project: KippoProject,
+        user: KippoUser,
+        month: datetime.date,
+        percentage: int,
+        is_confirmed: bool,
+        cli_user: KippoUser,
+        stats: LoadStats,
+        dry_run: bool,
+    ) -> None:
+        existing = ProjectMonthlyAssignment.objects.filter(project=project, user=user, month=month).first()
+        if existing is not None:
+            if existing.percentage == percentage and existing.is_confirmed == is_confirmed:
+                stats.unchanged += 1
+                return
+            existing.percentage = percentage
+            existing.is_confirmed = is_confirmed
+            existing.updated_by = cli_user
+            if not dry_run:
+                existing.save()
+            stats.updated += 1
+            return
+        if not dry_run:
+            ProjectMonthlyAssignment.objects.create(
+                project=project,
+                user=user,
+                month=month,
+                percentage=percentage,
+                is_confirmed=is_confirmed,
+                created_by=cli_user,
+                updated_by=cli_user,
+            )
+        stats.created += 1
+
+    def _print_summary(self, stats: LoadStats, dry_run: bool, sheet: str) -> None:
+        prefix = "[DRY-RUN] " if dry_run else ""
+        self.stdout.write(self.style.SUCCESS(f"{prefix}sheet {sheet} loaded:"))
+        self.stdout.write(f"  matched rows:       {stats.matched}")
+        self.stdout.write(f"  assignments created: {stats.created}")
+        self.stdout.write(f"  assignments updated: {stats.updated}")
+        self.stdout.write(f"  assignments unchanged: {stats.unchanged}")
+        self.stdout.write(f"  cells skipped (blank/zero): {stats.skipped_cells}")
+        self.stdout.write(f"  unresolved customers: {len(stats.unresolved_customer)}")
+        self.stdout.write(f"  unresolved projects:  {len(stats.unresolved_project)}")
+        self.stdout.write(f"  unresolved users:     {len(stats.unresolved_user)}")
+        for label, items in (
+            ("UNRESOLVED CUSTOMERS", stats.unresolved_customer),
+            ("UNRESOLVED PROJECTS", stats.unresolved_project),
+            ("UNRESOLVED USERS", stats.unresolved_user),
+        ):
+            sample_limit = 20
+            for line in items[:sample_limit]:
+                self.stdout.write(self.style.WARNING(f"  {label}: {line}"))
+            if len(items) > sample_limit:
+                self.stdout.write(self.style.WARNING(f"  {label}: … and {len(items) - sample_limit} more"))

--- a/kippo/projects/tests/test_load_monthly_assignments_from_sheet.py
+++ b/kippo/projects/tests/test_load_monthly_assignments_from_sheet.py
@@ -1,0 +1,265 @@
+"""Tests for the `load_monthly_assignments_from_sheet` management command."""
+
+import datetime
+import json
+from io import StringIO
+from pathlib import Path
+
+from accounts.models import OrganizationMembership
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from projects.management.commands import load_monthly_assignments_from_sheet as loader
+from projects.models import KippoCustomer, ProjectMonthlyAssignment
+
+
+def _write_json(tmp_dir: Path, name: str, payload: dict) -> Path:
+    path = tmp_dir / name
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+class LoadMonthlyAssignmentsFromSheetTestCase(TestCase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self) -> None:
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.user = created["KippoUser"]
+        self.project = created["KippoProject"]
+
+        # Add a second user + membership so multi-column tests are realistic
+        from accounts.models import KippoUser
+
+        self.user2 = KippoUser.objects.create(username="kanji-user-2", github_login="kanji2", email="b@example.com")
+        OrganizationMembership.objects.create(
+            user=self.user2,
+            organization=self.organization,
+            is_developer=True,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        # Customer + extra project (the loader looks projects up by `name` within the org)
+        self.customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="アクメ",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        self.project.customer = self.customer
+        self.project.start_date = datetime.date(2026, 6, 1)
+        self.project.save()
+
+        self.tmp = Path(self._get_tmp_dir())
+        self.mapping_path = _write_json(
+            self.tmp,
+            "mapping.json",
+            {
+                "user_columns": {"書": "octocat", "海": "kanji-user-2"},
+                "customer_aliases": {"PAO": None},
+                "project_aliases": {"内部|": self.project.name},
+            },
+        )
+
+    def _get_tmp_dir(self) -> str:
+        import tempfile
+
+        d = tempfile.mkdtemp(prefix="kippo_test_loader_")
+        self.addCleanup(self._cleanup_tmp, d)
+        return d
+
+    def _cleanup_tmp(self, d: str) -> None:
+        import shutil
+
+        shutil.rmtree(d, ignore_errors=True)
+
+    def _sheet_payload(self, data_rows: list[list[str]]) -> dict:
+        return {
+            "values": [
+                ["", "202606", "アサインアサイン表"],  # row 1: title
+                ["", "No.", "顧客", "プロジェクト内容", "目安売上換算", "書", "海"],  # row 2: header
+                ["", "", "", "", "", "100%", "100%"],  # row 3: availability (ignored)
+                *data_rows,
+            ]
+        }
+
+    def _call(self, *, sheet_data: dict, dry_run: bool = False, sheet: str = "202606") -> str:
+        sheet_path = _write_json(self.tmp, "sheet.json", sheet_data)
+        out = StringIO()
+        call_command(
+            "load_monthly_assignments_from_sheet",
+            "--sheet",
+            sheet,
+            "--organization",
+            self.organization.name,
+            "--mapping",
+            str(self.mapping_path),
+            "--input-json",
+            str(sheet_path),
+            *(["--dry-run"] if dry_run else []),
+            stdout=out,
+        )
+        return out.getvalue()
+
+    # ---- unit-ish tests on the helpers ------------------------------------
+
+    def test_extract_project_name_hint(self) -> None:
+        self.assertEqual(loader._extract_project_name_hint("desc (Canonical Name)"), "Canonical Name")
+        self.assertEqual(loader._extract_project_name_hint("Canonical Name"), None)
+        self.assertEqual(loader._extract_project_name_hint("desc (中身)"), "中身")
+
+    def test_parse_percentage(self) -> None:
+        self.assertEqual(loader._parse_percentage("50%"), 50)
+        self.assertEqual(loader._parse_percentage(" 35 "), 35)
+        self.assertEqual(loader._parse_percentage(""), None)
+        self.assertEqual(loader._parse_percentage("not a number"), None)
+        self.assertEqual(loader._parse_percentage("12.7%"), 13)
+
+    # ---- end-to-end command tests ----------------------------------------
+
+    def test_dry_run_creates_no_rows(self) -> None:
+        sheet = self._sheet_payload(
+            [
+                ["確", "1", "アクメ", self.project.name, "100,000", "50%", "30%"],
+            ]
+        )
+        output = self._call(sheet_data=sheet, dry_run=True)
+        self.assertIn("[DRY-RUN]", output)
+        self.assertEqual(ProjectMonthlyAssignment.objects.count(), 0)
+
+    def test_creates_assignments_for_each_user_column(self) -> None:
+        sheet = self._sheet_payload(
+            [
+                ["確", "1", "アクメ", self.project.name, "100,000", "50%", "30%"],
+            ]
+        )
+        self._call(sheet_data=sheet)
+        rows = ProjectMonthlyAssignment.objects.filter(project=self.project, month=datetime.date(2026, 6, 1))
+        self.assertEqual(rows.count(), 2)
+        by_user = {row.user_id: row for row in rows}
+        self.assertEqual(by_user[self.user.id].percentage, 50)
+        self.assertEqual(by_user[self.user2.id].percentage, 30)
+        self.assertTrue(by_user[self.user.id].is_confirmed)
+        self.assertTrue(by_user[self.user2.id].is_confirmed)
+
+    def test_confirmed_marker(self) -> None:
+        sheet = self._sheet_payload(
+            [
+                ["", "1", "アクメ", self.project.name, "0", "40%", ""],
+            ]
+        )
+        self._call(sheet_data=sheet)
+        row = ProjectMonthlyAssignment.objects.get(project=self.project, user=self.user)
+        self.assertFalse(row.is_confirmed)
+        self.assertEqual(row.percentage, 40)
+
+    def test_blank_and_zero_cells_skipped(self) -> None:
+        sheet = self._sheet_payload(
+            [
+                ["", "1", "アクメ", self.project.name, "", "", "0%"],
+            ]
+        )
+        self._call(sheet_data=sheet)
+        self.assertEqual(ProjectMonthlyAssignment.objects.count(), 0)
+
+    def test_idempotent_unchanged(self) -> None:
+        sheet = self._sheet_payload(
+            [
+                ["", "1", "アクメ", self.project.name, "", "25%", ""],
+            ]
+        )
+        self._call(sheet_data=sheet)
+        output = self._call(sheet_data=sheet)  # second run
+        self.assertEqual(ProjectMonthlyAssignment.objects.filter(user=self.user).count(), 1)
+        self.assertIn("unchanged: 1", output)
+
+    def test_update_changes_percentage(self) -> None:
+        sheet_a = self._sheet_payload(
+            [
+                ["", "1", "アクメ", self.project.name, "", "25%", ""],
+            ]
+        )
+        self._call(sheet_data=sheet_a)
+        sheet_b = self._sheet_payload(
+            [
+                ["確", "1", "アクメ", self.project.name, "", "60%", ""],
+            ]
+        )
+        output = self._call(sheet_data=sheet_b)
+        row = ProjectMonthlyAssignment.objects.get(user=self.user)
+        self.assertEqual(row.percentage, 60)
+        self.assertTrue(row.is_confirmed)
+        self.assertIn("updated: 1", output)
+
+    def test_parenthesized_project_hint(self) -> None:
+        sheet = self._sheet_payload(
+            [
+                ["", "1", "アクメ", f"description (  {self.project.name}  )", "", "40%", ""],
+            ]
+        )
+        self._call(sheet_data=sheet)
+        row = ProjectMonthlyAssignment.objects.get(user=self.user)
+        self.assertEqual(row.percentage, 40)
+        self.assertEqual(row.project_id, self.project.id)
+
+    def test_project_alias_with_blank_project_column(self) -> None:
+        # mapping has "内部|" -> self.project.name; sheet row has 顧客=内部, project=blank
+        sheet = self._sheet_payload(
+            [
+                ["", "1", "内部", "", "", "10%", ""],
+            ]
+        )
+        # Need '内部' to resolve as customer-or-aliased-null; add to customer_aliases
+        self.mapping_path.write_text(
+            json.dumps(
+                {
+                    "user_columns": {"書": "octocat", "海": "kanji-user-2"},
+                    "customer_aliases": {"内部": None},
+                    "project_aliases": {"内部|": self.project.name},
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        self._call(sheet_data=sheet)
+        row = ProjectMonthlyAssignment.objects.get(user=self.user)
+        self.assertEqual(row.percentage, 10)
+
+    def test_unresolved_customer_logged_and_skipped(self) -> None:
+        sheet = self._sheet_payload(
+            [
+                ["", "1", "存在しない顧客", self.project.name, "", "10%", ""],
+            ]
+        )
+        output = self._call(sheet_data=sheet)
+        self.assertEqual(ProjectMonthlyAssignment.objects.count(), 0)
+        self.assertIn("unresolved customers: 1", output)
+        self.assertIn("存在しない顧客", output)
+
+    def test_unresolved_project_logged_and_skipped(self) -> None:
+        sheet = self._sheet_payload(
+            [
+                ["", "1", "アクメ", "存在しないプロジェクト", "", "10%", ""],
+            ]
+        )
+        output = self._call(sheet_data=sheet)
+        self.assertEqual(ProjectMonthlyAssignment.objects.count(), 0)
+        self.assertIn("存在しないプロジェクト", output)
+
+    def test_invalid_sheet_name_format(self) -> None:
+        with self.assertRaises(CommandError):
+            self._call(sheet_data=self._sheet_payload([]), sheet="not-a-month")
+
+    def test_missing_user_columns_in_mapping_raises(self) -> None:
+        self.mapping_path.write_text(json.dumps({"user_columns": {}}), encoding="utf-8")
+        with self.assertRaises(CommandError):
+            self._call(
+                sheet_data=self._sheet_payload(
+                    [
+                        ["", "1", "アクメ", self.project.name, "", "10%", ""],
+                    ]
+                )
+            )


### PR DESCRIPTION
Closes kiconiaworks/kippo#15 (intentionally not auto-closing; will be closed manually after JST review).

## Summary

Adds `python manage.py load_monthly_assignments_from_sheet` so we can load monthly assignment data from the 第N期 アサイン表 Google Sheet (one tab per `YYYYMM`) into `ProjectMonthlyAssignment` rows scoped to a `KippoOrganization`.

- Reads sheet via Sheets REST API (env var `GOOGLE_SHEETS_OAUTH_TOKEN`) **or** a pre-exported JSON file (`--input-json`).
- Resolves single-Kanji column headers → `KippoUser`, sheet 顧客 → `KippoCustomer`, sheet project cell → `KippoProject` via a local `--mapping` JSON.
- Project cells accept three forms: bare canonical name, `description (canonical name)`, or sheet-text-only routed through `project_aliases`.
- Idempotent upsert keyed on `(project, user, month)` with `--dry-run` rollback support.
- Mapping file is **gitignored** (org-specific people data); the JSON schema is documented in the command module docstring.

## Why the mapping config is not committed

This work is a one-off bootstrap of historical data into kippo, and the column→user mapping is org-specific people data. Keeping it local (and adding `monthly_assignment_mapping*.json` to `.gitignore` as a guardrail) avoids leaking that into the repo while leaving the loader reusable for future months.

## Test plan

- [x] `uv run python manage.py test projects.tests.test_load_monthly_assignments_from_sheet` — 14/14 pass
- [x] `uv run poe check` (ruff) — clean
- [x] `uv run python manage.py test projects` — only pre-existing AWS-mocking errors (5, unrelated to this change)
- [ ] Manual run on 202606 against prod after merge, with the local mapping file