### PR TITLE
feat(projects): streamline KippoProject admin create form

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -6,6 +6,7 @@ import re
 import urllib.parse
 from collections import Counter, defaultdict
 from collections.abc import Iterable
+from pathlib import Path
 from string import ascii_lowercase
 from typing import TYPE_CHECKING
 
@@ -42,7 +43,7 @@ from slack_sdk.errors import SlackApiError
 from tasks.models import KippoTaskStatus
 from tasks.periodic.tasks import collect_github_project_issues
 
-from .definitions import UPSELL_CATEGORY_VALUES, WEEKLY_EFFORT_CLOSED_MESSAGE, ProjectProgressStatus
+from .definitions import UPSELL_CATEGORY_VALUES, WEEKLY_EFFORT_CLOSED_MESSAGE, ProjectProgressStatus, ProjectRoles
 from .exceptions import GithubMilestoneAlreadyExistsError, SlackChannelNotFoundError
 from .functions import (
     generate_kippoprojectusermonthlystatisfaction_csv,
@@ -90,6 +91,34 @@ PROJECT_CLOSURE_FIELDS = ("close_comment", "survey_issued")
 
 logger = logging.getLogger(__name__)
 
+# Default per-role daily rates pre-filled into the ProjectAssignmentRate inline on /add/.
+# Edit the values in fixtures/default_projectassignmentrates.json — no code change needed.
+# Keep the roles in this file aligned with ProjectRoles (rows with an unknown role are skipped).
+DEFAULT_ASSIGNMENT_RATES_FIXTURE = Path(__file__).parent / "fixtures" / "default_projectassignmentrates.json"
+
+
+def _default_assignment_rate_initial() -> tuple[dict, ...]:
+    """Role/rate_per_day defaults used to prefill the ProjectAssignmentRate inline on project creation.
+
+    Read fresh each call (tiny file, only on /add/). Rows whose role is not a valid ProjectRoles
+    value are skipped (logged); a missing/blank rate falls back to settings.DEFAULT_PROJECT_DAILY_RATE
+    so the fixture and the model default cannot silently drift.
+    """
+    try:
+        rows = json.loads(DEFAULT_ASSIGNMENT_RATES_FIXTURE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        logger.exception("Failed to load default project assignment rates fixture: %s", DEFAULT_ASSIGNMENT_RATES_FIXTURE)
+        return ()
+    valid_roles = set(ProjectRoles.values())
+    initial = []
+    for row in rows:
+        role = row.get("role")
+        if role not in valid_roles:
+            logger.warning("Skipping default assignment rate with unknown role %r (valid roles: %s)", role, sorted(valid_roles))
+            continue
+        initial.append({"role": role, "rate_per_day": row.get("rate_per_day") or settings.DEFAULT_PROJECT_DAILY_RATE})
+    return tuple(initial)
+
 
 class LockWhenProjectClosedInlineMixin:
     """Inline mixin that disables add/change/delete when the parent KippoProject is closed."""
@@ -113,9 +142,29 @@ class LockWhenProjectClosedInlineMixin:
 class ProjectAssignmentRateInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, admin.TabularInline):
     model = ProjectAssignmentRate
     extra = 0
-    max_num = 10
+    # One rate per role (unique_together project+role) — cap rows at the number of defined roles so
+    # no extra entries can be added beyond them. Stays in sync if ProjectRoles changes.
+    max_num = len(ProjectRoles.choices())
     fields = ("role", "rate_per_day")
-    classes = ["collapse"]
+
+    def get_formset(self, request: DjangoRequest, obj: KippoProject | None = None, **kwargs):
+        """On /add/ (obj is None) prefill one row per default role/rate from the fixture so the
+        section is populated with sensible defaults the admin can edit before saving.
+        """
+        formset = super().get_formset(request, obj, **kwargs)
+        if obj is not None:
+            return formset
+        defaults = _default_assignment_rate_initial()
+        if not defaults:
+            return formset
+        formset.extra = len(defaults)
+
+        class DefaultRatesFormSet(formset):
+            def __init__(self, *args, **inner_kwargs) -> None:
+                inner_kwargs.setdefault("initial", list(defaults))
+                super().__init__(*args, **inner_kwargs)
+
+        return DefaultRatesFormSet
 
 
 class ProjectMonthlyAssignmentInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, admin.TabularInline):
@@ -129,7 +178,6 @@ class KippoProjectContractInline(LockWhenProjectClosedInlineMixin, AllowIsStaffA
     model = KippoProjectContract
     extra = 1
     fields = ("billing_type", "amount", "start_date", "end_date", "note")
-    classes = ["collapse"]
 
     def get_min_num(self, request: DjangoRequest, obj: KippoProject | None = None, **kwargs):
         # 請求方法 is required at project registration (kippo#40 / T19): require ≥1 contract on /add/.
@@ -806,6 +854,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     # Inlines hidden on /add/ (only meaningful once a project exists). Exposed as a class
     # attribute so tests and subclasses can reference the same source of truth.
     HIDDEN_ON_ADD_INLINES = (
+        GithubRepositoryProjectInline,
         ProjectWeeklyEffortReadOnlyInine,
         ProjectWeeklyEffortAdminInline,
         KippoProjectStatusReadOnlyInine,
@@ -833,9 +882,9 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     # 顧客 (customer) is selected via a searchable autocomplete (searches/displays KippoCustomer.name
     # through KippoCustomerAdmin.search_fields) instead of a long unsearchable <select>.
     autocomplete_fields = ("customer",)
-    # confidence is derived from phase (editable=False); the revenue figures are derived from
-    # the contract + billing ledger (kippo#32 / T13) — all shown read-only in the form
-    readonly_fields = ("confidence", "get_contract_amount_display", "get_total_revenue_display")
+    # revenue figures are derived from the contract + billing ledger (kippo#32 / T13) — shown read-only.
+    # confidence is derived from phase (editable=False) and intentionally hidden from the form.
+    readonly_fields = ("get_contract_amount_display", "get_total_revenue_display")
     # Changelist ordering lives in get_ordering() (a Case() expression), not the `ordering`
     # attribute — see the note there for why the attribute can't express it.
     actions = [
@@ -857,7 +906,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
                 "fields": (
                     "name",
                     "problem_definition",
-                    "confidence",
+                    "phase",
                     "project_manager",
                     "meeting_calendar_url_field",
                     "meeting_description_tag_field",
@@ -867,7 +916,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         (
             _("Dates & Estimates"),
             {
-                "classes": ("collapse",),
                 "fields": (
                     "start_date",
                     "target_date",
@@ -890,7 +938,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
                 "fields": (
                     "organization",
                     "customer",
-                    "phase",
                     "category",
                     "parent_project",
                     "slack_channel_name",
@@ -904,16 +951,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
                 ),
             },
         ),
-        (
-            _("Closure & Survey"),
-            {
-                "classes": ("collapse",),
-                "fields": (
-                    "survey_issued",
-                    "close_comment",
-                ),
-            },
-        ),
     ]
     inlines = [
         # Milestones not used atm, commenting out.
@@ -922,7 +959,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         ProjectAssignmentRateInline,
         ProjectMonthlyAssignmentInline,
         KippoProjectContractInline,
-        KippoProjectBillingEntryInline,
         GithubRepositoryProjectInline,
         ProjectWeeklyEffortReadOnlyInine,
         KippoProjectStatusReadOnlyInine,
@@ -1240,6 +1276,12 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
 
         # customer: scope queryset to the project's organization (on change) or the user's orgs (on add).
         self._scope_customer_queryset(form, obj, user_memberships)
+
+        # Arriving from the customer admin's "プロジェクトを追加" button (?customer=<pk>): the customer is
+        # already chosen, so hide the field. The value is still prefilled (get_changeform_initial_data)
+        # and POSTed; the scoped queryset validates it server-side.
+        if obj is None and request.GET.get("customer") and "customer" in form.base_fields:
+            form.base_fields["customer"].widget = forms.HiddenInput()
 
         if obj is None and request.GET.get("_upsell_source") == "close":
             self._apply_upsell_source_widgets(form, user_memberships)

--- a/kippo/projects/fixtures/default_projectassignmentrates.json
+++ b/kippo/projects/fixtures/default_projectassignmentrates.json
@@ -1,0 +1,5 @@
+[
+  {"role": "developer", "rate_per_day": 180000},
+  {"role": "project_manager", "rate_per_day": 180000},
+  {"role": "tester", "rate_per_day": 180000}
+]

--- a/kippo/projects/templates/admin/projects/kippoproject/change_form.html
+++ b/kippo/projects/templates/admin/projects/kippoproject/change_form.html
@@ -66,4 +66,41 @@
     });
 })();
 </script>
+<script>
+'use strict';
+// Auto-populate the first contract row's period from the project's start_date / target_date
+// as they are entered on the add form. Only fills a contract date that is empty or was itself
+// auto-filled — a date the user typed (or a pre-existing contract date on the change form) is
+// never clobbered. The model also backfills blank contract dates on save as a safety net.
+(function () {
+    function mirror(sourceId, targetId) {
+        var source = document.getElementById(sourceId);
+        var target = document.getElementById(targetId);
+        if (!source || !target) {
+            return;
+        }
+        target.addEventListener('input', function () {
+            target.dataset.userEdited = 'true';
+        });
+        function apply() {
+            if (target.dataset.userEdited === 'true') {
+                return;
+            }
+            // don't overwrite a value that wasn't placed here by this auto-fill
+            if (target.value && target.dataset.autofilled !== 'true') {
+                return;
+            }
+            target.value = source.value;
+            target.dataset.autofilled = 'true';
+        }
+        source.addEventListener('change', apply);
+        source.addEventListener('input', apply);
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        mirror('id_start_date', 'id_contracts-0-start_date');
+        mirror('id_target_date', 'id_contracts-0-end_date');
+    });
+})();
+</script>
 {% endblock %}

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1297,18 +1297,158 @@ class KippoProjectAdminInlinesTestCase(KippoProjectAdminFixtureTestCaseBase):
         for cls in KippoProjectAdmin.HIDDEN_ON_ADD_INLINES:
             self.assertIn(cls, inlines, f"{cls.__name__} should be present on ActiveKippoProject change")
 
-    def test_add_view_keeps_assignment_rate_and_repository_inlines(self):
+    def test_add_view_keeps_assignment_rate_inline_and_hides_repository(self):
         from projects.admin import GithubRepositoryProjectInline
 
         modeladmin = KippoProjectAdmin(KippoProject, self.site)
         inlines = modeladmin.get_inlines(self.staff_user_request, obj=None)
         self.assertIn(ProjectAssignmentRateInline, inlines)
-        self.assertIn(GithubRepositoryProjectInline, inlines)
+        # GitHub repositories are only meaningful once the project exists (hidden on /add/).
+        self.assertNotIn(GithubRepositoryProjectInline, inlines)
+
+
+class DefaultAssignmentRateLoaderTestCase(SimpleTestCase):
+    """_default_assignment_rate_initial: skip unknown roles, fall back to the setting for a missing rate."""
+
+    def test_skips_unknown_roles_and_defaults_missing_rate(self):
+        import json
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from django.conf import settings
+
+        from projects import admin as projects_admin
+
+        rows = [
+            {"role": "developer", "rate_per_day": 123456},
+            {"role": "bogus-role", "rate_per_day": 999},  # unknown role -> skipped
+            {"role": "tester"},  # missing rate -> falls back to settings.DEFAULT_PROJECT_DAILY_RATE
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture_path = Path(tmp) / "rates.json"
+            fixture_path.write_text(json.dumps(rows), encoding="utf-8")
+            with patch.object(projects_admin, "DEFAULT_ASSIGNMENT_RATES_FIXTURE", fixture_path):
+                result = projects_admin._default_assignment_rate_initial()
+        self.assertEqual(
+            result,
+            (
+                {"role": "developer", "rate_per_day": 123456},
+                {"role": "tester", "rate_per_day": settings.DEFAULT_PROJECT_DAILY_RATE},
+            ),
+        )
+
+    def test_missing_fixture_returns_empty(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from projects import admin as projects_admin
+
+        with (
+            patch.object(projects_admin, "DEFAULT_ASSIGNMENT_RATES_FIXTURE", Path("/nonexistent/does-not-exist.json")),
+            self.assertLogs("projects.admin", level="ERROR"),
+        ):
+            self.assertEqual(projects_admin._default_assignment_rate_initial(), ())
 
 
 class ProjectAssignmentRateInlineConfigTestCase(TestCase):
-    def test_max_num_is_10(self):
-        self.assertEqual(ProjectAssignmentRateInline.max_num, 10)
+    def test_max_num_equals_role_count(self):
+        from projects.definitions import ProjectRoles
+
+        # one rate per role — no entries can be added beyond the number of defined roles
+        self.assertEqual(ProjectAssignmentRateInline.max_num, len(ProjectRoles.choices()))
+
+    def test_inline_expanded(self):
+        # the assignment-rates section is shown expanded (not collapsed) so prefilled defaults are visible
+        self.assertNotIn("collapse", getattr(ProjectAssignmentRateInline, "classes", ()) or ())
+
+
+class KippoProjectAddFormLayoutTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """Project add-form layout changes: phase top section, confidence/closure hidden, sections expanded."""
+
+    def setUp(self):
+        super().setUp()
+        self.existing_project = self.make_project("layout-existing-project")
+
+    @staticmethod
+    def _all_fieldset_fields(fieldsets: list) -> list:
+        return [field for _label, opts in fieldsets for field in opts.get("fields", ())]
+
+    def test_phase_in_top_section_on_add(self):
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        fieldsets = modeladmin.get_fieldsets(self.super_user_request, obj=None)
+        top_fields = fieldsets[0][1]["fields"]
+        self.assertIn("phase", top_fields)
+
+    def test_confidence_not_in_form(self):
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        fieldsets = modeladmin.get_fieldsets(self.super_user_request, obj=None)
+        self.assertNotIn("confidence", self._all_fieldset_fields(fieldsets))
+        self.assertNotIn("confidence", modeladmin.readonly_fields)
+
+    def test_closure_and_survey_section_not_displayed(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        for obj in (None, self.existing_project):
+            fields = self._all_fieldset_fields(modeladmin.get_fieldsets(self.super_user_request, obj=obj))
+            self.assertNotIn("close_comment", fields)
+            self.assertNotIn("survey_issued", fields)
+
+    def test_dates_and_estimates_section_expanded(self):
+        for _label, opts in KippoProjectBaseAdmin.fieldsets:
+            if "start_date" in opts.get("fields", ()):
+                self.assertNotIn("collapse", opts.get("classes", ()))
+                break
+        else:
+            self.fail("No 'Dates & Estimates' fieldset found")
+
+    def test_contract_inline_expanded_single_entry(self):
+        self.assertNotIn("collapse", getattr(KippoProjectContractInline, "classes", ()) or ())
+        self.assertEqual(KippoProjectContractInline.extra, 1)
+
+    def test_billing_entry_inline_removed(self):
+        from projects.admin import KippoProjectBillingEntryInline
+
+        self.assertNotIn(KippoProjectBillingEntryInline, KippoProjectBaseAdmin.inlines)
+
+
+class KippoProjectAddFormBehaviorTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """Add-form runtime behavior: default assignment rates prefilled, customer hidden when prefilled."""
+
+    def setUp(self):
+        super().setUp()
+        self.customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="layout-customer",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+    def test_assignment_rate_inline_prefills_defaults_on_add(self):
+        inline = ProjectAssignmentRateInline(parent_model=KippoProject, admin_site=self.site)
+        formset_class = inline.get_formset(request=self.super_user_request, obj=None)
+        self.assertEqual(formset_class.extra, 3)
+        formset = formset_class(instance=KippoProject())
+        roles = [form.initial.get("role") for form in formset.forms if form.initial]
+        self.assertEqual(roles, ["developer", "project_manager", "tester"])
+
+    def test_assignment_rate_inline_no_prefill_on_change(self):
+        inline = ProjectAssignmentRateInline(parent_model=KippoProject, admin_site=self.site)
+        formset_class = inline.get_formset(request=self.super_user_request, obj=self.make_project("rate-change-project"))
+        self.assertEqual(formset_class.extra, 0)
+
+    def test_customer_field_hidden_when_prefilled_from_customer_admin(self):
+        url = reverse("admin:projects_activekippoproject_add")
+        response = self.client.get(url, {"customer": str(self.customer.id), "organization": str(self.organization.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        form = response.context["adminform"].form
+        self.assertIsInstance(form.fields["customer"].widget, forms.HiddenInput)
+
+    def test_customer_field_visible_on_plain_add(self):
+        url = reverse("admin:projects_activekippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        form = response.context["adminform"].form
+        self.assertNotIsInstance(form.fields["customer"].widget, forms.HiddenInput)
 
 
 class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixtureTestCaseBase):


### PR DESCRIPTION
## Summary

Streamlines the **KippoProject / ActiveKippoProject** Django admin create flow:

- **Hide `confidence`** from the form (derived from `phase`; changelist column kept).
- **Move `phase`** into the top fieldset.
- **Expand "Dates & Estimates"** (no longer collapsed).
- **Hide `customer` on /add/** when arriving from the customer admin's プロジェクトを追加 button (`?customer=` present). The value is still prefilled, POSTed, and validated against the org-scoped queryset — hiding the widget does not bypass scoping.
- **Remove the "Closure & Survey" fieldset.**
- **Expand the contract inline** and **auto-populate the first contract row's start/end dates** from the project's start/target dates via JS on the add form. `KippoProjectContract.save()` still backfills blank contract dates as a safety net.
- **Remove the billing-entry (請求エントリ) inline.**
- **Hide the GitHub repositories inline on /add/** (shown only on existing projects).
- **Default assignment rates fixture** (`fixtures/default_projectassignmentrates.json`) prefilling one editable row per role on /add/. Unknown roles are skipped (logged) and a missing rate falls back to `settings.DEFAULT_PROJECT_DAILY_RATE` so the fixture and model default can't drift.
- **Cap the assignment-rate inline at one entry per role** (`max_num = len(ProjectRoles)`), so no rows can be added beyond the defined roles.

## Testing

- `manage.py test projects.tests.test_admin` — **107 passed**.
- `ruff check` clean (pre-commit ruff + ruff-format passed).

New/updated tests cover: form layout (phase top / confidence absent / closure absent / sections expanded), contract inline expanded + single entry, billing-entry inline removed, GitHub-repo inline hidden on add, default-rate prefill on add / none on change, the loader's unknown-role skip + rate fallback + missing-fixture path, customer hidden-when-prefilled vs visible-on-plain-add, and `max_num` == role count.

## Notes

- The contract-date JS is not covered by automated tests (no browser in CI); the model-side backfill is the real safety net.