### PR TITLE
:lipstick: admin: customer & project admin display improvements

### DIFF
--- a/kippo/commons/admin.py
+++ b/kippo/commons/admin.py
@@ -131,6 +131,19 @@ class KippoAdminSite(admin.AdminSite):
     site_title = settings.SITE_TITLE
     site_url = f"{settings.URL_PREFIX}/ui/weekly-effort"
 
+    # apps pinned to the top of the admin index, in this order; remaining apps keep Django's default order
+    APP_PRIORITY = ("customers", "projects")
+
+    def _app_sort_key(self, app: dict) -> int:
+        app_label = app["app_label"]
+        if app_label in self.APP_PRIORITY:
+            return self.APP_PRIORITY.index(app_label)
+        return len(self.APP_PRIORITY)
+
+    def get_app_list(self, request: DjangoRequest, app_label: str | None = None) -> list:
+        # stable sort keeps Django's default order for apps not in APP_PRIORITY
+        return sorted(super().get_app_list(request, app_label), key=self._app_sort_key)
+
 
 admin_site = KippoAdminSite(name="kippoadmin")
 

--- a/kippo/commons/tests/test_admin.py
+++ b/kippo/commons/tests/test_admin.py
@@ -1,10 +1,32 @@
 from django.conf import settings
-from django.test import TestCase
+from django.contrib import admin
+from django.test import RequestFactory, TestCase
 
 from commons.admin import KippoAdminSite
+
+from . import IsStaffModelAdminTestCaseBase
 
 
 class KippoAdminSiteTestCase(TestCase):
     def test_site_url_points_to_weekly_effort(self):
         expected = f"{settings.URL_PREFIX}/ui/weekly-effort"
         self.assertEqual(KippoAdminSite.site_url, expected)
+
+
+class KippoAdminSiteAppOrderTestCase(IsStaffModelAdminTestCaseBase):
+    def setUp(self):
+        super().setUp()
+        self.request = RequestFactory().get("/admin/")
+        self.request.user = self.superuser_no_org
+
+    def test_get_app_list_pins_customers_then_projects(self):
+        app_list = admin.site.get_app_list(self.request)
+        app_labels = [app["app_label"] for app in app_list]
+        self.assertEqual(app_labels[:2], ["customers", "projects"])
+
+    def test_get_app_list_preserves_default_order_for_remaining_apps(self):
+        # the relative order of non-pinned apps must match Django's default ordering
+        default_list = super(KippoAdminSite, admin.site).get_app_list(self.request)
+        default_remaining = [app["app_label"] for app in default_list if app["app_label"] not in KippoAdminSite.APP_PRIORITY]
+        actual_remaining = [app["app_label"] for app in admin.site.get_app_list(self.request) if app["app_label"] not in KippoAdminSite.APP_PRIORITY]
+        self.assertEqual(actual_remaining, default_remaining)

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -5,7 +5,8 @@ from django import forms
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.db import models
-from django.db.models import Count, Q
+from django.db.models import Count, IntegerField, OuterRef, Subquery
+from django.db.models.functions import Coalesce
 from django.forms import Form
 from django.http import request as DjangoRequest  # noqa: N812
 from django.urls import reverse
@@ -16,6 +17,23 @@ from projects.functions import get_user_session_organization
 from projects.models import KippoProject
 
 from customers.models import KippoCustomer
+
+# A customer's active (open + display_as_active) project count. A correlated Subquery (a scalar
+# expression), NOT an aggregate: Django 5.2 forbids ordering by an aggregate that isn't also in
+# annotate(), and get_ordering() is applied to bare manager querysets (no annotation) when Django
+# builds FK form fields via get_field_queryset(). A scalar Subquery orders correctly anywhere.
+# Coalesce(..., 0) so customers with no active projects sort/display as 0 rather than NULL.
+ACTIVE_PROJECT_COUNT = Coalesce(
+    Subquery(
+        KippoProject.objects.filter(customer=OuterRef("pk"), is_closed=False, display_as_active=True)
+        .order_by()
+        .values("customer")
+        .annotate(count=Count("pk"))
+        .values("count"),
+        output_field=IntegerField(),
+    ),
+    0,
+)
 
 
 class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
@@ -49,35 +67,43 @@ class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
 
 @admin.register(KippoCustomer)
 class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
-    list_display = ("name", "organization", "email", "get_active_project_count", "get_compliance_verified", "display_as_active", "updated_datetime")
+    list_display = ("name", "get_active_project_count", "get_compliance_verified", "display_as_active", "updated_datetime")
     list_display_links = ("name",)
     list_filter = ("organization", "display_as_active")
     search_fields = ("name", "email")
-    ordering = ("organization", "-display_as_active", "name")
     fields = ("organization", "name", "email", "phone", "website", "document_url", "notes", "display_as_active")
     inlines = (KippoProjectReadOnlyInline,)
 
+    def get_ordering(self, request: DjangoRequest) -> tuple:
+        # Most active customers first. Returns the self-contained Subquery expression (not the
+        # active_project_count annotation NAME) so order_by() resolves on ANY queryset — including
+        # the bare manager queryset Django builds for FK form fields via get_field_queryset(), which
+        # applies this admin's get_ordering(). Ordering by the annotation name would raise FieldError
+        # there, and the `ordering` attribute would be rejected by admin check E033.
+        return (ACTIVE_PROJECT_COUNT.desc(), "name")
+
+    def get_list_display(self, request: DjangoRequest) -> tuple:
+        # Show the organization column only for superusers who belong to more than one organization;
+        # non-superusers (org-scoped queryset) and single-org users have nothing to disambiguate.
+        if request.user.is_superuser and request.user.organizations.count() > 1:
+            return ("name", "organization", *self.list_display[1:])
+        return self.list_display
+
     def get_queryset(self, request: DjangoRequest):
-        # Annotate the count of each customer's active (open + display_as_active) projects so
-        # the list column is one query and sortable. distinct=True guards against row fan-out
-        # from the (non-superuser) organization join below.
+        # Annotate each customer's active (open + display_as_active) project count so the
+        # get_active_project_count column can render and sort on the annotation name. The count is a
+        # scalar Subquery (see ACTIVE_PROJECT_COUNT), so there is no join fan-out to dedup.
         qs = (
             super()
             .get_queryset(request)
             # select_related the OneToOne compliance_check so the 反社チェック column does not
             # issue one extra query per row in the changelist.
             .select_related("compliance_check")
-            .annotate(
-                active_project_count=Count(
-                    "projects",
-                    filter=Q(projects__is_closed=False, projects__display_as_active=True),
-                    distinct=True,
-                )
-            )
+            .annotate(active_project_count=ACTIVE_PROJECT_COUNT)
         )
         if request.user.is_superuser:
             return qs
-        return qs.filter(organization__in=request.user.organizations).order_by("organization").distinct()
+        return qs.filter(organization__in=request.user.organizations).distinct()
 
     @admin.display(description=_("アクティブプロジェクト数"), ordering="active_project_count")
     def get_active_project_count(self, obj: KippoCustomer) -> int:

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -243,3 +243,86 @@ class KippoCustomerAdminOrganizationFieldTestCase(IsStaffModelAdminTestCaseBase)
         # Multi-org → field stays visible, still initialized to the session org.
         self.assertNotIsInstance(form_class.base_fields["organization"].widget, forms.HiddenInput)
         self.assertEqual(form_class.base_fields["organization"].initial, self.organization)
+
+
+class KippoCustomerAdminListDisplayTestCase(IsStaffModelAdminTestCaseBase):
+    """The changelist drops the email column, orders by active project count, and shows the
+    organization column only for multi-org superusers.
+    """
+
+    fixtures = DEFAULT_FIXTURES
+
+    @staticmethod
+    def _request(user: KippoUser) -> MagicMock:
+        request = MagicMock()
+        request.user = user
+        return request
+
+    def test_email_not_in_list_display(self):
+        self.assertNotIn("email", KippoCustomerAdmin.list_display)
+
+    def test_ordering_by_active_project_count_descending(self):
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        ordering = modeladmin.get_ordering(self._request(self.superuser_no_org))
+        # most active first (descending), then name
+        self.assertTrue(ordering[0].descending)
+        self.assertEqual(ordering[1], "name")
+
+    def test_changelist_orders_customers_by_active_project_count(self):
+        # end-to-end: the rendered changelist must order rows by active project count, descending.
+        from datetime import date
+
+        from commons.tests import DEFAULT_COLUMNSET_PK
+        from projects.models import ProjectColumnSet
+
+        columnset = ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK)
+
+        def _customer(name: str) -> KippoCustomer:
+            return KippoCustomer.objects.create(
+                organization=self.organization, name=name, created_by=self.github_manager, updated_by=self.github_manager
+            )
+
+        busy = _customer("Busy")
+        idle = _customer("Idle")
+        for i in range(2):
+            KippoProject.objects.create(
+                organization=self.organization,
+                name=f"busy-project-{i}",
+                columnset=columnset,
+                start_date=date(2026, 6, 1),
+                customer=busy,
+                created_by=self.github_manager,
+                updated_by=self.github_manager,
+            )
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        request = self._request(self.superuser_no_org)
+        ordered = list(modeladmin.get_queryset(request).order_by(*modeladmin.get_ordering(request)))
+        self.assertLess(ordered.index(busy), ordered.index(idle))
+
+    def test_organization_hidden_for_non_superuser(self):
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        self.assertNotIn("organization", modeladmin.get_list_display(self._request(self.staffuser_with_org)))
+
+    def test_organization_hidden_for_single_org_superuser(self):
+        OrganizationMembership.objects.create(
+            user=self.superuser_no_org,
+            organization=self.organization,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        self.assertNotIn("organization", modeladmin.get_list_display(self._request(self.superuser_no_org)))
+
+    def test_organization_shown_for_multi_org_superuser(self):
+        for organization in (self.organization, self.other_organization):
+            OrganizationMembership.objects.create(
+                user=self.superuser_no_org,
+                organization=organization,
+                created_by=self.github_manager,
+                updated_by=self.github_manager,
+            )
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        list_display = modeladmin.get_list_display(self._request(self.superuser_no_org))
+        self.assertIn("organization", list_display)
+        # organization sits immediately after name
+        self.assertEqual(list_display[:2], ("name", "organization"))

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -995,6 +995,10 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
                     excluded.append(fieldname)
         if not request.user.is_superuser and "github_project_api_nodeid" not in excluded:
             excluded.append("github_project_api_nodeid")
+        # columnset is never an admin choice — it is auto-assigned to the organization's default
+        # in save_model (see below). Hidden from the form for every user.
+        if "columnset" not in excluded:
+            excluded.append("columnset")
         return tuple(excluded)
 
     def get_fieldsets(self, request: DjangoRequest, obj: KippoProject | None = None):
@@ -1003,9 +1007,16 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # estimated_completion_date is a computed readonly field, only surfaced for open projects on edit
         if obj is None or obj.is_closed:
             excluded.add("estimated_completion_date")
-        if not excluded:
-            return fieldsets
-        return [(label, {**opts, "fields": tuple(f for f in opts.get("fields", ()) if f not in excluded)}) for label, opts in fieldsets]
+        # Build a fresh fieldset list (never mutate the class attribute): strip excluded fields and,
+        # on /add/, expand the collapsed sections (Billing & Details) so their fields are visible
+        # without an extra click.
+        rebuilt = []
+        for label, opts in fieldsets:
+            new_opts = {**opts, "fields": tuple(f for f in opts.get("fields", ()) if f not in excluded)}
+            if obj is None and "collapse" in new_opts.get("classes", ()):
+                new_opts["classes"] = tuple(c for c in new_opts["classes"] if c != "collapse")
+            rebuilt.append((label, new_opts))
+        return rebuilt
 
     def get_updated_by_display(self, obj: KippoProject) -> str:
         result = ""
@@ -1258,8 +1269,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         if obj is None and user_initial_organization and len(user_organizations) == 1:
             form.base_fields["organization"].widget = forms.HiddenInput()
 
-        self._apply_columnset_field(form, request, user_initial_organization, obj)
-
         # remove add/change/delete buttons from all ForeignKey fields
         for fieldname in form.base_fields:
             form.base_fields[fieldname].widget.can_add_related = False
@@ -1296,38 +1305,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             form.base_fields["customer"].queryset = KippoCustomer.objects.filter(organization=obj.organization)
         else:
             form.base_fields["customer"].queryset = KippoCustomer.objects.filter(organization__in=user_memberships)
-
-    @staticmethod
-    def _apply_columnset_field(
-        form: Form,
-        request: DjangoRequest,
-        user_initial_organization: KippoOrganization | None,
-        obj: KippoProject | None,
-    ) -> None:
-        """Set up the columnset field on the project form.
-
-        Scope choices to the org's columnsets (+ shared/global) and default to the organization's
-        resolved default on /add/. Hidden from non-superusers — columnset selection is an admin
-        concern, not a per-project staff decision.
-        """
-        if "columnset" not in form.base_fields:
-            return
-        if user_initial_organization is not None:
-            form.base_fields["columnset"].queryset = ProjectColumnSet.objects.filter(
-                models.Q(organization=user_initial_organization) | models.Q(organization__isnull=True)
-            )
-            if obj is None:
-                default_columnset = user_initial_organization.get_default_columnset()
-                if default_columnset:
-                    form.base_fields["columnset"].initial = default_columnset
-        elif obj is None:
-            # No session org (e.g. a superuser without a membership): keep the legacy
-            # global-first prefill so the required field isn't left blank.
-            first_columnset = ProjectColumnSet.objects.first()
-            if first_columnset:
-                form.base_fields["columnset"].initial = first_columnset
-        if not request.user.is_superuser:
-            form.base_fields["columnset"].widget = forms.HiddenInput()
 
     @staticmethod
     def _apply_upsell_source_widgets(form: Form, user_memberships: models.QuerySet) -> None:
@@ -1475,6 +1452,13 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             obj.updated_by = request.user
         else:
             obj.updated_by = request.user
+
+        # columnset is hidden from the form (see get_exclude) — auto-assign the organization's
+        # default on create; existing projects keep their stored columnset.
+        if obj.columnset_id is None and obj.organization_id:
+            default_columnset = obj.organization.get_default_columnset()
+            if default_columnset is not None:
+                obj.columnset = default_columnset
 
         super().save_model(request, obj, form, change)
 

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1401,6 +1401,27 @@ class KippoProjectAddFormLayoutTestCase(KippoProjectAdminFixtureTestCaseBase):
         else:
             self.fail("No 'Dates & Estimates' fieldset found")
 
+    def test_billing_and_details_sections_expanded_on_add(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        fieldsets = modeladmin.get_fieldsets(self.super_user_request, obj=None)
+        # Billing (billing_date) and Details (category) start expanded on /add/.
+        for _label, opts in fieldsets:
+            fields = opts.get("fields", ())
+            if "billing_date" in fields or "category" in fields:
+                self.assertNotIn("collapse", opts.get("classes", ()))
+
+    def test_billing_and_details_sections_collapsed_on_change(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        fieldsets = modeladmin.get_fieldsets(self.super_user_request, obj=self.existing_project)
+        collapsed = [opts for _label, opts in fieldsets if "collapse" in opts.get("classes", ())]
+        self.assertTrue(any("billing_date" in opts.get("fields", ()) for opts in collapsed), "Billing should stay collapsed on change")
+        self.assertTrue(any("category" in opts.get("fields", ()) for opts in collapsed), "Details should stay collapsed on change")
+
+    def test_columnset_not_in_add_or_change_fieldsets(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        for obj in (None, self.existing_project):
+            self.assertNotIn("columnset", self._all_fieldset_fields(modeladmin.get_fieldsets(self.super_user_request, obj=obj)))
+
     def test_contract_inline_expanded_single_entry(self):
         self.assertNotIn("collapse", getattr(KippoProjectContractInline, "classes", ()) or ())
         self.assertEqual(KippoProjectContractInline.extra, 1)
@@ -1590,47 +1611,44 @@ class KippoProjectAdminSingleOrgHidesOrganizationFieldTestCase(KippoProjectAdmin
 
 
 class KippoProjectAdminColumnsetFieldTestCase(KippoProjectAdminFixtureTestCaseBase):
-    """columnset is required, defaults to first available on /add/, and hidden for non-superusers."""
+    """columnset is never selectable in the admin: it is hidden from every form (add & change,
+    superuser & non-superuser) and auto-assigned to the organization's default on create.
+    """
 
-    @staticmethod
-    def _columnset_widget(adminform: AdminForm) -> forms.Widget:
-        widget = adminform.form.fields["columnset"].widget
-        return getattr(widget, "widget", widget)
-
-    def test_add_view_initial_columnset_is_first_available(self):
-        # superuser
+    def test_add_view_omits_columnset_field_for_superuser(self):
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        adminform = response.context["adminform"]
-        self.assertEqual(adminform.form.fields["columnset"].initial, ProjectColumnSet.objects.first())
+        self.assertNotIn("columnset", response.context["adminform"].form.fields)
 
-    def test_add_view_hides_columnset_field_for_non_superuser(self):
-        # log in as staff (single-org); columnset should be HiddenInput
+    def test_add_view_omits_columnset_field_for_non_superuser(self):
         self.client.force_login(self.staffuser_with_org)
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        adminform = response.context["adminform"]
-        self.assertIsInstance(self._columnset_widget(adminform), forms.HiddenInput)
-        # initial still preselects the first columnset so the form submits successfully
-        self.assertEqual(adminform.form.fields["columnset"].initial, ProjectColumnSet.objects.first())
+        self.assertNotIn("columnset", response.context["adminform"].form.fields)
 
-    def test_add_view_keeps_columnset_visible_for_superuser(self):
-        url = reverse("admin:projects_kippoproject_add")
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, HTTPStatus.OK)
-        adminform = response.context["adminform"]
-        self.assertNotIsInstance(self._columnset_widget(adminform), forms.HiddenInput)
-
-    def test_change_view_hides_columnset_field_for_non_superuser(self):
+    def test_change_view_omits_columnset_field(self):
         existing = self.make_project("columnset-change-target")
-        self.client.force_login(self.staffuser_with_org)
         url = reverse("admin:projects_kippoproject_change", args=[existing.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        adminform = response.context["adminform"]
-        self.assertIsInstance(self._columnset_widget(adminform), forms.HiddenInput)
+        self.assertNotIn("columnset", response.context["adminform"].form.fields)
+
+    def test_save_model_auto_assigns_organization_default_columnset_on_create(self):
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        obj = KippoProject(organization=self.organization, name="auto-columnset-project", start_date=self.current_date)
+        self.assertIsNone(obj.columnset_id)
+        modeladmin.save_model(self.super_user_request, obj, form=None, change=False)
+        obj.refresh_from_db()
+        self.assertEqual(obj.columnset, self.organization.get_default_columnset())
+
+    def test_save_model_preserves_existing_columnset_on_change(self):
+        existing = self.make_project("columnset-preserve-target")
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        modeladmin.save_model(self.super_user_request, existing, form=None, change=True)
+        existing.refresh_from_db()
+        self.assertEqual(existing.columnset, self.columnset)
 
 
 class GithubRepositoryInlineSaveTestCase(KippoProjectAdminFixtureTestCaseBase):


### PR DESCRIPTION
## Summary

Admin UX improvements across the app index, customer admin, and project admin.

### App index ordering (`commons`)
- `KippoAdminSite.get_app_list` pins **Customers (顧客)** first, then **Projects**, with the remaining apps in Django's default order (stable sort).

### Customer admin (`customers`)
- **Hide the organization column** for non-superusers and single-org superusers (only multi-org superusers have anything to disambiguate).
- **Remove the email column** from the changelist (still editable on the form and searchable).
- **Order the customer list by active project count** (most active first). Implemented as a scalar correlated `Subquery` (Coalesced to 0) rather than an aggregate annotation name — Django 5.2 forbids ordering by an un-annotated aggregate, and `get_ordering()` is also applied to the bare manager queryset Django builds for the customer FK autocomplete via `get_field_queryset()`, where the annotation name would raise `FieldError`.
- Customer-name search was already supported via `search_fields` (`customer__name`) — no change needed there.

### Project admin (`projects`)
- **Auto-assign the organization's default columnset on create** and **hide the columnset field** from the add/change form for every user (`get_exclude` + `save_model`). Removes the now-dead `_apply_columnset_field` helper.
- **Expand the Billing and Details sections on `/add/`** so their fields are visible without an extra click (collapsed as before on change).

### Tests
- New/updated coverage for the app ordering, customer column visibility + count ordering, columnset auto-assign + hiding, and the add-form section expansion.
- All `customers`, `projects`, and `commons` admin test suites pass; ruff clean. (The unrelated S3-backed tests error locally on missing AWS credentials only.)

## Reviewer notes
- **Upsell behavior change:** the upsell close-action still passes a `columnset` GET param in its redirect, but since columnset is now excluded from the form, that param is inert — upsell children receive the organization default columnset like any other new project (rather than inheriting the parent's). Happy to make upsell inherit the parent's columnset instead if preferred.
- Auto-assignment of the default columnset currently lives in the admin's `save_model`, parallel to the create-time resolution in `requirements`/`projects` serializers. A model-level default could consolidate these later.