### PR TITLE
:sparkles: Allow setting project confidence directly via the API

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -173,6 +173,11 @@ class KippoProjectSerializer(serializers.ModelSerializer):
     customer_document_url = serializers.URLField(source="customer.document_url", read_only=True, allow_null=True)
     # Human-readable project status label for `phase` (kippo#37 / T10). `phase` stays the editable key.
     phase_display = serializers.CharField(source="get_phase_display", read_only=True)
+    # confidence (確度) defaults to the phase-derived value but is directly settable here for manual
+    # override (the model field is editable=False, so it is declared explicitly to make it writable).
+    # A set value is preserved by KippoProject.save() until phase changes; changing phase in the same
+    # update re-derives confidence from the new phase and ignores any confidence sent (kippo#36 / T09).
+    confidence = serializers.IntegerField(min_value=0, max_value=100, required=False)
     # category is a FK to KippoProjectOrganizationCategory; expose it as the category key string for
     # API backward-compatibility. Writes resolve against the global default categories (kippo#30 / T08, T20).
     category = serializers.SlugRelatedField(
@@ -267,7 +272,6 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "project_manager_username",
             "customer_document_url",  # linked customer's contract-folder URL (kippo#34 / T04)
             "phase_display",  # human-readable status label (kippo#37 / T10)
-            "confidence",  # derived from phase (kippo#36 / T09)
             "category_label",  # human-readable category label (kippo#39 / T14)
             "billing_types",  # distinct contract billing types (kippo#39 / T14)
             "monthly_billing_schedule",  # planned per-month schedule (kippo#39 / T15)

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -13,7 +13,7 @@ from freezegun import freeze_time
 from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
 
-from ..models import KippoProject, KippoProjectContract, KippoProjectOrganizationCategory, ProjectColumnSet, ProjectWeeklyEffort
+from ..models import PHASE_CONFIDENCE, KippoProject, KippoProjectContract, KippoProjectOrganizationCategory, ProjectColumnSet, ProjectWeeklyEffort
 
 
 def _registration_fields(organization: KippoOrganization, project_manager: KippoUser) -> dict:
@@ -192,6 +192,35 @@ class KippoProjectViewSetTestCase(TestCase):
         # no contracts/entries -> derived values stay 0, not the posted values
         self.assertEqual(data["total_revenue"], "0")
         self.assertEqual(data["contract_amount"], "0")
+
+    def test_confidence_is_writable_via_api(self):
+        """Confidence can be set directly for manual override; a phase-unchanged update persists it."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        original_phase = self.project.phase
+        response = self.client.patch(url, {"confidence": 55}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json()["confidence"], 55)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.confidence, 55)  # set value sticks (save() does not re-derive)
+        self.assertEqual(self.project.phase, original_phase)  # phase untouched
+
+    def test_confidence_out_of_range_rejected(self):
+        """Confidence is validated to 0-100."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(url, {"confidence": 150}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    def test_confidence_follows_phase_when_both_changed(self):
+        """When an update also changes phase, confidence is re-derived from the new phase and any
+        sent confidence is ignored (documented last-writer behavior).
+        """
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(url, {"phase": "under-contract", "confidence": 42}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json()["confidence"], PHASE_CONFIDENCE["under-contract"])  # 100, not 42
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.confidence, PHASE_CONFIDENCE["under-contract"])
+        self.assertEqual(self.project.phase, "under-contract")
 
     def test_list_exposes_category_label_and_billing_types(self):
         """List/detail expose category_label + distinct contract billing_types (kippo#39 / T14)."""


### PR DESCRIPTION
## Summary

`confidence` was read-only in `KippoProjectSerializer` (derived from phase, `#301`). Building on the `save()` change that preserves `confidence` except on a phase change (PR #315), this exposes `confidence` as a directly settable API field so a manual value can be set/corrected via `PATCH /api/projects/{id}/`.

Follow-up to #315 (merged).

## Changes

- Declare `confidence` explicitly on the serializer (the model field is `editable=False`, which would otherwise force read-only) with **0–100 validation**, and remove it from `read_only_fields`.
- A set value persists because `save()` only re-derives on a phase change; **changing phase in the same request re-derives `confidence` from the new phase and ignores the sent value** (documented in the field help_text).

## Tests

- `PATCH confidence` persists and leaves phase untouched.
- out-of-range (`150`) → 400.
- `PATCH {phase, confidence}` → confidence follows the new phase, sent value ignored (locks in the documented last-writer behavior).

Full `projects.tests.test_api_rest` / `test_models` / `test_projectmonthlyassignment` / `test_api_views` suites pass; ruff + pre-commit clean.

## ⚠️ Reviewer note — assignment-confirm gate

`ProjectMonthlyAssignmentSerializer.validate()` only allows confirming an assignment when `project.confidence == 100` (previously guaranteed by phase = under-contract/completed). With `confidence` now user-writable and no extra PM-only permission on the write, **any org-scoped editor can set `confidence=100` on a non-contract project and confirm assignments**, bypassing the gate's intent. This is an accepted consequence of making confidence manually settable. If that bypass is undesirable, a follow-up could either gate the write behind a stricter permission or change the confirm check to test `phase in (under-contract, completed)` instead of the raw confidence value.