### PR TITLE
:lock: monthly-assignments: only allow confirm when project confidence is 100%

### DIFF
--- a/kippo/projects/definitions.py
+++ b/kippo/projects/definitions.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 # Minimum effort percentage required for a user to be included in survey tracking
 SURVEY_EFFORT_THRESHOLD_PERCENTAGE = 3
 
+# A project's confidence (確度) must be at this percentage before its monthly
+# assignments can be confirmed (is_confirmed=True).
+FULL_CONFIDENCE_PERCENTAGE = 100
+
 KIPPOPROJECT_CATEGORY_CHOICES = (
     ("new-proposal", _("新規提案")),
     ("maintenance", _("保守")),

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -7,7 +7,12 @@ from django.db.models import Sum
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from .definitions import SURVEY_EFFORT_THRESHOLD_PERCENTAGE, ProjectProgressStatus, ProjectRoles
+from .definitions import (
+    FULL_CONFIDENCE_PERCENTAGE,
+    SURVEY_EFFORT_THRESHOLD_PERCENTAGE,
+    ProjectProgressStatus,
+    ProjectRoles,
+)
 from .models import (
     KippoCustomer,
     KippoProject,
@@ -584,6 +589,29 @@ class ProjectMonthlyAssignmentSerializer(serializers.ModelSerializer):
         if membership:
             return membership.slack_image_url or None
         return None
+
+    def validate(self, attrs: dict) -> dict:
+        """Reject *confirming* an assignment whose project confidence (確度) is not 100%.
+
+        Only the unconfirmed → confirmed transition is gated (returns a 400 so the UI can
+        surface the reason). Unconfirming, and editing a row that is already confirmed
+        (e.g. its percentage), are always allowed regardless of confidence.
+        """
+        attrs = super().validate(attrs)
+        was_confirmed = bool(getattr(self.instance, "is_confirmed", False))
+        will_be_confirmed = attrs.get("is_confirmed", was_confirmed)
+        if will_be_confirmed and not was_confirmed:
+            project = attrs.get("project") or getattr(self.instance, "project", None)
+            if project is not None and project.confidence != FULL_CONFIDENCE_PERCENTAGE:
+                raise serializers.ValidationError(
+                    {
+                        "is_confirmed": (
+                            "Assignment can only be confirmed when the project confidence (確度) is 100%. "
+                            f"Project '{project.name}' is at {project.confidence}%."
+                        )
+                    }
+                )
+        return attrs
 
 
 class ProjectMonthlyCostSerializer(serializers.ModelSerializer):

--- a/kippo/projects/tests/test_admin_projectweeklyeffortadmin.py
+++ b/kippo/projects/tests/test_admin_projectweeklyeffortadmin.py
@@ -63,8 +63,10 @@ class ProjectWeeklyEffortAdminTestCase(IsStaffModelAdminTestCaseBase):
         negative `hours` (the UI and Slack flows already block it). full_clean() exercises the
         same MinValue/MaxValue validators the admin form runs.
         """
-        today = timezone.now()
-        monday = today - timezone.timedelta(days=today.weekday())
+        # Use a Monday outside the setUp-populated (3 months ago .. today) range so the
+        # `zero.full_clean()` unique check below doesn't clash with a setUp-created
+        # (week_start, project, user) row — matches the sibling tests' `_future_monday()`.
+        monday = self._future_monday()
 
         negative = ProjectWeeklyEffort(week_start=monday, project=self.project1, user=self.staffuser_with_org, hours=-1)
         with self.assertRaises(ValidationError) as ctx:

--- a/kippo/projects/tests/test_projectmonthlyassignment.py
+++ b/kippo/projects/tests/test_projectmonthlyassignment.py
@@ -394,3 +394,52 @@ class ProjectMonthlyAssignmentViewSetTestCase(TestCase):
         url = f"{self.list_url}{self.other_assignment.id}/"
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_confirm_rejected_when_project_confidence_below_100(self):
+        # self.project keeps the default confidence (80) — confirming must 400.
+        self.assertNotEqual(self.project.confidence, 100)
+        url = f"{self.list_url}{self.assignment_apr.id}/"
+        response = self.client.patch(url, {"is_confirmed": True}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+        self.assertIn("is_confirmed", response.json())
+        self.assignment_apr.refresh_from_db()
+        self.assertFalse(self.assignment_apr.is_confirmed)
+
+    def test_confirm_allowed_when_project_confidence_100(self):
+        self.project.confidence = 100
+        self.project.save()
+        url = f"{self.list_url}{self.assignment_apr.id}/"
+        response = self.client.patch(url, {"is_confirmed": True}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        self.assignment_apr.refresh_from_db()
+        self.assertTrue(self.assignment_apr.is_confirmed)
+
+    def test_unconfirm_allowed_regardless_of_confidence(self):
+        # Confirm while at 100%, then drop confidence and unconfirm — must succeed.
+        self.project.confidence = 100
+        self.project.save()
+        self.assignment_apr.is_confirmed = True
+        self.assignment_apr.save()
+        self.project.confidence = 80
+        self.project.save()
+        url = f"{self.list_url}{self.assignment_apr.id}/"
+        response = self.client.patch(url, {"is_confirmed": False}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        self.assignment_apr.refresh_from_db()
+        self.assertFalse(self.assignment_apr.is_confirmed)
+
+    def test_edit_already_confirmed_row_allowed_below_100(self):
+        # Only the unconfirmed→confirmed transition is gated. Editing an already-confirmed
+        # row (here: its percentage) while confidence < 100 must still succeed.
+        self.project.confidence = 100
+        self.project.save()
+        self.assignment_apr.is_confirmed = True
+        self.assignment_apr.save()
+        self.project.confidence = 80
+        self.project.save()
+        url = f"{self.list_url}{self.assignment_apr.id}/"
+        response = self.client.patch(url, {"percentage": 33}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        self.assignment_apr.refresh_from_db()
+        self.assertEqual(self.assignment_apr.percentage, 33)
+        self.assertTrue(self.assignment_apr.is_confirmed)


### PR DESCRIPTION
## Summary

Confirming a monthly assignment (`is_confirmed` `False → True`) is now only permitted when the project's **confidence (確度) is 100%**. Otherwise the API returns **400** with a clear reason so the UI can surface it.

## Behavior
- `ProjectMonthlyAssignmentSerializer.validate` gates **only the unconfirmed → confirmed transition**:
  - confirm at confidence < 100% → `400 {"is_confirmed": "Assignment can only be confirmed when the project confidence (確度) is 100%. Project '…' is at 80%."}`
  - confirm at 100% → OK
- **Unconfirming** is always allowed regardless of confidence.
- **Editing an already-confirmed row** (e.g. its percentage) is always allowed — only the transition is gated, so existing confirmed rows aren't retroactively blocked (and re-saving/admin edits don't break).

## Implementation
- `definitions.py`: `FULL_CONFIDENCE_PERCENTAGE = 100`
- `serializers.py`: transition-aware `validate` (was_confirmed vs will_be_confirmed)
- Chose serializer-level (the API boundary) over `model.clean` deliberately: `model.clean` validates *state* on every save, which would block editing/grandfathered confirmed rows and broke existing over-cap tests.

## Tests (`test_projectmonthlyassignment.py`)
- confirm rejected (400) when confidence < 100
- confirm allowed at 100
- unconfirm allowed regardless of confidence
- edit already-confirmed row allowed below 100

`uv run poe test projects.tests.test_projectmonthlyassignment` → **27 passed**; ruff clean.