### PR TITLE
fix: reserve active-projects column width so expanding doesn't reflow

### DIFF
--- a/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
+++ b/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
@@ -32,6 +32,23 @@
 {{ block.super }}
 {% endblock %}
 {% block extrahead %}{{ block.super }}
+{# Reserve the アクティブプロジェクト column width up front so expanding the per-project detail does not resize the column. #}
+<style>
+  #result_list th.column-get_active_project_count,
+  #result_list td.field-get_active_project_count {
+    min-width: 32em;
+  }
+  td.field-get_active_project_count table.active-projects-detail {
+    width: 100%;
+    table-layout: fixed;
+  }
+  td.field-get_active_project_count table.active-projects-detail th,
+  td.field-get_active_project_count table.active-projects-detail td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>
 {# Toggle the per-project detail table under the アクティブプロジェクト count (KippoCustomerAdmin.get_active_project_count). #}
 <script>
 (function () {


### PR DESCRIPTION
## Problem

On the KippoCustomerAdmin changelist, clicking the アクティブプロジェクト count to expand a customer's per-project detail table widened the column and shifted the surrounding layout.

## Cause

The column was sized to its collapsed content (just the count link). The detail `<table>` (`display:none` while collapsed) contributes no width until shown, so revealing it grew the cell.

## Fix

Reserve the column width up front via CSS in the changelist template:
- `min-width: 32em` on the column header/cells (`column-`/`field-get_active_project_count`), so the collapsed column is already wide enough.
- The detail table is constrained to that width (`width:100%` + `table-layout:fixed` + `text-overflow:ellipsis`), so showing it fills the reserved space instead of expanding the column.

Toggling now changes only row height (the accordion), not column width.

## Testing

- `customers.tests.test_admin` (32) pass — the changelist renders with the added `<style>`. Presentational change; no model/migration/logic change.