### PR TITLE
:sparkles: admin: select KippoProject 顧客 via searchable autocomplete

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -724,6 +724,9 @@ class KippoProjectAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     list_display_links = ("id", "name")
     list_select_related = ("customer",)
     search_fields = ("id", "name", "phase", "category", "problem_definition", "customer__name")
+    # 顧客 (customer) is selected via a searchable autocomplete (searches/displays KippoCustomer.name
+    # through KippoCustomerAdmin.search_fields) instead of a long unsearchable <select>.
+    autocomplete_fields = ("customer",)
     ordering = ("organization", "-display_as_active", "-confidence", "phase", "name")
     actions = [
         create_github_organizational_project_action,

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -15,8 +15,10 @@ from accounts.models import KippoUser, OrganizationMembership
 from commons.tests import DEFAULT_COLUMNSET_PK, DEFAULT_FIXTURES, IsStaffModelAdminTestCaseBase
 from customers.models import KippoCustomer
 from django import forms
+from django.contrib import admin
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME, AdminForm
 from django.http import HttpResponse
+from django.test import SimpleTestCase
 from django.urls import reverse
 from django.utils import timezone
 
@@ -827,6 +829,22 @@ class KippoProjectAdminCustomerSearchTestCase(KippoProjectAdminFixtureTestCaseBa
         results = response.context["cl"].queryset
         self.assertIn(self.acme_project, results)
         self.assertNotIn(self.other_project, results)
+
+
+class KippoProjectAdminCustomerAutocompleteTestCase(SimpleTestCase):
+    """顧客 (customer) is selected via a searchable autocomplete on the project admins."""
+
+    def test_project_admins_declare_customer_autocomplete(self):
+        self.assertIn("customer", KippoProjectAdmin.autocomplete_fields)
+        # ActiveKippoProjectAdmin inherits the base configuration.
+        self.assertIn("customer", ActiveKippoProjectAdmin.autocomplete_fields)
+
+    def test_autocomplete_config_passes_admin_system_checks(self):
+        # admin.E039/E040 are raised here if KippoCustomer is not registered or its admin lacks
+        # search_fields — i.e. the prerequisites that make the customer autocomplete actually work.
+        errors = KippoProjectAdmin(KippoProject, admin.site).check()
+        autocomplete_errors = [e for e in errors if e.id in {"admin.E038", "admin.E039", "admin.E040"}]
+        self.assertEqual(autocomplete_errors, [])
 
 
 class ClosedProjectReadonlyTestCase(KippoProjectAdminFixtureTestCaseBase):


### PR DESCRIPTION
## Summary

The 顧客 (customer) field on `KippoProjectAdmin` (and `ActiveKippoProjectAdmin`) was a plain `<select>` listing every customer — unsearchable and unwieldy as customer counts grow. This switches it to a **searchable select2 autocomplete** that searches and displays the customer **name**.

## Change

- `KippoProjectAdmin.autocomplete_fields = ("customer",)` — inherited by `ActiveKippoProjectAdmin` (base + all).
- Works against the existing `KippoCustomerAdmin.search_fields = ("name", "email")`; the widget renders `KippoCustomer.__str__` (the name).
- Both `KippoProject` and `KippoCustomer` are registered on the default admin site, so the autocomplete AJAX URL resolves.
- The customer dropdown results come from `KippoCustomerAdmin.get_queryset` (already organization-scoped), and the existing per-form organization-scoping of the customer queryset still applies for validation.

## Tests

`KippoProjectAdminCustomerAutocompleteTestCase` (SimpleTestCase, no DB):
- asserts both project admins declare `customer` in `autocomplete_fields`;
- runs `ModelAdmin.check()` and asserts no `admin.E038/E039/E040` — i.e. the autocomplete prerequisites (KippoCustomer registered + has `search_fields`) hold.

`manage.py check` passes (validates the autocomplete config); `ruff` clean. Full DB test suite runs in CI (local DB unreachable behind an active tailscale exit node).