### PR TITLE
:sparkles: monthly-assignments: default ?month= to current month (JST) on list

### DIFF
--- a/kippo/projects/tests/test_projectmonthlyassignment.py
+++ b/kippo/projects/tests/test_projectmonthlyassignment.py
@@ -16,6 +16,7 @@ from commons.tests import DEFAULT_FIXTURES, setup_basic_project
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils import timezone
 from rest_framework.test import APIClient
 
 from projects.models import KippoProject, ProjectMonthlyAssignment
@@ -269,7 +270,8 @@ class ProjectMonthlyAssignmentViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_list_org_scoped_for_regular_user(self):
-        response = self.client.get(self.list_url)
+        # Broad range so the current-month (JST) default doesn't scope this org-scoping check.
+        response = self.client.get(self.list_url, {"month_gte": "2026-01-01"})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         ids = {row["id"] for row in response.json()["results"]}
         self.assertIn(self.assignment_apr.id, ids)
@@ -280,20 +282,21 @@ class ProjectMonthlyAssignmentViewSetTestCase(TestCase):
         superuser = KippoUser.objects.create(username="forecast-super", is_superuser=True, is_staff=True)
         admin_client = APIClient()
         admin_client.force_authenticate(user=superuser)
-        response = admin_client.get(self.list_url)
+        response = admin_client.get(self.list_url, {"month_gte": "2026-01-01"})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         ids = {row["id"] for row in response.json()["results"]}
         self.assertIn(self.assignment_apr.id, ids)
         self.assertIn(self.other_assignment.id, ids)
 
     def test_filter_by_project(self):
-        response = self.client.get(self.list_url, {"project": str(self.project.id)})
+        # Broad range so the fixed-date fixtures aren't scoped out by the current-month default.
+        response = self.client.get(self.list_url, {"project": str(self.project.id), "month_gte": "2026-01-01"})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         ids = {row["id"] for row in response.json()["results"]}
         self.assertEqual(ids, {self.assignment_apr.id, self.assignment_may.id})
 
     def test_filter_by_user(self):
-        response = self.client.get(self.list_url, {"user": str(self.user.id)})
+        response = self.client.get(self.list_url, {"user": str(self.user.id), "month_gte": "2026-01-01"})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertGreater(len(results), 0)
@@ -314,6 +317,52 @@ class ProjectMonthlyAssignmentViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         ids = {row["id"] for row in response.json()["results"]}
         self.assertEqual(ids, {self.assignment_apr.id})
+
+    def test_list_defaults_to_current_jst_month_when_no_month_param(self):
+        """No month/month_gte/month_lte → only the current-month (JST) rows are returned."""
+        current_month = timezone.localdate().replace(day=1)
+        past_month = (current_month - datetime.timedelta(days=1)).replace(day=1)
+        # Separate project so these don't collide with setUp's (project,user,month) rows.
+        project = KippoProject.objects.create(
+            name="current-month-default-project",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            start_date=past_month,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        current = ProjectMonthlyAssignment.objects.create(
+            project=project,
+            user=self.user,
+            month=current_month,
+            percentage=10,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        past = ProjectMonthlyAssignment.objects.create(
+            project=project,
+            user=self.user,
+            month=past_month,
+            percentage=20,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        rows = response.json()["results"]
+        ids = {row["id"] for row in rows}
+        self.assertIn(current.id, ids)
+        self.assertNotIn(past.id, ids)
+        # Every returned row is the current JST month.
+        self.assertTrue(all(row["month"] == current_month.isoformat() for row in rows))
+
+    def test_explicit_month_range_not_overridden_by_current_month_default(self):
+        """A month_gte alone keeps range semantics (the current-month default must not kick in)."""
+        response = self.client.get(self.list_url, {"month_gte": "2026-04-01"})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ids = {row["id"] for row in response.json()["results"]}
+        self.assertEqual(ids, {self.assignment_apr.id, self.assignment_may.id})
 
     def test_create_persists_new_assignment(self):
         new_month = datetime.date(2026, 6, 1)

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from typing import Any
 
 from accounts.models import KippoUser
+from django.utils import timezone
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, inline_serializer
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
@@ -511,7 +512,8 @@ class ProjectMonthlyAssignmentViewSet(viewsets.ModelViewSet):
     **Filtering:**
     - project: Filter by project UUID
     - user: Filter by user ID
-    - month: Filter by exact month (YYYY-MM-DD format, day should be 01)
+    - month: Filter by exact month (YYYY-MM-DD format, day should be 01). Defaults to the
+      current month (JST) when none of month/month_gte/month_lte is supplied.
     - month_gte: Filter by month >= date (YYYY-MM-DD format)
     - month_lte: Filter by month <= date (YYYY-MM-DD format)
 
@@ -545,7 +547,9 @@ class ProjectMonthlyAssignmentViewSet(viewsets.ModelViewSet):
             ),
             OpenApiParameter(
                 name="month",
-                description="Filter by exact month (YYYY-MM-DD format)",
+                description=(
+                    "Filter by exact month (YYYY-MM-DD format). When omitted (and no month_gte/month_lte), defaults to the current month in JST."
+                ),
                 required=False,
                 type=str,
             ),
@@ -590,18 +594,24 @@ class ProjectMonthlyAssignmentViewSet(viewsets.ModelViewSet):
         if user_id:
             queryset = queryset.filter(user__id=user_id)
 
-        # Filter by month parameter (exact match)
         month = self.request.query_params.get("month", None)
+        month_gte = self.request.query_params.get("month_gte", None)
+        month_lte = self.request.query_params.get("month_lte", None)
+
+        # On the list view with no month filter at all → default to the current month (JST).
+        # Detail actions (retrieve/update/destroy) must reach a row in any month by pk, so the
+        # default is list-only. Explicit range filters (month_gte/month_lte) are left as-is.
+        # `timezone.localdate()` resolves in settings.TIME_ZONE ("Asia/Tokyo").
+        if self.action == "list" and not any((month, month_gte, month_lte)):
+            month = timezone.localdate().replace(day=1)
+
+        # Filter by month parameter (exact match)
         if month:
             queryset = queryset.filter(month=month)
-
         # Filter by month_gte parameter
-        month_gte = self.request.query_params.get("month_gte", None)
         if month_gte:
             queryset = queryset.filter(month__gte=month_gte)
-
         # Filter by month_lte parameter
-        month_lte = self.request.query_params.get("month_lte", None)
         if month_lte:
             queryset = queryset.filter(month__lte=month_lte)
 


### PR DESCRIPTION
## Summary

`GET /api/monthly-assignments/` now **defaults to the current month (JST)** when no month filter is supplied, instead of returning every month. This matches how the endpoint is consumed — the assignments view works one month at a time.

## Behavior

```python
if self.action == "list" and not any((month, month_gte, month_lte)):
    month = timezone.localdate().replace(day=1)
```

- **List-only**: detail actions (`retrieve`/`update`/`destroy`) still reach a row in any month by pk — the default is gated on `self.action == "list"`, so it never scopes those out (would otherwise 404 non-current-month rows).
- **Ranges untouched**: an explicit `month_gte`/`month_lte` short-circuits the default, so range queries keep working.
- **JST**: `timezone.localdate()` resolves in `settings.TIME_ZONE = "Asia/Tokyo"` (the codebase idiom), giving the first of the current month in JST.
- Org-scoping is applied before this block and is unaffected.

Updated the `month` OpenAPI param description and the viewset docstring to document the default.

## Behavior change / compatibility

Any caller hitting `/api/monthly-assignments/` with **no** month now gets the current JST month rather than all months. **kippo-ui is unaffected** — it always sends `?month=` (`useMonthlyAssignments`, `AddAssignmentModal`). The only schema delta is the param *description*, which syncs to the UI via the normal release flow (no UI change needed).

## Test plan

- `projects.tests.test_projectmonthlyassignment` — 23 tests pass; autoassign/suggest/columnset suites (78) green; ruff clean.
- Added `test_list_defaults_to_current_jst_month_when_no_month_param` (computes the month from `timezone.localdate()` → run-date independent) and `test_explicit_month_range_not_overridden_by_current_month_default`.
- Decoupled the fixed-date fixture filter tests (org-scoping ×2, project, user) from the new default with an explicit `month_gte`.