### PR TITLE
:sparkles: projects: add exclude_category filter to project list API

### DIFF
--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -417,6 +417,37 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertIn(str(self.project.id), all_ids)
         self.assertIn(str(other_category_project.id), all_ids)
 
+    def test_exclude_by_category(self):
+        """Test excluding projects by the exclude_category query parameter (exact match on the category key)."""
+        si_category = KippoProjectOrganizationCategory.objects.get(organization__isnull=True, key="si")
+        non_project_category = KippoProjectOrganizationCategory.objects.get(organization__isnull=True, key="non-project")
+        self.project.category = si_category
+        self.project.save()
+
+        non_project = KippoProject.objects.create(
+            name="Non Project",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            category=non_project_category,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        # Exclude non-project — only the si project should be returned.
+        url = f"{settings.URL_PREFIX}/api/projects/?exclude_category=non-project"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        result_ids = [result["id"] for result in response.json()["results"]]
+        self.assertIn(str(self.project.id), result_ids)
+        self.assertNotIn(str(non_project.id), result_ids)
+
+        # Without the filter, both projects are returned.
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        response = self.client.get(url)
+        all_ids = [result["id"] for result in response.json()["results"]]
+        self.assertIn(str(self.project.id), all_ids)
+        self.assertIn(str(non_project.id), all_ids)
+
     def test_user_cannot_access_other_organization_projects(self):
         """Test that users can only access projects from their organizations."""
         url = f"{settings.URL_PREFIX}/api/projects/{self.other_project.id}/"

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -53,6 +53,8 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
 
     **Filtering:**
     - is_active: Filter by display_as_active field (true/false)
+    - category: Include only the given category key (exact match)
+    - exclude_category: Exclude the given category key (exact match), e.g. drop non-project rows
 
     **Permissions:**
     - Read (GET): Authenticated users (organization-scoped for regular users)
@@ -92,6 +94,12 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
                 required=False,
                 type=str,
             ),
+            OpenApiParameter(
+                name="exclude_category",
+                description="Exclude projects whose category key matches this value (e.g. 'non-project').",
+                required=False,
+                type=str,
+            ),
         ]
     )
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
@@ -126,6 +134,11 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
         category = self.request.query_params.get("category", None)
         if category is not None:
             queryset = queryset.filter(category__key=category)
+
+        # Exclude by category (exact match) — lets clients drop e.g. non-project rows server-side.
+        exclude_category = self.request.query_params.get("exclude_category", None)
+        if exclude_category is not None:
+            queryset = queryset.exclude(category__key=exclude_category)
 
         return queryset
 


### PR DESCRIPTION
## Summary

The project list endpoint (`/api/projects/`) only supported **including** a single category (`?category=<key>`). The kippo-ui project-status view needs to drop `non-project` rows server-side rather than filtering them in the browser.

This adds `?exclude_category=<key>` — an exact match on the `KippoProject.category` key — so clients can request e.g. `?exclude_category=non-project`.

## Changes

- `KippoProjectViewSet.get_queryset`: `exclude(category__key=<value>)` when `exclude_category` is provided.
- Documented the new parameter in the `list` OpenAPI schema (so the generated kippo-ui client picks it up via `pnpm update:api`).
- Updated the viewset docstring filtering notes.

## Test

- `test_exclude_by_category` (mirrors `test_filter_by_category`): asserts `?exclude_category=non-project` drops the non-project row while keeping others, and that the unfiltered list still returns both.

## Follow-up (kippo-ui)

Once released, kippo-ui runs `pnpm update:api` to regenerate the typed client, then swaps `project-status.tsx` from its client-side `EXCLUDED_CATEGORIES` filter to `projectsList({ is_active: true, exclude_category: 'non-project' })`.