### PR TITLE
feat(projects): expose phase_display status label on the API

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -156,6 +156,8 @@ class KippoProjectSerializer(serializers.ModelSerializer):
     organization_name = serializers.CharField(source="organization.name", read_only=True)
     project_manager_username = serializers.CharField(source="project_manager.username", read_only=True, allow_null=True)
     customer_name = serializers.CharField(source="customer.name", read_only=True, allow_null=True)
+    # Human-readable project status label for `phase` (kippo#37 / T10). `phase` stays the editable key.
+    phase_display = serializers.CharField(source="get_phase_display", read_only=True)
     # category is a FK to KippoProjectOrganizationCategory; expose it as the category key string for
     # API backward-compatibility. Writes resolve against the global default categories (kippo#30 / T08, T20).
     category = serializers.SlugRelatedField(
@@ -191,6 +193,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "slug",
             "columnset",
             "phase",
+            "phase_display",
             "confidence",
             "category",
             "slack_channel_name",
@@ -228,6 +231,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "organization_name",
             "customer_name",
             "project_manager_username",
+            "phase_display",  # human-readable status label (kippo#37 / T10)
             "confidence",  # derived from phase (kippo#36 / T09)
             "closed_datetime",
             "allocated_effort_hours",

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -142,6 +142,8 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertEqual(data["organization_name"], self.organization.name)
         self.assertEqual(data["allocated_staff_days"], 60)
         self.assertEqual(data["allocated_effort_hours"], 60 * settings.DAY_WORKHOURS)
+        # phase_display exposes the human-readable status label for the phase key (kippo#37 / T10)
+        self.assertEqual(data["phase_display"], self.project.get_phase_display())
 
     def test_filter_by_is_active(self):
         """Test filtering projects by is_active parameter.


### PR DESCRIPTION
## Summary

Adds a read-only `phase_display` field to `KippoProjectSerializer` exposing the human-readable **project status** label for the `phase` key (the editable `phase` field is unchanged).

This is the **backend portion of kiconiaworks/kippo#37** (技術要件 T10). Builds on #36 (phase→status) and #30 (category).

## Why backend-only
kippo-ui's API types (`PhaseEnum`, the generated client) come from a kippo **release** via `pnpm update:api` and still hold the old phase values. The kippo-ui changes — showing the status label in the list/detail and replacing the 確度% display — will follow once this ships in a release and the client is regenerated. (The anon-project→`category=="non-project"` repointing already landed with #36.)

## Changes
- `KippoProjectSerializer`: `phase_display = CharField(source="get_phase_display", read_only=True)`, added to `fields` and `read_only_fields`.

## Testing
- Full suite (`KIPPO_TESTING=True`): 741 tests, no failures from this change (only the pre-existing S3-environment errors, which pass under CI's mocked S3).
- Added an assertion to the project-retrieve API test that `phase_display` equals `get_phase_display()`.
- `ruff` / `manage.py check` clean.