### PR TITLE
:lipstick: admin: hide KippoCustomer organization field only for single-org users

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1315,16 +1315,18 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         if "organization" not in form.base_fields:
             return form
         try:
-            user_initial_organization, _user_organizations = get_user_session_organization(request)
+            user_initial_organization, user_organizations = get_user_session_organization(request)
         except ValueError:
-            user_initial_organization = None
+            user_initial_organization, user_organizations = None, []
         if not request.user.is_superuser:
             form.base_fields["organization"].queryset = request.user.memberships.all()
         if user_initial_organization:
             form.base_fields["organization"].initial = user_initial_organization
-            # Hide — derived from the user's session organization. Multi-org users still get
-            # the session value; to create a customer in a different org, switch the session org first.
-            form.base_fields["organization"].widget = forms.HiddenInput()
+            # Hide the field only for single-org users (there's nothing to choose). Multi-org
+            # users keep it visible — initialized to the session org — so they can pick which
+            # organization the customer belongs to.
+            if len(user_organizations) == 1:
+                form.base_fields["organization"].widget = forms.HiddenInput()
         return form
 
 

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1439,7 +1439,9 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
 
 
 class KippoCustomerAdminOrganizationFieldTestCase(IsStaffModelAdminTestCaseBase):
-    """KippoCustomerAdmin auto-sets the organization from the user's session and hides the field."""
+    """KippoCustomerAdmin initializes the organization from the user's session, and hides the
+    field only for single-org users (multi-org users keep it visible to choose the org).
+    """
 
     fixtures = DEFAULT_FIXTURES
 
@@ -1462,3 +1464,18 @@ class KippoCustomerAdminOrganizationFieldTestCase(IsStaffModelAdminTestCaseBase)
         request = self._make_request(self.superuser_no_org)
         form_class = modeladmin.get_form(request)
         self.assertNotIsInstance(form_class.base_fields["organization"].widget, forms.HiddenInput)
+
+    def test_get_form_keeps_organization_field_visible_for_multi_org_user(self):
+        # Add the staff user to a second org so they belong to two organizations.
+        OrganizationMembership.objects.create(
+            user=self.staffuser_with_org,
+            organization=self.other_organization,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        request = self._make_request(self.staffuser_with_org, organization_id=str(self.organization.id))
+        form_class = modeladmin.get_form(request)
+        # Multi-org → field stays visible, still initialized to the session org.
+        self.assertNotIsInstance(form_class.base_fields["organization"].widget, forms.HiddenInput)
+        self.assertEqual(form_class.base_fields["organization"].initial, self.organization)


### PR DESCRIPTION
## Summary

`KippoCustomerAdmin` hid the organization field whenever the user had a session org — which forced **multi-org** users onto the session org with no way to choose. Now it hides the field **only when the user belongs to a single organization** (there's nothing to pick). Multi-org users keep the field **visible**, still initialized to the session org, so they can choose which organization the customer belongs to.

This matches `KippoProjectAdmin`'s existing single-org behavior (`len(user_organizations) == 1`).

## Tests
- existing: single-org user → field hidden + initialized to session org ✅
- existing: user without membership → field visible ✅
- **new**: multi-org user → field stays visible, initialized to the session org

`projects.tests.test_admin.KippoCustomerAdminOrganizationFieldTestCase` → 3 passed; ruff clean.