### PR TITLE
chore: remove unused django-reversion dependency

### DIFF
--- a/kippo/customers/models.py
+++ b/kippo/customers/models.py
@@ -1,12 +1,10 @@
 import uuid
 
-import reversion
 from commons.models import UserCreatedBaseModel
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 
-@reversion.register()
 class KippoCustomer(UserCreatedBaseModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     organization = models.ForeignKey(

--- a/kippo/kippo/settings.py
+++ b/kippo/kippo/settings.py
@@ -56,7 +56,6 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 
 INSTALLED_APPS = [
     "social_django",
-    "reversion",
     "bootstrap4",
     "commons",  # must be *before* "'common.apps.KippoAdminConfig',  # 'django.contrib.admin'," in order to override admin template!
     "commons.admin.KippoAdminConfig",  # 'django.contrib.admin',

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -5,7 +5,6 @@ from collections import Counter
 from typing import Any
 from urllib.parse import quote, urlencode
 
-import reversion
 from accounts.models import KippoOrganization, KippoUser, OrganizationMembership, PublicHoliday
 from commons.fields import CommaSeparatedCharField
 from commons.models import TimestampedModel, UserCreatedBaseModel
@@ -227,7 +226,6 @@ def get_default_project_category():
     )
 
 
-@reversion.register()
 class KippoProject(UserCreatedBaseModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     organization = models.ForeignKey("accounts.KippoOrganization", on_delete=models.CASCADE, verbose_name=_("組織"))
@@ -730,7 +728,6 @@ class KippoProjectStatus(UserCreatedBaseModel):
         return f"ProjectStatus({self.project.name} {self.created_datetime})"
 
 
-@reversion.register()
 class KippoMilestone(UserCreatedBaseModel):
     """Provides milestone definition and mapping to a Github Repository Milestone"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "django>=5.2,<5.3",
     "psycopg[binary]",
     "social-auth-app-django",
-    "django-reversion",
     "requests",
     "django-bootstrap4",
     "ghorgs@git+https://github.com/monkut/github-org-manager.git",

--- a/uv.lock
+++ b/uv.lock
@@ -287,18 +287,6 @@ wheels = [
 ]
 
 [[package]]
-name = "django-reversion"
-version = "5.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/aa/d7e9d98b23041b24d2b35cefcbbfa51e6e557e8e58c1c1bddabdb0baf13f/django_reversion-5.1.0.tar.gz", hash = "sha256:3309821e5b6fceedcce6b6975f1a9c7fab6ae7c7d0e1276a90e345946fa0dcb8", size = 73178, upload-time = "2024-08-09T21:30:29.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/84/898fec51294e6764ab5fdde5db079ca89d528cef039c05447ca41d6f4c74/django_reversion-5.1.0-py3-none-any.whl", hash = "sha256:084d4f117d9e2b4e8dfdfaad83ebb34410a03eed6071c96089e6811fdea82ad3", size = 84857, upload-time = "2024-08-09T21:30:27.761Z" },
-]
-
-[[package]]
 name = "djangorestframework"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -518,7 +506,6 @@ dependencies = [
     { name = "django-admin-rangefilter" },
     { name = "django-bootstrap4" },
     { name = "django-cors-headers" },
-    { name = "django-reversion" },
     { name = "djangorestframework" },
     { name = "djangorestframework-simplejwt" },
     { name = "drf-nested-routers" },
@@ -550,7 +537,6 @@ requires-dist = [
     { name = "django-admin-rangefilter" },
     { name = "django-bootstrap4" },
     { name = "django-cors-headers" },
-    { name = "django-reversion" },
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.5.1" },
     { name = "drf-nested-routers", specifier = ">=0.95.0" },


### PR DESCRIPTION
## Summary

Removes `django-reversion`, which is present but never actually records anything.

`@reversion.register()` sat on `KippoProject`, `KippoMilestone`, and `KippoCustomer`, and `reversion` was in `INSTALLED_APPS`. But registration alone does not save versions — django-reversion only writes a version inside a revision context (`VersionAdmin`, `RevisionMiddleware`, or an explicit `create_revision()` block). None of those exist anywhere in the codebase, so no revision has ever been recorded.

This came up in review of #303 (the reviewer questioned the decorator on a new model). Confirmed unused project-wide and removed entirely.

## Changes

- Drop `@reversion.register()` from `KippoProject`, `KippoMilestone`, `KippoCustomer` and the now-unused `import reversion`.
- Remove `"reversion"` from `INSTALLED_APPS`.
- Remove `django-reversion` from `pyproject.toml` and `uv.lock`.

## Notes

- No project migration depends on reversion (verified), so no migration changes are needed.
- On existing databases the `reversion_revision` / `reversion_version` tables remain as orphaned (empty) tables — harmless; they can be dropped manually later if desired.

## Verification

- `uv run poe check` — clean (ruff + ruff-format)
- `manage.py check` — no issues
- `manage.py test customers` — 26/26 pass
- `manage.py test projects` — no new failures (the 12 errors are the pre-existing S3/`InvalidAccessKeyId` test-env errors, unrelated)