### PR TITLE
fix: active-projects detail needs a definite width to stop column resize

### DIFF
--- a/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
+++ b/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
@@ -39,7 +39,10 @@
     min-width: 32em;
   }
   td.field-get_active_project_count table.active-projects-detail {
-    width: 100%;
+    /* definite width (matching the column min-width) so table-layout:fixed engages — a percentage
+       resolves against the content-sized cell and is indefinite, which silently disables fixed
+       layout and lets the table grow to its content, resizing the column on expand. */
+    width: 32em;
     table-layout: fixed;
   }
   td.field-get_active_project_count table.active-projects-detail th,


### PR DESCRIPTION
## Problem

Clicking the アクティブプロジェクト count on the KippoCustomerAdmin changelist **still** resized the column, despite #327.

## Cause

#327 reserved the column (`min-width: 32em`) and capped the detail table with `table-layout: fixed` + `width: 100%`. But `width: 100%` resolves against the `<td>`, whose width is content-based (indefinite) in the auto-layout `#result_list` table. A percentage against an indefinite container is itself indefinite — which **silently disables `table-layout: fixed`** (it falls back to `auto`). The inner table then sizes to its intrinsic content, overruns the reserved 32em, and grows the column on expand.

## Fix

Give the detail table a **definite** `width: 32em` (matching the column `min-width`). `table-layout: fixed` now engages, the 4 columns split the fixed width, overflow ellipsises, and the cell is 32em in both states → no resize.

## Testing

- `customers.tests.test_admin` (34) pass — the changelist renders with the updated `<style>`. CSS-only; no model/logic change.

Note: this is an admin **template** change served by Django on render — the deployed Lambda must be redeployed to pick it up (no `collectstatic` needed; the `<style>` is inline).