### PR TITLE
feat(projects): expose linked customer's contract-folder URL on the project API (#34)

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -156,6 +156,9 @@ class KippoProjectSerializer(serializers.ModelSerializer):
     organization_name = serializers.CharField(source="organization.name", read_only=True)
     project_manager_username = serializers.CharField(source="project_manager.username", read_only=True, allow_null=True)
     customer_name = serializers.CharField(source="customer.name", read_only=True, allow_null=True)
+    # 契約書フォルダURL (kippo#34 / T04): the linked customer's document_url, shown read-only on the
+    # project (edited via the customer). Lets the project create/edit form display the contract folder.
+    customer_document_url = serializers.URLField(source="customer.document_url", read_only=True, allow_null=True)
     # Human-readable project status label for `phase` (kippo#37 / T10). `phase` stays the editable key.
     phase_display = serializers.CharField(source="get_phase_display", read_only=True)
     # category is a FK to KippoProjectOrganizationCategory; expose it as the category key string for
@@ -193,6 +196,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "organization_name",
             "customer",
             "customer_name",
+            "customer_document_url",
             "name",
             "slug",
             "columnset",
@@ -238,6 +242,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "organization_name",
             "customer_name",
             "project_manager_username",
+            "customer_document_url",  # linked customer's contract-folder URL (kippo#34 / T04)
             "phase_display",  # human-readable status label (kippo#37 / T10)
             "confidence",  # derived from phase (kippo#36 / T09)
             "total_revenue",  # ledger-derived (kippo#32 / T13)

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -174,6 +174,56 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertEqual(data["total_revenue"], "0")
         self.assertEqual(data["contract_amount"], "0")
 
+    def test_customer_link_and_contract_folder_url(self):
+        """Project create/edit can set the customer; the contract-folder URL (customer.document_url)
+        is exposed read-only on the project (kippo#34 / T04).
+        """
+        from customers.models import KippoCustomer
+
+        customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="Acme Co",
+            document_url="https://drive.example.com/acme/contracts",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        # link the customer via the project edit API
+        patch = self.client.patch(url, {"customer": str(customer.id)}, format="json")
+        self.assertEqual(patch.status_code, HTTPStatus.OK)
+        data = patch.json()
+        self.assertEqual(data["customer"], str(customer.id))
+        self.assertEqual(data["customer_name"], "Acme Co")
+        # contract-folder URL surfaces from the linked customer
+        self.assertEqual(data["customer_document_url"], "https://drive.example.com/acme/contracts")
+
+    def test_customer_document_url_null_without_customer(self):
+        """customer_document_url is null when the project has no customer (kippo#34 / T04)."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        data = self.client.get(url).json()
+        self.assertIsNone(data["customer_document_url"])
+
+    def test_contract_folder_url_is_read_only_on_project(self):
+        """Writing customer_document_url through the project is ignored — edit via the customer (kippo#34 / T04)."""
+        from customers.models import KippoCustomer
+
+        customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="Beta Co",
+            document_url="https://drive.example.com/beta",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.project.customer = customer
+        self.project.save()
+
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(url, {"customer_document_url": "https://evil.example.com"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        customer.refresh_from_db()
+        self.assertEqual(customer.document_url, "https://drive.example.com/beta")  # unchanged
+
     def test_filter_by_is_active(self):
         """Test filtering projects by is_active parameter.
 


### PR DESCRIPTION
Implements the backend half of kiconiaworks/kippo#34 (T04, T05). Most of what the issue asks for already exists; this PR fills the one API gap.

## Already in place (no change)

- **T05 — admin Customer autocomplete + new-add**: `KippoProjectAdmin.autocomplete_fields = ("customer",)` with `KippoCustomerAdmin.search_fields`; the widget's built-in "＋" adds a new customer. (The issue itself notes 管理画面は autocomplete_fields 実装済.)
- **T04 — customer link via API**: `customer` is already a writable field on `KippoProjectSerializer`.
- **Customer search API for the UI autocomplete**: `/api/customers/?search=<name>` (org-scoped, supports POST to create) already exists.

## This PR (T04 gap)

Per review decision, the 契約書フォルダURL is the **linked customer's `document_url`** (not a new project field, and distinct from the project's existing `document_folder_url`). Added `customer_document_url` to `KippoProjectSerializer` — **read-only**, sourced from `customer.document_url`, null when there's no customer. The project create/edit form can now display the contract folder; editing the URL stays on the customer (customer API/admin), so the shared customer record has a single owner.

## Tests

`KippoProjectViewSetTestCase`: linking a customer via PATCH surfaces `customer_name` + `customer_document_url`; the field is null without a customer; and writing `customer_document_url` through the project is ignored (the customer's URL is unchanged). Full projects-API + customers-viewset suites green.

## UI

The create/edit form work (customer autocomplete + contract-folder URL display) is a follow-up kippo-ui PR, after a release exposes `customer_document_url` — consistent with the #37 / #32 split.