### PR TITLE
:sparkles: api: add category filter to projects list endpoint

### DIFF
--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -187,6 +187,35 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertIn(str(inactive_project.id), inactive_ids)
         self.assertNotIn(str(self.project.id), inactive_ids)
 
+    def test_filter_by_category(self):
+        """Test filtering projects by the category query parameter (exact match)."""
+        self.project.category = "PAO"
+        self.project.save()
+
+        other_category_project = KippoProject.objects.create(
+            name="New Proposal Project",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            category="new-proposal",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        # Filter to PAO — only the PAO project should be returned.
+        url = f"{settings.URL_PREFIX}/api/projects/?category=PAO"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        category_ids = [result["id"] for result in response.json()["results"]]
+        self.assertIn(str(self.project.id), category_ids)
+        self.assertNotIn(str(other_category_project.id), category_ids)
+
+        # Without the filter, both projects are returned.
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        response = self.client.get(url)
+        all_ids = [result["id"] for result in response.json()["results"]]
+        self.assertIn(str(self.project.id), all_ids)
+        self.assertIn(str(other_category_project.id), all_ids)
+
     def test_user_cannot_access_other_organization_projects(self):
         """Test that users can only access projects from their organizations."""
         url = f"{settings.URL_PREFIX}/api/projects/{self.other_project.id}/"

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -80,6 +80,12 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
                 required=False,
                 type=bool,
             ),
+            OpenApiParameter(
+                name="category",
+                description="Filter by category (exact match on the KippoProject.category value, e.g. 'PAO')",
+                required=False,
+                type=str,
+            ),
         ]
     )
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
@@ -109,6 +115,11 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(display_as_active=is_active_bool)
             if is_active_bool:
                 queryset = queryset.filter(is_closed=False)
+
+        # Filter by category (exact match on KippoProject.category)
+        category = self.request.query_params.get("category", None)
+        if category is not None:
+            queryset = queryset.filter(category=category)
 
         return queryset
 


### PR DESCRIPTION
## Why
The kippo-ui project list needs to scope projects by category. The projects list endpoint supported `is_active` but not `category`.

## What
Add `GET /api/projects/?category=<value>` — an exact match on `KippoProject.category`, mirroring the existing `is_active` filter and documented via drf-spectacular's `@extend_schema`.

## Tests
- New `test_filter_by_category` in `projects/tests/test_api_rest.py` (filtered list returns only the matching category; unfiltered returns all).
- `KippoProjectViewSetTestCase` green (10 tests); ruff + ruff-format pre-commit passed.

Companion UI change: monkut/kippo-ui#105.