### PR TITLE
feat(projects): add category_label + billing_types to the list/detail API (#39)

### DIFF
--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -423,6 +423,15 @@ class KippoProject(UserCreatedBaseModel):
         """契約金額 (kippo#32 / T13): total contracted value across the project's contracts."""
         return sum((contract.contract_value for contract in self.contracts.all()), Decimal(0))
 
+    @property
+    def billing_types(self) -> list[str]:
+        """請求方法 (kippo#39 / T14): distinct billing types across the project's contracts.
+
+        After kippo#31 the billing method lives on KippoProjectContract; a project may have
+        several contracts (e.g. renewals), so the list view shows the distinct set.
+        """
+        return sorted({contract.billing_type for contract in self.contracts.all()})
+
     def developers(self):
         from tasks.models import KippoTask
 

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -169,6 +169,11 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         required=False,
         help_text="Project category key (e.g. 'ai-development', 'other', 'non-project').",
     )
+    # Human-readable category label for the list/detail view (kippo#39 / T14); `category` stays the key.
+    category_label = serializers.CharField(source="category.label", read_only=True, allow_null=True)
+    # 請求方法 — distinct billing types across the project's contracts (kippo#39 / T14). Read-only;
+    # the billing method moved to KippoProjectContract in kippo#31.
+    billing_types = serializers.ListField(child=serializers.CharField(), read_only=True)
     # Derived revenue figures (kippo#32 / T13). Read-only — sourced from the contract + billing
     # ledger (kippo#31), so they never drift from the underlying records.
     total_revenue = serializers.DecimalField(max_digits=12, decimal_places=0, read_only=True)
@@ -204,6 +209,8 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "phase_display",
             "confidence",
             "category",
+            "category_label",
+            "billing_types",
             "slack_channel_name",
             "slack_notification_channel_name",
             "project_manager",
@@ -245,6 +252,8 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "customer_document_url",  # linked customer's contract-folder URL (kippo#34 / T04)
             "phase_display",  # human-readable status label (kippo#37 / T10)
             "confidence",  # derived from phase (kippo#36 / T09)
+            "category_label",  # human-readable category label (kippo#39 / T14)
+            "billing_types",  # distinct contract billing types (kippo#39 / T14)
             "total_revenue",  # ledger-derived (kippo#32 / T13)
             "contract_amount",  # contract-derived (kippo#32 / T13)
             "closed_datetime",

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -174,6 +174,36 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertEqual(data["total_revenue"], "0")
         self.assertEqual(data["contract_amount"], "0")
 
+    def test_list_exposes_category_label_and_billing_types(self):
+        """List/detail expose category_label + distinct contract billing_types (kippo#39 / T14)."""
+        from decimal import Decimal
+
+        # two contracts on the project: one monthly, one delivery -> distinct billing_types
+        KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type="monthly",
+            amount=Decimal("300000"),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type="delivery",
+            amount=Decimal("1000000"),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        list_data = self.client.get(f"{settings.URL_PREFIX}/api/projects/").json()
+        row = next(r for r in list_data["results"] if r["id"] == str(self.project.id))
+        self.assertEqual(row["category_label"], self.project.category.label)
+        self.assertEqual(row["billing_types"], ["delivery", "monthly"])  # sorted distinct
+
+    def test_billing_types_empty_without_contracts(self):
+        """billing_types is an empty list when the project has no contracts (kippo#39 / T14)."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        self.assertEqual(self.client.get(url).json()["billing_types"], [])
+
     def test_problem_definition_shown_in_list_and_detail(self):
         """problem_definition (reused as the project intro) is writable and shown in list/detail (kippo#29 / T07)."""
         url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -61,8 +61,10 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
     permission_classes = [IsSuperuserOrOwnOrgReadUpdateCreate]
     queryset = (
         KippoProject.objects.all()
-        .select_related("organization", "project_manager")
-        .prefetch_related("github_repositories")
+        .select_related("organization", "project_manager", "customer", "category")
+        # contracts + billing_entries back the list's billing_types / contract_amount / total_revenue
+        # derived fields (kippo#39 / T14) — prefetch to avoid N+1 across the list.
+        .prefetch_related("github_repositories", "contracts", "billing_entries")
         .order_by("-created_datetime")
     )
 


### PR DESCRIPTION
Implements the **T14 backend half** of kiconiaworks/kippo#39. The T15 UI half (kippo-ui list columns / sort / search, per-month monthly rows) is a follow-up kippo-ui PR after a release.

## Already present (from #31/#32/#37) — no change

`customer_name` (社名), `phase_display` (ステータス), `total_revenue` + `contract_amount` (売上), `start_date` (開始日), `target_date` (完了予定日), `category` (key).

## This PR adds the two missing T14 fields

- **`category_label`** — human-readable category label for display; `category` stays the editable key.
- **`billing_types`** (請求方法) — distinct billing types across the project's contracts, via a derived `KippoProject.billing_types` property. The billing method moved to `KippoProjectContract` in #31, and a project may have several contracts (renewals), so the list shows the distinct sorted set (e.g. `["delivery","monthly"]`). Empty list when there are no contracts.

Both are read-only.

## Performance

The list serializer's derived billing/revenue fields (`billing_types`, `contract_amount`, `total_revenue`) read `contracts` / `billing_entries` per row. Added `prefetch_related("contracts","billing_entries")` and `select_related("customer","category")` on the viewset queryset to avoid N+1 across the list.

## Tests

`test_api_rest`: list exposes `category_label` + distinct sorted `billing_types` for a project with mixed monthly/delivery contracts; `billing_types` is empty without contracts. Full projects API + admin suites green.

## Note on representation

`billing_types` is a distinct **list** (a project can hold multiple contracts). If a single primary billing method is preferred for the list column, easy to change — flagging the choice.