### PR TITLE
:sparkles: admin: show active project count on KippoCustomer list

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -19,7 +19,7 @@ from django.conf import settings
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Case, JSONField, Model, Value, When
+from django.db.models import Case, Count, JSONField, Model, Q, Value, When
 from django.forms import BaseFormSet, Form
 from django.forms.models import BaseInlineFormSet
 from django.http import (
@@ -1296,7 +1296,7 @@ class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
 
 @admin.register(KippoCustomer)
 class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
-    list_display = ("name", "organization", "email", "display_as_active", "updated_datetime")
+    list_display = ("name", "organization", "email", "get_active_project_count", "display_as_active", "updated_datetime")
     list_display_links = ("name",)
     list_filter = ("organization", "display_as_active")
     search_fields = ("name", "email")
@@ -1305,10 +1305,27 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     inlines = (KippoProjectReadOnlyInline,)
 
     def get_queryset(self, request: DjangoRequest):
-        qs = super().get_queryset(request)
+        # Annotate the count of each customer's active (open + display_as_active) projects so
+        # the list column is one query and sortable. distinct=True guards against row fan-out
+        # from the (non-superuser) organization join below.
+        qs = (
+            super()
+            .get_queryset(request)
+            .annotate(
+                active_project_count=Count(
+                    "projects",
+                    filter=Q(projects__is_closed=False, projects__display_as_active=True),
+                    distinct=True,
+                )
+            )
+        )
         if request.user.is_superuser:
             return qs
         return qs.filter(organization__in=request.user.organizations).order_by("organization").distinct()
+
+    @admin.display(description=_("アクティブプロジェクト数"), ordering="active_project_count")
+    def get_active_project_count(self, obj: KippoCustomer) -> int:
+        return obj.active_project_count
 
     def get_form(self, request: DjangoRequest, obj: KippoCustomer | None = None, **kwargs) -> Form:
         form = super().get_form(request, obj, **kwargs)

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1437,6 +1437,30 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertIn(mine.name, content)
         self.assertNotIn(theirs.name, content)
 
+    def test_changelist_active_project_count_excludes_closed_and_inactive(self):
+        # Two active projects (is_closed=False, display_as_active=True by default).
+        self._make_customer_project("acme-a1", self.customer, date(2026, 6, 1), date(2026, 6, 1))
+        self._make_customer_project("acme-a2", self.customer, date(2026, 7, 1), date(2026, 7, 1))
+        # Closed → not active → excluded.
+        closed = self._make_customer_project("acme-closed", self.customer, date(2026, 6, 1), date(2026, 6, 1))
+        closed.is_closed = True
+        closed.save()
+        # display_as_active=False → excluded.
+        inactive = self._make_customer_project("acme-inactive", self.customer, date(2026, 6, 1), date(2026, 6, 1))
+        inactive.display_as_active = False
+        inactive.save()
+        # Active project for a different customer must not inflate this customer's count.
+        self._make_customer_project("globex-active", self.other_customer, date(2026, 6, 1), date(2026, 6, 1))
+
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        request = MockRequest()
+        request.user = self.superuser_no_org
+        qs = modeladmin.get_queryset(request)
+        customer = qs.get(pk=self.customer.pk)
+        self.assertEqual(customer.active_project_count, 2)
+        self.assertEqual(modeladmin.get_active_project_count(customer), 2)
+        self.assertEqual(qs.get(pk=self.other_customer.pk).active_project_count, 1)
+
 
 class KippoCustomerAdminOrganizationFieldTestCase(IsStaffModelAdminTestCaseBase):
     """KippoCustomerAdmin auto-sets the organization from the user's session and hides the field."""


### PR DESCRIPTION
## Summary

Adds an **アクティブプロジェクト数** column to the `KippoCustomer` admin changelist — the number of each customer's **active** projects, where active = `is_closed=False` **and** `display_as_active=True` (the `ActiveKippoProject` definition).

## Implementation
- `get_queryset` annotates `active_project_count` with `Count("projects", filter=Q(is_closed=False, display_as_active=True), distinct=True)` — one query (no N+1), and the column is **sortable** (`@admin.display(ordering=...)`).
- `get_active_project_count` display method added to `list_display`.

## Test
`test_changelist_active_project_count_excludes_closed_and_inactive`: with 2 active + 1 closed + 1 `display_as_active=False` for one customer (and an active project on another customer), the count is **2**, scoped per customer.

`uv run poe test projects.tests.test_admin.KippoCustomerAdminProjectsInlineTestCase` → 5 passed; ruff check + format clean.