### PR TITLE
:bug: projects/auto-extend: move URL to nested /projects/<id>/monthly-assignments/auto-extend/

### DIFF
--- a/kippo/projects/tests/test_autoassign.py
+++ b/kippo/projects/tests/test_autoassign.py
@@ -522,10 +522,10 @@ class AutoExtendSkipReasonTestCase(AutoAssignTestCaseBase):
 
 
 class AutoExtendRESTEndpointTestCase(AutoAssignTestCaseBase):
-    """kippo#19: REST endpoint at POST /api/.../monthly-assignments/auto-extend/<project_id>/."""
+    """kippo#19: REST endpoint at POST /api/projects/<project_id>/monthly-assignments/auto-extend/."""
 
     def _url(self, project_id: str) -> str:
-        return f"/api/monthly-assignments/auto-extend/{project_id}/"
+        return f"/api/projects/{project_id}/monthly-assignments/auto-extend/"
 
     def test_post_creates_rows_for_eligible_project(self):
         from rest_framework.test import APIClient

--- a/kippo/projects/urls.py
+++ b/kippo/projects/urls.py
@@ -67,6 +67,13 @@ project_github_repository_detail = ProjectGithubRepositoryViewSet.as_view(
     }
 )
 
+# kippo#19 — manual auto-extend nested under projects/, matching the issue spec.
+project_monthly_assignment_auto_extend = ProjectMonthlyAssignmentViewSet.as_view(
+    {
+        "post": "auto_extend",
+    }
+)
+
 # HTML Views and Legacy API
 html_and_legacy_patterns = [
     # HTML Views
@@ -120,6 +127,12 @@ api_patterns = [
         "projects/<uuid:project_id>/github-repositories/<uuid:pk>/",
         project_github_repository_detail,
         name="project-github-repository-detail",
+    ),
+    # kippo#19 — manual auto-extend (nested under projects/)
+    path(
+        "projects/<uuid:project_id>/monthly-assignments/auto-extend/",
+        project_monthly_assignment_auto_extend,
+        name="project-monthly-assignment-auto-extend",
     ),
     # API ViewSets
     path("", include(router.urls)),

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -619,12 +619,6 @@ class ProjectMonthlyAssignmentViewSet(viewsets.ModelViewSet):
             ),
         },
     )
-    @action(
-        detail=False,
-        methods=["post"],
-        url_path=r"auto-extend/(?P<project_id>[a-f0-9-]{36})",
-        url_name="auto-extend",
-    )
     def auto_extend(self, request: Request, project_id: str) -> Response:
         """Manually trigger auto-create of future-month assignments for `project_id` (kippo#19).
 


### PR DESCRIPTION
## Summary

Spec drift fix surfaced by a post-deploy smoke test against prod.

kiconiaworks/kippo#19 specified the manual extend endpoint at
`POST /api/projects/{id}/monthly-assignments/auto-extend/`, but the
`@action` decorator implementation in monkut/kippo#288 registered it as
a flat collection action at `POST /api/monthly-assignments/auto-extend/<project_id>/`.

The endpoint works, but the URL didn't match the documented spec. With
no kippo-ui consumer yet, now is the cheapest moment to align.

## Change

- `viewsets.py`: drop the `@action` decorator on `auto_extend` (no behavior change to the method body).
- `urls.py`: bind `ProjectMonthlyAssignmentViewSet.as_view({"post": "auto_extend"})` and add `path("projects/<uuid:project_id>/monthly-assignments/auto-extend/", ...)` before the router — same pattern kippo#284 used for nested GithubRepository routes.
- `test_autoassign.py`: update `_url()` to the new path.

No backend logic changed; no UI changes needed (no callers yet).

## Test plan

- [x] `python manage.py test projects.tests.test_autoassign` — 47/47 pass
- [x] `ruff check` + `ruff format --check` — clean
- [ ] After merge + deploy: re-run smoke test against prod, confirm `POST /api/projects/<id>/monthly-assignments/auto-extend/` returns 200/202/404/401/403 as expected and the old path 404s.