### PR TITLE
change: KippoCustomerAdmin filters + filter-aware FY summary

### DIFF
--- a/kippo/commons/functions.py
+++ b/kippo/commons/functions.py
@@ -1,9 +1,19 @@
 import datetime
+import uuid
 from calendar import monthrange
 
 from django.utils import timezone
 
 DECEMBER = 12
+
+
+def is_uuid(value: str) -> bool:
+    """True if `value` is a valid UUID string."""
+    try:
+        uuid.UUID(value)
+    except (ValueError, TypeError):
+        return False
+    return True
 
 
 def get_current_month_date_range() -> tuple[timezone.datetime, timezone.datetime]:

--- a/kippo/commons/tests/__init__.py
+++ b/kippo/commons/tests/__init__.py
@@ -1,4 +1,5 @@
 from accounts.models import EmailDomain, KippoOrganization, KippoUser, OrganizationMembership, PersonalHoliday
+from django.http import QueryDict
 from django.test import TestCase
 from django.utils import timezone
 from octocat.models import GithubAccessToken, GithubRepository
@@ -103,7 +104,7 @@ def setup_basic_project(
 
 
 class MockRequest:
-    pass
+    GET = QueryDict()  # empty, immutable — admin list filters read request.GET.getlist()
 
 
 class IsStaffModelAdminTestCaseBase(TestCase):

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -121,7 +121,7 @@ class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
 
 @admin.register(KippoCustomer)
 class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
-    list_display = ("name", "get_active_project_count", "get_compliance_verified", "display_as_active", "updated_datetime")
+    list_display = ("name", "get_active_project_count", "get_compliance_verified", "updated_datetime")
     list_display_links = ("name",)
     # organization is added conditionally in get_list_filter (only for multi-org members);
     # the display_as_active filter is intentionally omitted.

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -1,5 +1,6 @@
 import datetime
 import urllib.parse
+import uuid
 from collections import defaultdict
 from collections.abc import Iterator
 
@@ -58,6 +59,14 @@ def _yen(amount: object) -> str:
     return f"¥{amount:,.0f}"
 
 
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+    except (ValueError, TypeError):
+        return False
+    return True
+
+
 class CustomerEndingProjectsFilter(admin.SimpleListFilter):
     """Multi-select customer-name filter listing only customers with 1+ project whose contract ends
     within the last two fiscal years (previous + current FY) of the customer's organization.
@@ -72,8 +81,9 @@ class CustomerEndingProjectsFilter(admin.SimpleListFilter):
 
     def __init__(self, request: DjangoRequest, params: dict, model: type, model_admin: admin.ModelAdmin) -> None:
         super().__init__(request, params, model, model_admin)
-        # read all selected values (the param may repeat); super() only keeps the last one
-        self.selected_values = request.GET.getlist(self.parameter_name)
+        # read all selected values (the param may repeat); super() only keeps the last one. Drop
+        # non-UUID values so a tampered query can't raise on the pk__in (UUID) lookup → 500.
+        self.selected_values = [value for value in request.GET.getlist(self.parameter_name) if _is_uuid(value)]
 
     def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
         pairs: dict[str, str] = {}

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -1,11 +1,14 @@
 import datetime
 import urllib.parse
+from collections import defaultdict
+from collections.abc import Iterator
 
 from accounts.models import KippoOrganization, KippoUser
 from commons.admin import AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
+from django.contrib.admin.views.main import ChangeList
 from django.db import models
 from django.db.models import Count, IntegerField, OuterRef, Prefetch, Subquery, Sum
 from django.db.models.functions import Coalesce
@@ -56,12 +59,21 @@ def _yen(amount: object) -> str:
 
 
 class CustomerEndingProjectsFilter(admin.SimpleListFilter):
-    """Customer-name filter listing only customers with 1+ project whose contract ends within the
-    last two fiscal years (previous + current FY) of the customer's organization.
+    """Multi-select customer-name filter listing only customers with 1+ project whose contract ends
+    within the last two fiscal years (previous + current FY) of the customer's organization.
+
+    Selecting several customers ORs them (pk__in). Each choice is a toggle link (add/remove the
+    customer from the selection) rendered by the default admin/filter.html template — no checkbox
+    template needed; ``get_query_string`` emits repeated params (doseq=True).
     """
 
     title = _("顧客名（直近2会計年度に終了案件あり）")
     parameter_name = "recent_ending_customer"
+
+    def __init__(self, request: DjangoRequest, params: dict, model: type, model_admin: admin.ModelAdmin) -> None:
+        super().__init__(request, params, model, model_admin)
+        # read all selected values (the param may repeat); super() only keeps the last one
+        self.selected_values = request.GET.getlist(self.parameter_name)
 
     def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
         pairs: dict[str, str] = {}
@@ -84,10 +96,26 @@ class CustomerEndingProjectsFilter(admin.SimpleListFilter):
         return sorted(pairs.items(), key=lambda item: item[1])
 
     def queryset(self, request: DjangoRequest, queryset: models.QuerySet) -> models.QuerySet:
-        value = self.value()
-        if value:
-            return queryset.filter(pk=value)
+        if self.selected_values:
+            return queryset.filter(pk__in=self.selected_values)
         return queryset
+
+    def choices(self, changelist: ChangeList) -> Iterator[dict]:
+        selected = set(self.selected_values)
+        yield {
+            "selected": not selected,
+            "query_string": changelist.get_query_string(remove=[self.parameter_name]),
+            "display": _("すべて"),
+        }
+        for pk, name in self.lookup_choices:
+            is_selected = pk in selected
+            # toggle this customer in/out of the current selection
+            remaining = [value for value in self.selected_values if value != pk] if is_selected else [*self.selected_values, pk]
+            if remaining:
+                query_string = changelist.get_query_string({self.parameter_name: remaining})
+            else:
+                query_string = changelist.get_query_string(remove=[self.parameter_name])
+            yield {"selected": is_selected, "query_string": query_string, "display": name}
 
 
 class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
@@ -229,23 +257,32 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         return (name_link, _yen(received), total_display, end_display)
 
     def changelist_view(self, request: DjangoRequest, extra_context: dict | None = None):
-        # Inject a per-organization current-fiscal-year summary header (rendered by change_list.html).
-        extra_context = extra_context or {}
-        extra_context["fiscal_year_summaries"] = self._fiscal_year_org_summaries(request.user)
-        return super().changelist_view(request, extra_context=extra_context)
+        # Render the per-organization current-fiscal-year summary header AFTER super() so it can be
+        # scoped to the customers actually shown (i.e. respecting the active filters).
+        response = super().changelist_view(request, extra_context=extra_context)
+        if hasattr(response, "context_data") and "cl" in response.context_data:
+            response.context_data["fiscal_year_summaries"] = self._fiscal_year_org_summaries(response.context_data["cl"].queryset)
+        return response
 
-    def _fiscal_year_org_summaries(self, user: KippoUser) -> list[dict]:
-        """Per-organization current-fiscal-year summary for the header — one entry per organization
-        the user belongs to. 'Projects planned to complete this FY' = contracts whose end_date falls
-        in the current fiscal year; planned total = Σ their total_amount; received total = Σ their
-        received billing-entry amounts.
+    @staticmethod
+    def _fiscal_year_org_summaries(customers: models.QuerySet) -> list[dict]:
+        """Per-organization current-fiscal-year summary for the header, scoped to the (filtered)
+        ``customers`` shown on the changelist. Per org: customer count; 'projects planned to complete
+        this FY' = those customers' contracts whose end_date falls in the current FY; planned total =
+        Σ their total_amount; received total = Σ their received billing-entry amounts.
         """
+        customer_pks_by_org: dict = defaultdict(list)
+        for customer_pk, organization_id in customers.values_list("pk", "organization_id"):
+            customer_pks_by_org[organization_id].append(customer_pk)
+
+        organizations = {org.pk: org for org in KippoOrganization.objects.filter(pk__in=customer_pks_by_org)}
         summaries = []
-        for organization in _visible_organizations(user):
+        for organization_id, customer_pks in customer_pks_by_org.items():
+            organization = organizations[organization_id]
             fiscal_year_start = organization.current_fiscal_year_start()
             fiscal_year_end = _shift_fiscal_year(fiscal_year_start, 1)
             contracts = KippoProjectContract.objects.filter(
-                project__organization=organization,
+                project__customer__in=customer_pks,
                 end_date__gte=fiscal_year_start,
                 end_date__lt=fiscal_year_end,
             )
@@ -259,12 +296,13 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
                     "organization": organization.name,
                     "fiscal_year_start": fiscal_year_start,
                     "fiscal_year_end": fiscal_year_end,
+                    "customer_count": len(customer_pks),
                     "project_count": contract_summary["count"],
                     "received_total_display": _yen(received_total),
                     "planned_total_display": _yen(contract_summary["total"] or 0),
                 }
             )
-        return summaries
+        return sorted(summaries, key=lambda summary: summary["organization"])
 
     @admin.display(boolean=True, description=_("反社チェック"))
     def get_compliance_verified(self, obj: KippoCustomer) -> bool:

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -1,11 +1,11 @@
 import datetime
 import urllib.parse
-import uuid
 from collections import defaultdict
 from collections.abc import Iterator
 
 from accounts.models import KippoOrganization, KippoUser
 from commons.admin import AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin
+from commons.functions import is_uuid
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
@@ -59,14 +59,6 @@ def _yen(amount: object) -> str:
     return f"¥{amount:,.0f}"
 
 
-def _is_uuid(value: str) -> bool:
-    try:
-        uuid.UUID(value)
-    except (ValueError, TypeError):
-        return False
-    return True
-
-
 class CustomerEndingProjectsFilter(admin.SimpleListFilter):
     """Multi-select customer-name filter listing only customers with 1+ project whose contract ends
     within the last two fiscal years (previous + current FY) of the customer's organization.
@@ -83,7 +75,7 @@ class CustomerEndingProjectsFilter(admin.SimpleListFilter):
         super().__init__(request, params, model, model_admin)
         # read all selected values (the param may repeat); super() only keeps the last one. Drop
         # non-UUID values so a tampered query can't raise on the pk__in (UUID) lookup → 500.
-        self.selected_values = [value for value in request.GET.getlist(self.parameter_name) if _is_uuid(value)]
+        self.selected_values = [value for value in request.GET.getlist(self.parameter_name) if is_uuid(value)]
 
     def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
         pairs: dict[str, str] = {}

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -123,7 +123,9 @@ class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
 class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     list_display = ("name", "get_active_project_count", "get_compliance_verified", "display_as_active", "updated_datetime")
     list_display_links = ("name",)
-    list_filter = ("organization", "display_as_active", CustomerEndingProjectsFilter)
+    # organization is added conditionally in get_list_filter (only for multi-org members);
+    # the display_as_active filter is intentionally omitted.
+    list_filter = (CustomerEndingProjectsFilter,)
     search_fields = ("name", "email")
     fields = ("organization", "name", "email", "phone", "website", "document_url", "notes", "display_as_active")
     inlines = (KippoProjectReadOnlyInline,)
@@ -145,6 +147,13 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         if request.user.is_superuser and request.user.organizations.count() > 1:
             return ("name", "organization", *self.list_display[1:])
         return self.list_display
+
+    def get_list_filter(self, request: DjangoRequest) -> tuple:
+        # Offer the organization filter only to users who belong to more than one organization;
+        # a single-org member has nothing to filter by.
+        if request.user.organizations.count() > 1:
+            return ("organization", *self.list_filter)
+        return self.list_filter
 
     def get_queryset(self, request: DjangoRequest):
         # Annotate each customer's active (open + display_as_active) project count so the

--- a/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
+++ b/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
@@ -8,6 +8,7 @@
       <tr>
         <th>組織</th>
         <th>会計年度</th>
+        <th style="text-align:right">顧客数</th>
         <th style="text-align:right">完了予定プロジェクト数</th>
         <th style="text-align:right">入金済合計</th>
         <th style="text-align:right">契約予定合計</th>
@@ -18,6 +19,7 @@
       <tr>
         <td>{{ summary.organization }}</td>
         <td>{{ summary.fiscal_year_start|date:"Y-m-d" }} 〜 {{ summary.fiscal_year_end|date:"Y-m-d" }}</td>
+        <td style="text-align:right">{{ summary.customer_count }}</td>
         <td style="text-align:right">{{ summary.project_count }}</td>
         <td style="text-align:right">{{ summary.received_total_display }}</td>
         <td style="text-align:right">{{ summary.planned_total_display }}</td>

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -312,6 +312,36 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         staff_user = self.staff_user_request.user
         self.assertEqual(set(_visible_organizations(staff_user)), set(staff_user.organizations))
 
+    def test_list_filter_omits_display_as_active_and_org_for_single_org_member(self):
+        from customers.admin import CustomerEndingProjectsFilter
+
+        # super_user_request.user is a member of exactly one org (added in the base setUp).
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        list_filter = modeladmin.get_list_filter(self.super_user_request)
+        self.assertNotIn("display_as_active", list_filter)
+        self.assertNotIn("organization", list_filter)
+        self.assertIn(CustomerEndingProjectsFilter, list_filter)
+
+    def test_list_filter_includes_org_for_multi_org_member(self):
+        from accounts.models import KippoOrganization, OrganizationMembership
+
+        other = KippoOrganization.objects.create(
+            name="second-org",
+            github_organization_name="ghsecondorg",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        OrganizationMembership.objects.create(
+            user=self.super_user_request.user,
+            organization=other,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        list_filter = modeladmin.get_list_filter(self.super_user_request)
+        self.assertIn("organization", list_filter)
+        self.assertNotIn("display_as_active", list_filter)
+
 
 class KippoCustomerAdminComplianceDisplayTestCase(IsStaffModelAdminTestCaseBase):
     """KippoCustomerAdmin shows the 反社チェック (compliance verified) state as a boolean column."""

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -212,7 +212,81 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertEqual(summary["project_count"], 1)  # only the contract ending this FY
         self.assertEqual(summary["planned_total_display"], "¥2,000,000")
         self.assertEqual(summary["received_total_display"], "¥500,000")
+        self.assertGreaterEqual(summary["customer_count"], 2)  # self.customer + self.other_customer
         self.assertIn("契約予定合計", response.content.decode())  # header block rendered
+
+    def test_fiscal_year_summary_is_filter_aware(self):
+        from decimal import Decimal
+
+        from django.utils import timezone
+        from projects.models import KippoProjectBillingEntry, KippoProjectContract
+
+        self.organization.fiscalyear_start_month = 1
+        self.organization.save()
+        today = timezone.localdate()
+
+        def _ending_contract(customer: KippoCustomer, name: str, total: str, received: str) -> None:
+            project = self._make_customer_project(name, customer, date(today.year, 6, 30))
+            contract = KippoProjectContract.objects.create(
+                project=project,
+                billing_type="delivery",
+                total_amount=Decimal(total),
+                end_date=date(today.year, 6, 30),
+                created_by=self.github_manager,
+                updated_by=self.github_manager,
+            )
+            KippoProjectBillingEntry.objects.create(
+                contract=contract, billing_date=date(today.year, 3, 31), amount=Decimal(received), is_received=True
+            )
+
+        _ending_contract(self.customer, "cust-a", "2000000", "500000")
+        _ending_contract(self.other_customer, "cust-b", "1000000", "300000")
+
+        # unfiltered → both customers' FY contracts roll up
+        url = reverse("admin:customers_kippocustomer_changelist")
+        unfiltered = next(s for s in self.client.get(url).context["fiscal_year_summaries"] if s["organization"] == self.organization.name)
+        self.assertEqual(unfiltered["project_count"], 2)
+        self.assertEqual(unfiltered["planned_total_display"], "¥3,000,000")
+        self.assertEqual(unfiltered["received_total_display"], "¥800,000")
+
+        # filtered to one customer → summary reflects only that customer
+        filtered_response = self.client.get(f"{url}?recent_ending_customer={self.customer.pk}")
+        filtered = next(s for s in filtered_response.context["fiscal_year_summaries"] if s["organization"] == self.organization.name)
+        self.assertEqual(filtered["customer_count"], 1)
+        self.assertEqual(filtered["project_count"], 1)
+        self.assertEqual(filtered["planned_total_display"], "¥2,000,000")
+        self.assertEqual(filtered["received_total_display"], "¥500,000")
+
+    def test_filter_supports_multiple_customer_selection(self):
+        from decimal import Decimal
+
+        from django.utils import timezone
+        from projects.models import KippoProjectContract
+
+        self.organization.fiscalyear_start_month = 1
+        self.organization.save()
+        today = timezone.localdate()
+        third = KippoCustomer.objects.create(
+            organization=self.organization, name="Initech", created_by=self.github_manager, updated_by=self.github_manager
+        )
+        for customer in (self.customer, self.other_customer, third):
+            project = self._make_customer_project(f"proj-{customer.name}", customer, date(today.year, 6, 30))
+            KippoProjectContract.objects.create(
+                project=project,
+                billing_type="delivery",
+                total_amount=Decimal("1000000"),
+                end_date=date(today.year, 6, 30),
+                created_by=self.github_manager,
+                updated_by=self.github_manager,
+            )
+
+        url = reverse("admin:customers_kippocustomer_changelist")
+        # repeated param → OR of the two selected customers (pk__in)
+        response = self.client.get(f"{url}?recent_ending_customer={self.customer.pk}&recent_ending_customer={self.other_customer.pk}")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        results = set(response.context["cl"].queryset)
+        self.assertEqual(results, {self.customer, self.other_customer})
+        self.assertNotIn(third, results)
 
     def test_active_project_detail_sums_received_within_current_fiscal_year(self):
         from datetime import timedelta

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -375,6 +375,11 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertIn(self.customer, results)
         self.assertNotIn(self.other_customer, results)
 
+        # a non-UUID (tampered) filter value must not 500 — it is ignored
+        bad_response = self.client.get(reverse("admin:customers_kippocustomer_changelist") + "?recent_ending_customer=not-a-uuid")
+        self.assertEqual(bad_response.status_code, HTTPStatus.OK)
+        self.assertIn(self.customer, bad_response.context["cl"].queryset)  # no filtering applied
+
     def test_visible_organizations_scope_matches_changelist(self):
         # the FY header and the name filter use the same org scope as the rows: all orgs for a
         # superuser (changelist is not org-scoped for superusers), else the user's own orgs.


### PR DESCRIPTION
## Summary

Follow-up to #324 (merged). Several `KippoCustomerAdmin` changelist refinements.

### Filters
- **Removed** the `display_as_active` filter.
- **`organization` filter shown only for multi-org members** (`get_list_filter`, mirroring `get_list_display`).
- **`CustomerEndingProjectsFilter` is now multi-select** — choices are toggle links (add/remove a customer), OR'd via `pk__in`, read from `request.GET.getlist`. Rendered by the default `admin/filter.html` (no custom template; `get_query_string` emits repeated params via `doseq=True`). Still bounded to customers with a project ending in the last two fiscal years.

### Columns
- **Removed** the `display_as_active` column from `list_display`.

### Fiscal-year summary header (now filter-aware)
- Computed over the customers **actually shown** on the changelist (`cl.queryset`, respecting the active filters), grouped by organization.
- **Added a 顧客数 (customer count)** column.
- `入金済合計` / `契約予定合計` are the shown customers' current-FY totals (received entries / Σ `total_amount` of contracts ending this FY). No filter ⇒ all customers in scope.

## Testing

- `accounts` + `customers` suites pass (161): single/multi-org filter scoping; multi-select OR (`pk__in`) via repeated param; filter-aware summary (unfiltered rolls up all shown customers, filtered reflects the selection) + customer count.
- `MockRequest` gained an empty `GET` so list-filter unit tests can instantiate filters that read `request.GET`.
- `ruff` clean. No model/migration changes.