### PR TITLE
:sparkles: accounts: members endpoint returns per-user available_work_days for a given month

### DIFF
--- a/kippo/accounts/serializers.py
+++ b/kippo/accounts/serializers.py
@@ -38,6 +38,15 @@ class OrganizationMemberDetailSerializer(serializers.Serializer):
     slack_username = serializers.CharField(allow_blank=True)
     slack_user_id = serializers.CharField(allow_blank=True)
     slack_image_url = serializers.CharField(allow_blank=True)
+    available_work_days = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text=(
+            "Workdays this member is available in the calendar month requested via "
+            "the `month` query parameter (committed weekdays minus public/personal "
+            "holidays). Null/absent when `month` is not provided."
+        ),
+    )
 
 
 class PersonalHolidaySerializer(serializers.ModelSerializer):

--- a/kippo/accounts/tests/test_organization_members_api.py
+++ b/kippo/accounts/tests/test_organization_members_api.py
@@ -1,5 +1,6 @@
 """Tests for the org-level user-listing API (kippo#14)."""
 
+import datetime
 import uuid
 from http import HTTPStatus
 
@@ -8,7 +9,7 @@ from django.conf import settings
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from accounts.models import EmailDomain, KippoOrganization, KippoUser, OrganizationMembership
+from accounts.models import Country, EmailDomain, KippoOrganization, KippoUser, OrganizationMembership, PersonalHoliday, PublicHoliday
 
 
 class OrganizationListTestCase(TestCase):
@@ -260,8 +261,11 @@ class OrganizationMembersAPITestCase(TestCase):
                 "slack_username",
                 "slack_user_id",
                 "slack_image_url",
+                "available_work_days",
             },
         )
+        # `available_work_days` is null when the `month` query parameter is not given.
+        self.assertIsNone(pm["available_work_days"])
         # Slack/email fields come from OrganizationMembership, not KippoUser.
         self.assertEqual(pm["email"], "pat@github.com")
         self.assertEqual(pm["slack_username"], "pat")
@@ -279,3 +283,123 @@ class OrganizationMembersAPITestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         usernames = [m["username"] for m in response.json()["members"]]
         self.assertIn(self.other_org_user.username, usernames)
+
+
+class OrganizationMembersMonthAvailableWorkdaysTestCase(TestCase):
+    """`?month=YYYY-MM-DD` populates per-member `available_work_days`."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.user = created["KippoUser"]
+        self.organization = created["KippoOrganization"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        # 2026-06: 22 weekdays (1-Mon … 30-Tue). No JP public holidays in June.
+        self.country = Country.objects.create(name="Japan")
+
+        # User with full Mon-Fri commitment, JP holidays, one personal holiday.
+        self.fulltime_user = KippoUser.objects.create(
+            username="ft-user",
+            first_name="Full",
+            last_name="Time",
+            holiday_country=self.country,
+            is_staff=True,
+        )
+        OrganizationMembership.objects.create(
+            user=self.fulltime_user,
+            organization=self.organization,
+            email="ft@github.com",
+            monday=True,
+            tuesday=True,
+            wednesday=True,
+            thursday=True,
+            friday=True,
+            saturday=False,
+            sunday=False,
+            is_developer=True,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        # Personal holiday: 2026-06-15 (Mon), 3 days → 15, 16, 17.
+        PersonalHoliday.objects.create(user=self.fulltime_user, day=datetime.date(2026, 6, 15), duration=3, is_half=False)
+
+        # Public holiday in JP: 2026-06-08 (Mon) — synthetic, real JP June has none.
+        PublicHoliday.objects.create(country=self.country, name="Synthetic Holiday", day=datetime.date(2026, 6, 8))
+
+        # Part-time user: Mon/Wed/Fri only, no holiday country (skips public holidays).
+        self.parttime_user = KippoUser.objects.create(
+            username="pt-user",
+            first_name="Part",
+            last_name="Time",
+            is_staff=True,
+        )
+        OrganizationMembership.objects.create(
+            user=self.parttime_user,
+            organization=self.organization,
+            email="pt@github.com",
+            monday=True,
+            tuesday=False,
+            wednesday=True,
+            thursday=False,
+            friday=True,
+            saturday=False,
+            sunday=False,
+            is_developer=True,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _url(self, **params) -> str:
+        url = f"{settings.URL_PREFIX}/api/organizations/{self.organization.id}/members/"
+        if params:
+            url += "?" + "&".join(f"{k}={v}" for k, v in params.items())
+        return url
+
+    def _member(self, response_json: dict, username: str) -> dict:
+        return next(m for m in response_json["members"] if m["username"] == username)
+
+    def test_no_month_param_returns_null_available_work_days(self):
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ft = self._member(response.json(), "ft-user")
+        self.assertIsNone(ft["available_work_days"])
+
+    def test_month_param_populates_available_work_days(self):
+        response = self.client.get(self._url(month="2026-06-01"))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ft = self._member(response.json(), "ft-user")
+        # June 2026: 22 weekdays minus 1 public holiday (06-08) minus 3 personal (06-15..17) = 18.
+        self.assertEqual(ft["available_work_days"], 18)
+
+    def test_parttime_user_only_committed_weekdays_counted(self):
+        response = self.client.get(self._url(month="2026-06-01"))
+        pt = self._member(response.json(), "pt-user")
+        # Mon/Wed/Fri only in June 2026:
+        # Mon: 1, 8, 15, 22, 29 = 5
+        # Wed: 3, 10, 17, 24 = 4
+        # Fri: 5, 12, 19, 26 = 4
+        # Total = 13 (no holiday subtraction; pt-user has no holiday_country and no PersonalHoliday).
+        self.assertEqual(pt["available_work_days"], 13)
+
+    def test_month_param_with_arbitrary_day_snaps_to_month_start(self):
+        # Any day-of-month should yield the same count as day=01.
+        response_mid = self.client.get(self._url(month="2026-06-17"))
+        response_first = self.client.get(self._url(month="2026-06-01"))
+        ft_mid = self._member(response_mid.json(), "ft-user")
+        ft_first = self._member(response_first.json(), "ft-user")
+        self.assertEqual(ft_mid["available_work_days"], ft_first["available_work_days"])
+
+    def test_invalid_month_param_returns_400(self):
+        response = self.client.get(self._url(month="not-a-date"))
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    def test_month_param_other_month_unaffected_by_june_holidays(self):
+        # July 2026: 23 weekdays, no JP public holidays declared, no personal holidays for ft-user → 23.
+        response = self.client.get(self._url(month="2026-07-01"))
+        ft = self._member(response.json(), "ft-user")
+        self.assertEqual(ft["available_work_days"], 23)

--- a/kippo/accounts/viewsets.py
+++ b/kippo/accounts/viewsets.py
@@ -1,8 +1,11 @@
 """ViewSets for Accounts API."""
 
+import datetime
+from collections import defaultdict
 from http import HTTPStatus
 from typing import Any
 
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, inline_serializer
 from rest_framework import viewsets
@@ -20,6 +23,50 @@ from .serializers import (
     PersonalHolidaySerializer,
     PublicHolidaySerializer,
 )
+
+
+def _calc_available_workdays_in_month(
+    memberships: list[OrganizationMembership],
+    month_start: datetime.date,
+) -> dict[Any, int]:
+    """Return {user_id: available_workdays_count} for the calendar month starting at `month_start`.
+
+    Available = committed weekdays in the month, minus public holidays for the
+    user's holiday_country, minus the user's personal holidays. Batched to avoid
+    N+1 queries.
+    """
+    month_end = month_start + relativedelta(months=1) - datetime.timedelta(days=1)
+    user_ids = [m.user_id for m in memberships]
+
+    # Personal holidays touching the month (expand by `duration`).
+    personal_by_user: dict[Any, set[datetime.date]] = defaultdict(set)
+    earliest_relevant_start = month_start - datetime.timedelta(days=365)
+    for ph in PersonalHoliday.objects.filter(user_id__in=user_ids, day__gte=earliest_relevant_start, day__lte=month_end):
+        for offset in range(ph.duration):
+            d = ph.day + datetime.timedelta(days=offset)
+            if month_start <= d <= month_end:
+                personal_by_user[ph.user_id].add(d)
+
+    # Public holidays per country for the month window.
+    country_ids = {m.user.holiday_country_id for m in memberships if m.user.holiday_country_id}
+    public_by_country: dict[Any, set[datetime.date]] = defaultdict(set)
+    if country_ids:
+        for ph in PublicHoliday.objects.filter(country_id__in=country_ids, day__gte=month_start, day__lte=month_end):
+            public_by_country[ph.country_id].add(ph.day)
+
+    result: dict[Any, int] = {}
+    for membership in memberships:
+        committed = set(membership.committed_weekdays)
+        personal = personal_by_user.get(membership.user_id, set())
+        public = public_by_country.get(membership.user.holiday_country_id, set())
+        count = 0
+        current = month_start
+        while current <= month_end:
+            if current.weekday() in committed and current not in personal and current not in public:
+                count += 1
+            current += datetime.timedelta(days=1)
+        result[membership.user_id] = count
+    return result
 
 
 class PersonalHolidayViewSet(viewsets.ModelViewSet):
@@ -149,6 +196,17 @@ class OrganizationViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
                 required=False,
                 type=bool,
             ),
+            OpenApiParameter(
+                name="month",
+                description=(
+                    "When set (YYYY-MM-DD; any day, snapped to month start), each member's "
+                    "`available_work_days` field is populated with the count of available "
+                    "workdays in that month (committed weekdays minus public/personal holidays). "
+                    "Omitted or invalid → `available_work_days` is null."
+                ),
+                required=False,
+                type=str,
+            ),
         ],
         responses={
             HTTPStatus.OK: OpenApiResponse(
@@ -158,13 +216,17 @@ class OrganizationViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
                 ),
                 description="Members of the organization, with per-org Slack and email fields.",
             ),
+            HTTPStatus.BAD_REQUEST: OpenApiResponse(description="`month` query parameter is not in YYYY-MM-DD format."),
             HTTPStatus.FORBIDDEN: OpenApiResponse(description="Requester is not a member of the organization."),
             HTTPStatus.NOT_FOUND: OpenApiResponse(description="Organization does not exist."),
         },
         description=(
             "Active members of the given organization. Excludes the unassigned bot user "
             "and (by default) KippoUser.is_active=False users. Returns the richer per-org "
-            "shape (adds email and slack_* fields) that the per-project endpoint omits."
+            "shape (adds email and slack_* fields) that the per-project endpoint omits. "
+            "Pass `?month=YYYY-MM-DD` to include each member's `available_work_days` for "
+            "that calendar month — used by the assignments-matrix UI to express row totals "
+            "in person-days instead of percentages."
         ),
     )
     @action(detail=True, methods=["get"], url_path="members", permission_classes=[IsAuthenticated])
@@ -190,20 +252,33 @@ class OrganizationViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
         include_inactive_raw = self.request.query_params.get("include_inactive")
         include_inactive = include_inactive_raw is not None and include_inactive_raw.lower() in _TRUTHY
 
+        month_raw = self.request.query_params.get("month")
+        month_start: datetime.date | None = None
+        if month_raw:
+            try:
+                month_start = datetime.datetime.strptime(month_raw, "%Y-%m-%d").date().replace(day=1)  # noqa: DTZ007
+            except ValueError:
+                return Response(
+                    {"detail": "month must be YYYY-MM-DD"},
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+
         membership_filters: dict[str, Any] = {"organization": organization}
         for key in ("is_developer", "is_project_manager"):
             raw = self.request.query_params.get(key)
             if raw is not None:
                 membership_filters[key] = raw.lower() in _TRUTHY
 
-        memberships = (
+        memberships = list(
             OrganizationMembership.objects.filter(**membership_filters)
             .select_related("user")
             .exclude(user__username__startswith=settings.UNASSIGNED_USER_GITHUB_LOGIN_PREFIX)
             .order_by("user__username")
         )
         if not include_inactive:
-            memberships = memberships.filter(user__is_active=True)
+            memberships = [m for m in memberships if m.user.is_active]
+
+        workdays_by_user: dict[Any, int] = _calc_available_workdays_in_month(memberships, month_start) if month_start else {}
 
         payload = [
             {
@@ -219,6 +294,7 @@ class OrganizationViewSet(ListModelMixin, RetrieveModelMixin, GenericViewSet):
                 "slack_username": m.slack_username or "",
                 "slack_user_id": m.slack_user_id or "",
                 "slack_image_url": m.slack_image_url or "",
+                "available_work_days": workdays_by_user.get(m.user_id) if month_start else None,
             }
             for m in memberships
         ]


### PR DESCRIPTION
## Summary

Adds an optional `month=YYYY-MM-DD` query parameter to `GET /api/organizations/<id>/members/`. When set, each member's `available_work_days` field is populated with the count of available workdays in that calendar month:

```
committed weekdays in the month
  − public holidays for the user's holiday_country
  − the user's personal holidays falling in the month
```

Omitted/invalid `month` → `available_work_days` is null (backward-compatible response shape). Day-of-month is snapped to month start. Invalid format returns 400.

## Why

The kippo-ui monthly project assignments matrix currently shows a 月合計 column that's just `Σ percentages` across users. That mixes users with different monthly capacities (e.g. a part-timer's 50% ≠ a full-timer's 50% in absolute terms) and isn't expressible as a meaningful "effort" unit.

With this endpoint change, kippo-ui can compute `Σ (assignment_pct / 100) × available_work_days` per project — a row total in person-days that aligns with the unit kippo already uses for `KippoProject.allocated_staff_days`. UI PR will follow once this deploys.

## Implementation notes

- New helper `_calc_available_workdays_in_month(memberships, month_start)` in `accounts/viewsets.py`. Batches `PersonalHoliday` + `PublicHoliday` lookups by user/country (no N+1).
- `OrganizationMemberDetailSerializer` gains an optional, nullable `available_work_days` integer field.
- `@extend_schema` updated so the OpenAPI client picks up the new param + field.

## Test plan

- [x] `uv run python manage.py test accounts.tests.test_organization_members_api` — 25/25 pass (6 new tests covering: null when `month` omitted, count matches when given, part-time committed_weekdays respected, day-of-month snaps to month start, invalid format → 400, holidays in other months don't bleed into the requested month)
- [x] `uv run python manage.py test accounts` — 104/104 pass (no regressions)
- [x] `uv run poe check` (ruff) — clean
- [ ] After deploy: kippo-ui PR will switch the 月合計 column to person-days using this field