### PR TITLE
fix: customer filter lists by project target_date, not contract end_date

### DIFF
--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -60,8 +60,10 @@ def _yen(amount: object) -> str:
 
 
 class CustomerEndingProjectsFilter(admin.SimpleListFilter):
-    """Multi-select customer-name filter listing only customers with 1+ project whose contract ends
-    within the last two fiscal years (previous + current FY) of the customer's organization.
+    """Multi-select customer-name filter listing only customers with 1+ project whose target_date
+    (planned completion) falls within the last two fiscal years (previous + current FY) of the
+    customer's organization. Keyed on the project's own target_date — not the optional OneToOne
+    KippoProjectContract.end_date, which most projects do not have.
 
     Selecting several customers ORs them (pk__in). Each choice is a toggle link (add/remove the
     customer from the selection) rendered by the default admin/filter.html template — no checkbox
@@ -87,8 +89,8 @@ class CustomerEndingProjectsFilter(admin.SimpleListFilter):
             qualifying = (
                 KippoCustomer.objects.filter(
                     organization=organization,
-                    projects__contract__end_date__gte=window_start,
-                    projects__contract__end_date__lt=window_end,
+                    projects__target_date__gte=window_start,
+                    projects__target_date__lt=window_end,
                 )
                 .distinct()
                 .values_list("pk", "name")

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -330,12 +330,10 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertIn("¥2,000,000", rendered)  # contract total_amount
         self.assertIn(date(today.year, 9, 30).isoformat(), rendered)  # contract end date
 
-    def test_recent_ending_customer_filter_lists_only_customers_with_projects_ending_in_last_2_fy(self):
+    def test_recent_ending_customer_filter_lists_customers_with_projects_in_last_2_fy(self):
         from datetime import timedelta
-        from decimal import Decimal
 
         from django.utils import timezone
-        from projects.models import KippoProjectContract
 
         from customers.admin import CustomerEndingProjectsFilter
 
@@ -344,27 +342,15 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         today = timezone.localdate()
         fy_start = date(today.year, 1, 1)
 
-        def _contract(project: KippoProject, end_date: date) -> None:
-            KippoProjectContract.objects.create(
-                project=project,
-                billing_type="delivery",
-                total_amount=Decimal("1000000"),
-                end_date=end_date,
-                created_by=self.github_manager,
-                updated_by=self.github_manager,
-            )
-
-        # self.customer: a project whose contract ends this FY → qualifies
-        _contract(self._make_customer_project("recent", self.customer, date(today.year, 6, 30)), date(today.year, 6, 30))
-        # self.other_customer: only a contract ending 2 FYs before the current one → excluded
-        _contract(
-            self._make_customer_project("old", self.other_customer, fy_start - timedelta(days=400)),
-            fy_start - timedelta(days=400),
-        )
+        # self.customer: a project with target_date in the last 2 FY and NO contract → still listed
+        # (the filter keys on the project's target_date, not the optional contract.end_date)
+        self._make_customer_project("recent", self.customer, date(today.year, 6, 30))
+        # self.other_customer: only a project ending well before the 2-FY window → excluded
+        self._make_customer_project("old", self.other_customer, fy_start - timedelta(days=400))
 
         flt = CustomerEndingProjectsFilter(self.super_user_request, {}, KippoCustomer, KippoCustomerAdmin(KippoCustomer, self.site))
         names = {name for _pk, name in flt.lookups(self.super_user_request, None)}
-        self.assertIn(self.customer.name, names)
+        self.assertIn(self.customer.name, names)  # listed despite having no contract
         self.assertNotIn(self.other_customer.name, names)
 
         # selecting a customer filters the changelist to it


### PR DESCRIPTION
## Problem

`CustomerEndingProjectsFilter` (KippoCustomerAdmin) came up empty — it didn't list customers with projects in the last 2 fiscal years.

## Cause

`lookups()` keyed on `projects__contract__end_date`, but `KippoProjectContract` is an **optional OneToOne** that most projects don't have. Customers whose projects lack a contract were excluded, so on real data the filter listed (almost) nothing.

## Fix

Key the filter on the project's own **`target_date`** (planned completion, a populated core field) within the last-2-FY window instead of the sparse contract `end_date`. Matches "customers with projects in the last 2 years".

The FY **summary header** is unchanged — it intentionally keeps using contract `end_date` (financial totals of contracts ending this FY).

## Testing

- Reworked the filter test to be project-based: a customer with a project (target_date in the last 2 FY) **and no contract** is now listed; a customer whose only project ends before the window is excluded.
- `customers.tests.test_admin` (32) pass; `ruff` clean. No model/migration changes.