### PR TITLE
:bug: Re-derive project confidence only when phase changes

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -836,8 +836,8 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     # confidence is derived from phase (editable=False); the revenue figures are derived from
     # the contract + billing ledger (kippo#32 / T13) — all shown read-only in the form
     readonly_fields = ("confidence", "get_contract_amount_display", "get_total_revenue_display")
-    # Changelist ordering lives in get_ordering() (it references the is_anon_project annotation
-    # added in get_queryset, which the `ordering` attribute can't name without failing admin checks).
+    # Changelist ordering lives in get_ordering() (a Case() expression), not the `ordering`
+    # attribute — see the note there for why the attribute can't express it.
     actions = [
         create_github_organizational_project_action,
         create_github_repository_milestones_action,

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -730,6 +730,13 @@ class KippoProject(UserCreatedBaseModel):
         )
         return description
 
+    @classmethod
+    def from_db(cls, db: str, field_names: list[str], values: list[Any]) -> "KippoProject":
+        # Snapshot the persisted phase so save() can re-derive confidence only when phase changes.
+        instance = super().from_db(db, field_names, values)
+        instance._confidence_synced_phase = instance.phase
+        return instance
+
     def save(self, *args, **kwargs):
         if self.survey_issued and not self.survey_issued_datetime:
             self.survey_issued_datetime = timezone.now()
@@ -742,8 +749,14 @@ class KippoProject(UserCreatedBaseModel):
         if not self.billing_date and self.target_date:
             self.billing_date = self.target_date
 
-        # confidence (確度) is derived from phase — never user-set (kippo#36 / T09)
-        self.confidence = PHASE_CONFIDENCE.get(self.phase, self.confidence)
+        # confidence (確度) tracks phase, but is re-derived ONLY when phase changes (or on create).
+        # An existing or manually-set confidence is otherwise preserved (kippo#36 / T09). The
+        # migration that introduced phase set the initial values; ordinary edits leave them alone.
+        if self._state.adding or self.phase != getattr(self, "_confidence_synced_phase", None):
+            self.confidence = PHASE_CONFIDENCE.get(self.phase, self.confidence)
+            update_fields = kwargs.get("update_fields")
+            if update_fields is not None and "confidence" not in update_fields:
+                kwargs["update_fields"] = [*update_fields, "confidence"]
 
         if self._state.adding:  # created
             # perform initial creation tasks
@@ -757,6 +770,8 @@ class KippoProject(UserCreatedBaseModel):
         self.slack_notification_channel_name = _normalize_slack_channel_name(self.slack_notification_channel_name)
 
         super().save(*args, **kwargs)
+        # Keep the snapshot current so a later phase edit on this same instance is detected.
+        self._confidence_synced_phase = self.phase
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.name})"

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -752,9 +752,12 @@ class KippoProject(UserCreatedBaseModel):
         # confidence (確度) tracks phase, but is re-derived ONLY when phase changes (or on create).
         # An existing or manually-set confidence is otherwise preserved (kippo#36 / T09). The
         # migration that introduced phase set the initial values; ordinary edits leave them alone.
-        if self._state.adding or self.phase != getattr(self, "_confidence_synced_phase", None):
+        # A partial save (update_fields) that does not write phase must NOT touch confidence either,
+        # or the DB would hold a new confidence against the old phase.
+        update_fields = kwargs.get("update_fields")
+        phase_persisted = update_fields is None or "phase" in update_fields
+        if self._state.adding or (phase_persisted and self.phase != getattr(self, "_confidence_synced_phase", None)):
             self.confidence = PHASE_CONFIDENCE.get(self.phase, self.confidence)
-            update_fields = kwargs.get("update_fields")
             if update_fields is not None and "confidence" not in update_fields:
                 kwargs["update_fields"] = [*update_fields, "confidence"]
 
@@ -770,8 +773,10 @@ class KippoProject(UserCreatedBaseModel):
         self.slack_notification_channel_name = _normalize_slack_channel_name(self.slack_notification_channel_name)
 
         super().save(*args, **kwargs)
-        # Keep the snapshot current so a later phase edit on this same instance is detected.
-        self._confidence_synced_phase = self.phase
+        # Refresh the snapshot only when phase was actually written, so a partial save that skipped
+        # phase doesn't poison the comparison for the next full save.
+        if phase_persisted:
+            self._confidence_synced_phase = self.phase
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.name})"

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1104,6 +1104,17 @@ class KippoProjectAdminActiveParityTestCase(KippoProjectAdminFixtureTestCaseBase
         list_request.user = self.superuser_no_org
         self.assertTrue(modeladmin.has_delete_permission(list_request))
 
+    def test_changelist_renders_for_non_superuser_org_member(self):
+        # The non-superuser get_queryset branch (org filter + .distinct()) combines with the Case()
+        # expression in get_ordering(). The fixture base logs in a superuser, which skips that
+        # branch entirely — so drive the staff path explicitly to cover the DISTINCT + Case render.
+        self.make_project("non-su-visible")
+        self.client.force_login(self.staffuser_with_org)
+        for model_path in ("projects_kippoproject", "projects_activekippoproject"):
+            with self.subTest(model=model_path):
+                response = self.client.get(reverse(f"admin:{model_path}_changelist"))
+                self.assertEqual(response.status_code, HTTPStatus.OK)
+
     def test_changelist_orders_non_project_category_first(self):
         # Regression guard: non-project-first ordering was previously dead (the order_by in
         # get_queryset was overridden by the `ordering` attribute). Names are chosen so the

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -703,13 +703,33 @@ class KippoProjectPhaseStatusTestCase(TestCase):
         self.assertEqual(self.project.confidence, PHASE_CONFIDENCE[DEFAULT_PROJECT_PHASE])
         self.assertFalse(KippoProject._meta.get_field("confidence").editable)
 
-    def test_confidence_is_derived_from_phase_on_save(self):
+    def test_confidence_is_rederived_when_phase_changes_on_save(self):
         for phase, expected in PHASE_CONFIDENCE.items():
-            self.project.phase = phase
-            self.project.confidence = 0  # any user-set value must be overwritten
+            self.project.phase = phase  # phase changes each iteration → confidence re-derived
+            self.project.confidence = 0  # a user-set value is overwritten only because phase changed
             self.project.save()
             self.project.refresh_from_db()
             self.assertEqual(self.project.confidence, expected, msg=f"{phase} -> {expected}")
+
+    def test_confidence_preserved_when_phase_unchanged(self):
+        # An existing / manually-set confidence survives an edit that does not touch phase.
+        KippoProject.objects.filter(pk=self.project.pk).update(confidence=55)
+        reloaded = KippoProject.objects.get(pk=self.project.pk)  # from_db snapshots the persisted phase
+        self.assertEqual(reloaded.confidence, 55)
+        reloaded.problem_definition = "edited, phase untouched"
+        reloaded.save()
+        reloaded.refresh_from_db()
+        self.assertEqual(reloaded.confidence, 55)
+        self.assertEqual(reloaded.phase, DEFAULT_PROJECT_PHASE)
+
+    def test_confidence_rederived_only_when_phase_actually_changes(self):
+        # Same instance, manual confidence, then a phase change → confidence re-derived from phase.
+        KippoProject.objects.filter(pk=self.project.pk).update(confidence=55)
+        reloaded = KippoProject.objects.get(pk=self.project.pk)
+        reloaded.phase = "under-contract"
+        reloaded.save()
+        reloaded.refresh_from_db()
+        self.assertEqual(reloaded.confidence, PHASE_CONFIDENCE["under-contract"])
 
     def test_only_contract_and_completed_reach_full_confidence(self):
         full = {phase for phase, conf in PHASE_CONFIDENCE.items() if conf == FULL_CONFIDENCE_PERCENTAGE}

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -731,6 +731,28 @@ class KippoProjectPhaseStatusTestCase(TestCase):
         reloaded.refresh_from_db()
         self.assertEqual(reloaded.confidence, PHASE_CONFIDENCE["under-contract"])
 
+    def test_partial_save_with_phase_persists_derived_confidence(self):
+        # update_fields=["phase"] → confidence is derived and added to update_fields so it persists.
+        self.project.phase = "under-contract"
+        self.project.save(update_fields=["phase"])
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.phase, "under-contract")
+        self.assertEqual(self.project.confidence, PHASE_CONFIDENCE["under-contract"])
+
+    def test_partial_save_without_phase_keeps_confidence_consistent(self):
+        # update_fields that omits phase must not write a recomputed confidence (which would leave
+        # the DB confidence misaligned with the still-persisted phase).
+        self.project.phase = "under-contract"
+        self.project.save()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.confidence, PHASE_CONFIDENCE["under-contract"])
+        self.project.phase = "lost"  # changed in memory only
+        self.project.problem_definition = "edited"
+        self.project.save(update_fields=["problem_definition"])
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.phase, "under-contract")  # phase was not written
+        self.assertEqual(self.project.confidence, PHASE_CONFIDENCE["under-contract"])  # nor confidence
+
     def test_only_contract_and_completed_reach_full_confidence(self):
         full = {phase for phase, conf in PHASE_CONFIDENCE.items() if conf == FULL_CONFIDENCE_PERCENTAGE}
         self.assertEqual(full, {"under-contract", "completed"})


### PR DESCRIPTION
## Summary

`KippoProject.save()` re-derived `confidence` from `phase` on **every** save, so any existing or manually-set confidence was overwritten on each edit. This makes confidence track `phase` only when `phase` actually changes (or on create); otherwise the stored value is preserved.

Follow-up to #314 (merged).

## Changes

- **`from_db()`** snapshots the persisted phase onto the instance.
- **`save()`** re-derives `confidence` only when `self._state.adding` or `phase != snapshot`, and refreshes the snapshot after `super().save()`.
- **Partial-save safety:** a `save(update_fields=[…])` that does **not** include `phase` no longer touches `confidence` — otherwise the DB could hold a recomputed confidence against the old, still-persisted phase. When `phase` *is* in `update_fields`, `confidence` is added so the derived value persists. The snapshot is refreshed only when phase was actually written.
- Minor: fixed a stale comment referencing a removed `is_anon_project` annotation; added a non-superuser org-member changelist render test (fixtures otherwise only exercise the superuser branch).

The phase-introduction migration (`0040`) already set the initial confidence values; this only stops ordinary edits from clobbering them. Downstream readers (the assignment-confirm gate at `confidence == 100`, the Slack report filter) are unaffected — confidence still becomes 100 the moment a project moves to `under-contract`/`completed`.

## Tests

- confidence re-derived when phase changes; preserved when an edit leaves phase untouched; re-derived again on a later phase change.
- partial save **with** phase persists the derived confidence; partial save **without** phase keeps phase/confidence consistent.
- non-superuser org-member changelist renders (DISTINCT + `Case` ordering path).

Full `projects.tests.test_models`, `test_admin`, `customers.tests.test_admin`, monthly-assignment and views suites pass (180 tests); ruff + pre-commit clean.