### PR TITLE
feat(projects): required-field validation at project registration (#40)

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -119,6 +119,11 @@ class KippoProjectContractInline(LockWhenProjectClosedInlineMixin, AllowIsStaffA
     fields = ("billing_type", "amount", "start_date", "end_date", "note")
     classes = ["collapse"]
 
+    def get_min_num(self, request: DjangoRequest, obj: KippoProject | None = None, **kwargs):
+        # 請求方法 is required at project registration (kippo#40 / T19): require ≥1 contract on /add/.
+        # Editing an existing project is unaffected (existing contract-less projects still save).
+        return 1 if obj is None else 0
+
     def get_formset(self, request: DjangoRequest, obj: KippoProject | None = None, **kwargs):
         """Pre-fill the new contract row's period with the project's dates so the admin user
         sees the defaults before saving (the model still backfills them on save if cleared).
@@ -689,12 +694,23 @@ add_calendar_links_to_slack_channels_action.short_description = _("Add MTG calen
 
 
 class KippoProjectAdminForm(forms.ModelForm):
+    # Required at project registration (kippo#40 / T19) — enforced create-only so existing rows/edits
+    # are unaffected. category/phase always carry model defaults; 請求方法 is enforced via the required
+    # contract inline (see KippoProjectContractInline.get_min_num).
+    REQUIRED_AT_REGISTRATION = ("customer", "project_manager", "start_date", "target_date")
+
     class Meta:
         model = KippoProject
         exclude = ()  # noqa: DJ006 (admin form inherits field config from ModelAdmin)
 
     def clean(self):
         cleaned_data = super().clean()
+        # KippoProject.id is a UUID with a default, so .pk is set even before save — use _state.adding
+        # to detect a genuine registration (add) vs an edit of an existing row.
+        if self.instance._state.adding:
+            for field in self.REQUIRED_AT_REGISTRATION:
+                if not cleaned_data.get(field):
+                    self.add_error(field, _("This field is required at project registration."))
         category = cleaned_data.get("category")
         organization = cleaned_data.get("organization")
         submitted_parent_project = cleaned_data.get("parent_project")

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -295,6 +295,17 @@ class KippoProjectSerializer(serializers.ModelSerializer):
                     {"columnset": "No columnset provided and no default columnset is configured for this organization."}
                 )
             attrs["columnset"] = columnset
+
+        # Required-field validation at project registration (kippo#40 / T19). Create-only — edits of
+        # existing rows (and existing data) are unaffected. category/phase always carry model defaults,
+        # so the enforced gaps are the genuinely-optional fields. 請求方法 (billing method) lives on
+        # KippoProjectContract since kippo#31; the API cannot attach a contract at project-create
+        # (no nested write), so that requirement is enforced on the admin registration form instead.
+        if self.instance is None:
+            required_at_registration = ("customer", "project_manager", "start_date", "target_date")
+            missing = {field: "This field is required at project registration." for field in required_at_registration if not attrs.get(field)}
+            if missing:
+                raise serializers.ValidationError(missing)
         return attrs
 
     @extend_schema_field(serializers.FloatField(allow_null=True))

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -721,6 +721,12 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
     def test_upsell_form_with_derived_organization_is_valid_and_saves_parent(self):
         # the upsell prefill always sets organization = parent_project.organization, so the form
         # validator's parent-org invariant is satisfied by construction. Save and verify the result.
+        customer = KippoCustomer.objects.create(
+            organization=self.project1.organization,
+            name="upsell-form-customer",
+            created_by=self.superuser_no_org,
+            updated_by=self.superuser_no_org,
+        )
         form = KippoProjectAdminForm(
             data={
                 "organization": str(self.project1.organization_id),
@@ -730,7 +736,11 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
                 "confidence": "80",
                 "category": str(_global_category("upsell-improvement").pk),
                 "columnset": str(self.project1.columnset_id),
+                # required at registration (kippo#40 / T19)
+                "customer": str(customer.id),
+                "project_manager": str(self.superuser_no_org.id),
                 "start_date": self.current_date.isoformat(),
+                "target_date": self.current_date.isoformat(),
             },
         )
         self.assertTrue(form.is_valid(), form.errors)
@@ -768,6 +778,12 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
         super().setUp()
         self.columnset = ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK)
         self.current_date = timezone.now().date()
+        self.customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="adminform-customer",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
         self.parent = KippoProject.objects.create(
             organization=self.organization,
             name="parent-project",
@@ -780,6 +796,7 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
 
     def _form_data(self, *, category: str, parent_project_id: str | None = None) -> dict:
         # category is a FK ModelChoiceField — submit the category's PK, resolved from its key.
+        # customer / project_manager / target_date are required at registration (kippo#40 / T19).
         data = {
             "organization": str(self.organization.id),
             "name": "manual-new-project",
@@ -787,7 +804,10 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
             "confidence": "80",
             "category": str(_global_category(category).pk),
             "columnset": str(self.columnset.pk),
+            "customer": str(self.customer.id),
+            "project_manager": str(self.github_manager.id),
             "start_date": self.current_date.isoformat(),
+            "target_date": self.current_date.isoformat(),
         }
         if parent_project_id:
             data["parent_project"] = parent_project_id
@@ -807,6 +827,38 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
     def test_non_upsell_category_does_not_require_parent_project(self):
         form = KippoProjectAdminForm(data=self._form_data(category="other"))
         self.assertTrue(form.is_valid(), form.errors)
+
+    def test_registration_requires_customer_pm_and_dates(self):
+        # add-form missing the required registration fields is invalid (kippo#40 / T19)
+        data = self._form_data(category="other")
+        for field in ("customer", "project_manager", "start_date", "target_date"):
+            del data[field]
+        form = KippoProjectAdminForm(data=data)
+        self.assertFalse(form.is_valid())
+        for field in ("customer", "project_manager", "start_date", "target_date"):
+            self.assertIn(field, form.errors)
+
+    def test_edit_existing_project_not_blocked_by_registration_requirements(self):
+        # editing an existing customer-less / PM-less project must still validate (create-only rule)
+        existing = KippoProject.objects.create(
+            organization=self.organization,
+            name="pre-existing-minimal",
+            category=_global_category("other"),
+            columnset=self.columnset,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        data = self._form_data(category="other")
+        for field in ("customer", "project_manager", "start_date", "target_date"):
+            del data[field]
+        form = KippoProjectAdminForm(instance=existing, data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_contract_inline_required_on_add_optional_on_change(self):
+        # 請求方法 required at registration via the contract inline (kippo#40 / T19)
+        inline = KippoProjectContractInline(parent_model=KippoProject, admin_site=self.site)
+        self.assertEqual(inline.get_min_num(request=self.super_user_request, obj=None), 1)
+        self.assertEqual(inline.get_min_num(request=self.super_user_request, obj=self.parent), 0)
 
     def test_change_form_with_upsell_category_uses_persisted_parent_when_field_omitted(self):
         # change form: parent_project is readonly so it isn't submitted in POST data;

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -15,6 +15,24 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from ..models import KippoProject, KippoProjectContract, KippoProjectOrganizationCategory, ProjectColumnSet, ProjectWeeklyEffort
 
 
+def _registration_fields(organization: KippoOrganization, project_manager: KippoUser) -> dict:
+    """Required-at-registration project fields for POST /api/projects/ (kippo#40 / T19)."""
+    from customers.models import KippoCustomer
+
+    customer = KippoCustomer.objects.create(
+        organization=organization,
+        name="reg-test-customer",
+        created_by=project_manager,
+        updated_by=project_manager,
+    )
+    return {
+        "customer": str(customer.id),
+        "project_manager": project_manager.id,
+        "start_date": "2026-01-01",
+        "target_date": "2026-03-31",
+    }
+
+
 class JWTAuthenticationTestCase(TestCase):
     """Test cases for JWT authentication endpoints."""
 
@@ -741,6 +759,7 @@ class PermissionsTestCase(TestCase):
             "name": "Org Member Project",
             "organization": str(self.organization.id),
             "columnset": self.project.columnset.id,
+            **_registration_fields(self.organization, self.user),
         }
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
@@ -788,9 +807,35 @@ class PermissionsTestCase(TestCase):
             "name": "Superuser Project",
             "organization": str(self.organization.id),
             "columnset": self.project.columnset.id,
+            **_registration_fields(self.organization, self.superuser),
         }
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
+
+    def test_create_missing_required_registration_fields_rejected(self):
+        """Registration requires customer/PM/start_date/target_date (kippo#40 / T19)."""
+        self.client.force_authenticate(user=self.superuser)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Incomplete Project",
+            "organization": str(self.organization.id),
+            "columnset": self.project.columnset.id,
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        for field in ("customer", "project_manager", "start_date", "target_date"):
+            self.assertIn(field, response.json())
+
+    def test_edit_existing_project_not_blocked_by_registration_requirements(self):
+        """The required-field validation is create-only; editing a contract-less / customer-less
+        project must still succeed (kippo#40 / T19).
+        """
+        self.client.force_authenticate(user=self.superuser)
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        # self.project (from setup_basic_project) has no customer/PM; a PATCH must not be blocked
+        response = self.client.patch(url, {"name": "Renamed Project"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json()["name"], "Renamed Project")
 
     def test_superuser_can_create_project_in_any_org(self):
         """Superusers retain unrestricted create across orgs (kippo#284)."""
@@ -806,6 +851,7 @@ class PermissionsTestCase(TestCase):
             "name": "Superuser Cross-Org Project",
             "organization": str(other_org.id),
             "columnset": self.project.columnset.id,
+            **_registration_fields(other_org, self.superuser),
         }
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
@@ -1154,7 +1200,7 @@ class ProjectColumnsetDefaultTestCase(TestCase):
         self.organization.default_columnset = explicit
         self.organization.save()
         self.client.force_authenticate(user=self.user)
-        data = {"name": "Default Columnset Project", "organization": str(self.organization.id)}
+        data = {"name": "Default Columnset Project", "organization": str(self.organization.id), **_registration_fields(self.organization, self.user)}
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
         created = KippoProject.objects.get(name="Default Columnset Project")
@@ -1162,7 +1208,7 @@ class ProjectColumnsetDefaultTestCase(TestCase):
 
     def test_create_project_without_columnset_falls_back_to_global(self):
         self.client.force_authenticate(user=self.user)
-        data = {"name": "Fallback Columnset Project", "organization": str(self.organization.id)}
+        data = {"name": "Fallback Columnset Project", "organization": str(self.organization.id), **_registration_fields(self.organization, self.user)}
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
         created = KippoProject.objects.get(name="Fallback Columnset Project")


### PR DESCRIPTION
Implements kiconiaworks/kippo#40 (T19). Validates the required fields when **registering (creating)** a project. Enforcement is **create-only** so existing rows, fixtures, and edits are unaffected (per design decision).

## Required at registration

| Field | Where enforced |
|---|---|
| 企業 (customer) | serializer + admin form |
| プロジェクトマネージャー (project_manager) | serializer + admin form |
| 開始日 (start_date) | serializer + admin form |
| 完了予定日 (target_date) | serializer + admin form |
| 請求方法 (billing method) | **required contract inline** (admin) |
| カテゴリ / ステータス | already guaranteed by model defaults |

## 請求方法 after #31

The billing method moved to `KippoProjectContract` in #31, so it's enforced by requiring **≥1 contract at registration**: `KippoProjectContractInline.get_min_num()` returns 1 on `/add/`, 0 on change. The REST API can't attach a contract at project-create (no nested write / no contracts endpoint), so the contract requirement is admin-only for now — the project-field requirements still apply at the API.

## Implementation notes

- `KippoProjectSerializer.validate()` enforces the four project fields on create (`self.instance is None`).
- `KippoProjectAdminForm.clean()` enforces them gated on `self.instance._state.adding` — **not** `.pk is None`, because `KippoProject.id` is a UUID with a default, so `.pk` is already set before save (this was a real footgun).
- Create-only: editing an existing customer-less / contract-less project still saves.

## Tests

- API: missing-fields create → 400 with each field flagged; edit of an existing minimal project → 200 (create-only exemption). Existing create-path tests updated to supply the now-required fields.
- Admin: add-form missing fields → invalid; edit not blocked; contract inline `get_min_num` is 1 on add / 0 on change.
- Full projects suite: only the pre-existing S3-env errors remain.

## UI

The kippo-ui create form surfacing these errors is a follow-up UI PR after a release.