### PR TITLE
feat(projects): expose monthly_billing_schedule for per-month list rows (#39 / T15)

### DIFF
--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -432,6 +432,19 @@ class KippoProject(UserCreatedBaseModel):
         """
         return sorted({contract.billing_type for contract in self.contracts.all()})
 
+    @property
+    def monthly_billing_schedule(self) -> list[tuple[datetime.date, Decimal]]:
+        """Planned per-month billing schedule across the project's monthly contracts (kippo#39 / T15).
+
+        Sorted ``(month_end_date, amount)`` entries — lets the UI render one row per month for
+        monthly-billing projects (月額は契約期間内毎月表示). Empty when the project has no
+        monthly contracts.
+        """
+        schedule: list[tuple[datetime.date, Decimal]] = []
+        for contract in self.contracts.all():
+            schedule.extend(contract.monthly_schedule())
+        return sorted(schedule)
+
     def developers(self):
         from tasks.models import KippoTask
 
@@ -852,6 +865,24 @@ class KippoProjectContract(UserCreatedBaseModel):
         if self.billing_type == BILLING_TYPE_MONTHLY:
             return self.amount * self._month_count()
         return self.amount
+
+    def monthly_schedule(self) -> list[tuple[datetime.date, Decimal]]:
+        """Planned per-month billing schedule for a monthly contract (kippo#39 / T15).
+
+        One ``(month_end_date, amount)`` entry per calendar month in the contract period,
+        matching the month-end dates generate_billing_entries() bills. Empty for delivery
+        contracts and when the period is unresolved. This is the *planned* schedule derived
+        from the contract terms (so it is available before any ledger entries are generated).
+        """
+        if self.billing_type != BILLING_TYPE_MONTHLY or not self.start_date or not self.end_date:
+            return []
+        schedule = []
+        current = first_of_month(self.start_date)
+        end = first_of_month(self.end_date)
+        while current <= end:
+            schedule.append((last_of_month(current), self.amount))
+            current = first_of_next_month(current)
+        return schedule
 
     def generate_billing_entries(self, created_by: KippoUser | None = None) -> list["KippoProjectBillingEntry"]:
         """Populate the project's billing ledger from these terms (kippo#31 / T12).

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -36,6 +36,13 @@ class ProjectAssignmentRateInlineSerializer(serializers.Serializer):
     is_default = serializers.BooleanField()
 
 
+class MonthlyBillingScheduleEntrySerializer(serializers.Serializer):
+    """One planned monthly billing row (kippo#39 / T15): month-end date + amount."""
+
+    month = serializers.DateField(help_text="Month-end (月末) billing date.")
+    amount = serializers.DecimalField(max_digits=12, decimal_places=0, help_text="Billed amount for the month (JPY).")
+
+
 class ProjectProgressStatusInlineSerializer(serializers.Serializer):
     """Inline serializer for project progress status in OpenAPI schema."""
 
@@ -174,6 +181,9 @@ class KippoProjectSerializer(serializers.ModelSerializer):
     # 請求方法 — distinct billing types across the project's contracts (kippo#39 / T14). Read-only;
     # the billing method moved to KippoProjectContract in kippo#31.
     billing_types = serializers.ListField(child=serializers.CharField(), read_only=True)
+    # Planned per-month billing schedule for monthly-billing projects (kippo#39 / T15) — lets the
+    # list render one row per month (月額は契約期間内毎月表示). Empty for non-monthly projects.
+    monthly_billing_schedule = serializers.SerializerMethodField()
     # Derived revenue figures (kippo#32 / T13). Read-only — sourced from the contract + billing
     # ledger (kippo#31), so they never drift from the underlying records.
     total_revenue = serializers.DecimalField(max_digits=12, decimal_places=0, read_only=True)
@@ -211,6 +221,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "category",
             "category_label",
             "billing_types",
+            "monthly_billing_schedule",
             "slack_channel_name",
             "slack_notification_channel_name",
             "project_manager",
@@ -254,6 +265,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "confidence",  # derived from phase (kippo#36 / T09)
             "category_label",  # human-readable category label (kippo#39 / T14)
             "billing_types",  # distinct contract billing types (kippo#39 / T14)
+            "monthly_billing_schedule",  # planned per-month schedule (kippo#39 / T15)
             "total_revenue",  # ledger-derived (kippo#32 / T13)
             "contract_amount",  # contract-derived (kippo#32 / T13)
             "closed_datetime",
@@ -318,6 +330,11 @@ class KippoProjectSerializer(serializers.ModelSerializer):
     @extend_schema_field(GithubRepositoryInlineSerializer(many=True))
     def get_github_repositories(self, obj: KippoProject) -> list[dict]:
         return [{"repository_url": repo.html_url} for repo in obj.github_repositories.all()]
+
+    @extend_schema_field(MonthlyBillingScheduleEntrySerializer(many=True))
+    def get_monthly_billing_schedule(self, obj: KippoProject) -> list[dict]:
+        # str(amount) to match the string rendering of the model's DecimalField revenue fields
+        return [{"month": month.isoformat(), "amount": str(amount)} for month, amount in obj.monthly_billing_schedule]
 
     @extend_schema_field(ProjectAssignmentRateInlineSerializer(many=True))
     def get_assignment_rates(self, obj: KippoProject) -> list[dict]:

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -217,6 +217,34 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertEqual(row["category_label"], self.project.category.label)
         self.assertEqual(row["billing_types"], ["delivery", "monthly"])  # sorted distinct
 
+    def test_monthly_billing_schedule_exposed_for_per_month_rows(self):
+        """Monthly projects expose a per-month schedule for the list's per-month rows (kippo#39 / T15)."""
+        from decimal import Decimal
+
+        KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type="monthly",
+            amount=Decimal("300000"),
+            start_date=datetime.date(2026, 1, 1),
+            end_date=datetime.date(2026, 3, 31),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        schedule = self.client.get(url).json()["monthly_billing_schedule"]
+        self.assertEqual(
+            schedule,
+            [
+                {"month": "2026-01-31", "amount": "300000"},
+                {"month": "2026-02-28", "amount": "300000"},
+                {"month": "2026-03-31", "amount": "300000"},
+            ],
+        )
+
+    def test_monthly_billing_schedule_empty_without_monthly_contract(self):
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        self.assertEqual(self.client.get(url).json()["monthly_billing_schedule"], [])
+
     def test_billing_types_empty_without_contracts(self):
         """billing_types is an empty list when the project has no contracts (kippo#39 / T14)."""
         url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"

--- a/kippo/projects/tests/test_models_billing.py
+++ b/kippo/projects/tests/test_models_billing.py
@@ -420,6 +420,67 @@ class DerivedRevenueFiguresTestCase(TestCase):
     def test_contract_amount_is_zero_without_contracts(self):
         self.assertEqual(self.project.contract_amount, Decimal(0))
 
+    def test_monthly_schedule_is_month_end_per_month(self):
+        contract = KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_MONTHLY,
+            amount=Decimal("300000"),
+            start_date=datetime.date(2026, 1, 15),
+            end_date=datetime.date(2026, 3, 10),
+        )
+        self.assertEqual(
+            contract.monthly_schedule(),
+            [
+                (datetime.date(2026, 1, 31), Decimal("300000")),
+                (datetime.date(2026, 2, 28), Decimal("300000")),
+                (datetime.date(2026, 3, 31), Decimal("300000")),
+            ],
+        )
+
+    def test_delivery_contract_has_empty_monthly_schedule(self):
+        contract = KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_DELIVERY,
+            amount=Decimal("2000000"),
+            end_date=datetime.date(2026, 9, 30),
+        )
+        self.assertEqual(contract.monthly_schedule(), [])
+
+    def test_project_monthly_billing_schedule_aggregates_sorted(self):
+        # two monthly contracts (e.g. renewal) merge into one sorted schedule
+        KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_MONTHLY,
+            amount=Decimal("300000"),
+            start_date=datetime.date(2026, 3, 1),
+            end_date=datetime.date(2026, 4, 30),
+        )
+        KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_MONTHLY,
+            amount=Decimal("250000"),
+            start_date=datetime.date(2026, 1, 1),
+            end_date=datetime.date(2026, 2, 28),
+        )
+        self.assertEqual(
+            self.project.monthly_billing_schedule,
+            [
+                (datetime.date(2026, 1, 31), Decimal("250000")),
+                (datetime.date(2026, 2, 28), Decimal("250000")),
+                (datetime.date(2026, 3, 31), Decimal("300000")),
+                (datetime.date(2026, 4, 30), Decimal("300000")),
+            ],
+        )
+
+    def test_project_monthly_billing_schedule_empty_for_delivery_only(self):
+        KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_DELIVERY,
+            amount=Decimal("2000000"),
+            end_date=datetime.date(2026, 9, 30),
+        )
+        self.assertEqual(self.project.monthly_billing_schedule, [])
+
     def test_total_revenue_sums_billing_ledger(self):
         KippoProjectContract.objects.create(
             project=self.project,


### PR DESCRIPTION
Unblocks the deferred **per-month monthly rows** of kiconiaworks/kippo#39 (T15). The kippo-ui list (monkut/kippo-ui#111) renders project cards but couldn't show one row per month for monthly-billing projects (月額は契約期間内毎月表示) — the list API only exposed `billing_types` / `total_revenue`, not the per-project monthly breakdown. This adds it.

## Added

- **`KippoProjectContract.monthly_schedule()`** — planned `(month_end_date, amount)` per calendar month over the contract period; empty for delivery contracts. Month-end dates match `generate_billing_entries()`. Derived from the contract **terms**, so it's available before any ledger entries are generated.
- **`KippoProject.monthly_billing_schedule`** — sorted aggregate across the project's monthly contracts (handles renewals).
- **Serializer**: `monthly_billing_schedule` read-only field as `[{month, amount}]` (amount stringified to match `total_revenue` / `contract_amount`). Empty list for non-monthly projects.

## Design notes

- This is the **planned schedule from the contract template**, not the billing ledger. It's always available (the ledger only fills once an admin runs *generate billing entries*) and is the right basis for a list overview. Manual per-entry ledger adjustments remain visible in the admin / detail; the list shows the planned monthly amount.
- Payload: bounded by contract length and empty for the common non-monthly case; the viewset already `prefetch_related("contracts")`, so no new N+1.
- No model/migration change.

## Tests

- model: contract `monthly_schedule()` (month-end per month, empty for delivery), project aggregate (sorted across two monthly contracts, empty for delivery-only).
- API: monthly project exposes the `[{month, amount}]` schedule; empty without a monthly contract.
- Full projects API + billing suites green.

## Follow-up

The kippo-ui list will consume `monthly_billing_schedule` to render per-month sub-rows in a follow-up UI PR (after this releases).