### PR TITLE
change: KippoCustomerAdmin — compliance-completed action + caret-toggle active-projects detail

### DIFF
--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -16,6 +16,7 @@ from django.db.models.functions import Coalesce
 from django.forms import BaseFormSet, Form
 from django.http import request as DjangoRequest  # noqa: N812
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 from projects.admin import RETURN_TO_PARAM
@@ -174,6 +175,7 @@ class KippoCustomerComplianceCheckInline(AllowIsStaffAdminMixin, admin.StackedIn
 class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     list_display = ("name", "get_active_project_count", "get_compliance_verified", "updated_datetime")
     list_display_links = ("name",)
+    actions = ("mark_compliance_check_completed",)
     # organization is added conditionally in get_list_filter (only for multi-org members).
     list_filter = (CustomerEndingProjectsFilter,)
     search_fields = ("name", "email")
@@ -253,8 +255,10 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
 
     @admin.display(description=_("アクティブプロジェクト"), ordering="active_project_count")
     def get_active_project_count(self, obj: KippoCustomer) -> int | str:
-        # Default: the count. Clicking a non-zero count toggles a per-project detail table (the
-        # toggle script is inlined in change_list.html). 0 renders plainly (nothing to expand).
+        # Default: the count. A non-zero count renders a caret toggle that expands a per-project
+        # detail table inline below the count (the toggle script + caret styling are inlined in
+        # change_list.html; the column width is reserved up front so expanding never resizes it).
+        # 0 renders plainly (nothing to expand).
         count = obj.active_project_count
         if not count:
             return count
@@ -267,10 +271,12 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             (self._active_project_row(project, fiscal_year_start) for project in getattr(obj, "active_projects", ())),
         )
         return format_html(
-            '<a href="#" class="active-projects-toggle">{}</a>'
-            '<table class="active-projects-detail" hidden>'
+            '<a href="#" class="active-projects-toggle" role="button" aria-expanded="false">'
+            '<span class="active-projects-caret" aria-hidden="true"></span>{}</a>'
+            '<div class="active-projects-detail" hidden>'
+            "<table>"
             "<thead><tr><th>{}</th><th>{}</th><th>{}</th><th>{}</th></tr></thead>"
-            "<tbody>{}</tbody></table>",
+            "<tbody>{}</tbody></table></div>",
             count,
             _("プロジェクト"),
             _("入金済合計(今期)"),
@@ -341,11 +347,38 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             )
         return sorted(summaries, key=lambda summary: summary["organization"])
 
-    @admin.display(boolean=True, description=_("反社チェック"))
-    def get_compliance_verified(self, obj: KippoCustomer) -> bool:
-        # The compliance_check is auto-created via signal; guard against its absence anyway.
+    @admin.display(description=_("反社チェック"))
+    def get_compliance_verified(self, obj: KippoCustomer):
+        # Verified → a check mark. Not verified → an inline reminder telling the admin to run the
+        # 「反社チェック完了」 action once the check is done (the wording mirrors the action's label so
+        # it is findable in the actions dropdown). The compliance_check is auto-created via signal;
+        # guard against its absence anyway.
         compliance_check = getattr(obj, "compliance_check", None)
-        return bool(compliance_check and compliance_check.verified)
+        if compliance_check and compliance_check.verified:
+            return format_html('<span style="color:#447e3c">✓</span>')
+        return format_html(
+            '<span style="color:#ba2121">{}</span>',
+            _("反社チェックが未完了です。完了後、「反社チェック完了」アクションで更新してください。"),
+        )
+
+    @admin.action(description=_("反社チェック完了（ComplianceCheck Completed）"))
+    def mark_compliance_check_completed(self, request: DjangoRequest, queryset: models.QuerySet) -> None:
+        # Mark each selected customer's 反社チェック completed: stamp the verified flag, the datetime,
+        # and the acting admin as verifier. Already-completed checks are left untouched so their
+        # original datetime/verifier are preserved.
+        now = timezone.now()
+        completed = 0
+        for customer in queryset:
+            compliance_check = getattr(customer, "compliance_check", None)
+            if compliance_check is None or compliance_check.verified:
+                continue
+            compliance_check.verified = True
+            compliance_check.verified_datetime = now
+            compliance_check.verified_by = request.user
+            compliance_check.updated_by = request.user
+            compliance_check.save()
+            completed += 1
+        self.message_user(request, _("反社チェックを完了にしました: %(count)d 件") % {"count": completed})
 
     def change_view(self, request: DjangoRequest, object_id: str, form_url: str = "", extra_context: dict | None = None):
         # Surface an "プロジェクトを追加" button under the projects inline that sends the user to the

--- a/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
+++ b/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
@@ -32,21 +32,42 @@
 {{ block.super }}
 {% endblock %}
 {% block extrahead %}{{ block.super }}
-{# Reserve the アクティブプロジェクト column width up front so expanding the per-project detail does not resize the column. #}
+{# A caret toggle expands the per-project detail inline below the count. The column width is reserved
+   up front (min-width) and the detail table fills it exactly (width:100% + fixed layout), so expanding
+   the detail can never widen the column. In-flow (not an absolutely-positioned popover) so it is never
+   clipped by the admin's `.results { overflow-x: auto }` container. #}
 <style>
   #result_list th.column-get_active_project_count,
   #result_list td.field-get_active_project_count {
     min-width: 32em;
   }
-  td.field-get_active_project_count table.active-projects-detail {
-    /* definite width (matching the column min-width) so table-layout:fixed engages — a percentage
-       resolves against the content-sized cell and is indefinite, which silently disables fixed
-       layout and lets the table grow to its content, resizing the column on expand. */
-    width: 32em;
-    table-layout: fixed;
+  a.active-projects-toggle {
+    cursor: pointer;
+    white-space: nowrap;
   }
-  td.field-get_active_project_count table.active-projects-detail th,
-  td.field-get_active_project_count table.active-projects-detail td {
+  .active-projects-caret::before {
+    content: "\25B6"; /* ▶ collapsed; rotates to ▼ when expanded */
+    display: inline-block;
+    margin-right: .4em;
+    font-size: .75em;
+    transition: transform .1s ease;
+  }
+  a.active-projects-toggle[aria-expanded="true"] .active-projects-caret::before {
+    transform: rotate(90deg);
+  }
+  td.field-get_active_project_count .active-projects-detail {
+    margin-top: .4em;
+  }
+  td.field-get_active_project_count .active-projects-detail table {
+    /* width:100% fills the reserved cell content box exactly (a fixed em would overflow by the cell
+       padding and widen the column); table-layout:fixed engages because the cell width is definite
+       via the column min-width, so the detail never forces the column wider. */
+    width: 100%;
+    table-layout: fixed;
+    margin: 0;
+  }
+  td.field-get_active_project_count .active-projects-detail th,
+  td.field-get_active_project_count .active-projects-detail td {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -63,6 +84,7 @@
         var detail = toggle.parentElement.querySelector(".active-projects-detail");
         if (detail) {
           detail.hidden = !detail.hidden;
+          toggle.setAttribute("aria-expanded", detail.hidden ? "false" : "true");
         }
       });
     });

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -198,11 +198,46 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         qs = modeladmin.get_queryset(self.super_user_request)
         customer = qs.get(pk=self.customer.pk)
         self.assertEqual(customer.active_project_count, 2)
-        # non-zero count renders the clickable toggle showing the count
+        # non-zero count renders the clickable toggle (with an expand/collapse caret) showing the count
         rendered = modeladmin.get_active_project_count(customer)
         self.assertIn("active-projects-toggle", rendered)
+        self.assertIn("active-projects-caret", rendered)  # expand/collapse icon
+        self.assertIn('aria-expanded="false"', rendered)  # starts collapsed
         self.assertIn(">2<", rendered)
         self.assertEqual(qs.get(pk=self.other_customer.pk).active_project_count, 1)
+
+    def test_compliance_check_completed_action_stamps_verified_fields(self):
+        check = self.customer.compliance_check
+        self.assertFalse(check.verified)
+        url = reverse("admin:customers_kippocustomer_changelist")
+        response = self.client.post(
+            url,
+            {"action": "mark_compliance_check_completed", "_selected_action": [str(self.customer.pk)]},
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)  # redirects back to the changelist
+        check.refresh_from_db()
+        self.assertTrue(check.verified)
+        self.assertIsNotNone(check.verified_datetime)
+        self.assertEqual(check.verified_by, self.superuser_no_org)  # acting admin stamped as verifier
+
+    def test_compliance_check_completed_action_preserves_already_verified(self):
+        from django.utils import timezone
+
+        check = self.other_customer.compliance_check
+        original_datetime = timezone.now() - timezone.timedelta(days=3)
+        check.verified = True
+        check.verified_datetime = original_datetime
+        check.verified_by = self.github_manager
+        check.save()
+        url = reverse("admin:customers_kippocustomer_changelist")
+        self.client.post(
+            url,
+            {"action": "mark_compliance_check_completed", "_selected_action": [str(self.other_customer.pk)]},
+        )
+        check.refresh_from_db()
+        # already-completed check is left untouched (original verifier/datetime preserved)
+        self.assertEqual(check.verified_by, self.github_manager)
+        self.assertEqual(check.verified_datetime, original_datetime)
 
     def test_active_project_count_zero_renders_plain(self):
         modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
@@ -465,22 +500,22 @@ class KippoCustomerAdminComplianceDisplayTestCase(IsStaffModelAdminTestCaseBase)
     def test_compliance_column_in_list_display(self):
         self.assertIn("get_compliance_verified", KippoCustomerAdmin.list_display)
 
-    def test_compliance_display_method_is_boolean(self):
+    def test_compliance_display_shows_not_completed_message_when_unverified(self):
         modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
-        self.assertTrue(modeladmin.get_compliance_verified.boolean)
+        # Auto-created compliance_check is unverified → render the reminder pointing at the action.
+        rendered = modeladmin.get_compliance_verified(self.customer)
+        self.assertIn("未完了", rendered)
+        self.assertIn("反社チェック完了", rendered)  # references the action label
 
-    def test_compliance_display_false_when_unverified(self):
-        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
-        # Auto-created compliance_check is unverified.
-        self.assertFalse(modeladmin.get_compliance_verified(self.customer))
-
-    def test_compliance_display_true_when_verified(self):
+    def test_compliance_display_shows_checkmark_when_verified(self):
         modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
         check = self.customer.compliance_check
         check.verified = True
         check.save()
         refreshed = KippoCustomer.objects.get(pk=self.customer.pk)
-        self.assertTrue(modeladmin.get_compliance_verified(refreshed))
+        rendered = modeladmin.get_compliance_verified(refreshed)
+        self.assertIn("✓", rendered)
+        self.assertNotIn("未完了", rendered)
 
     def test_queryset_selects_related_compliance_check(self):
         modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)


### PR DESCRIPTION
## Summary

Two changes to `KippoCustomerAdmin` (`kippo/customers/`):

### 1. ComplianceCheck Completed admin action
- New action **「反社チェック完了（ComplianceCheck Completed）」**. Run on selected customers, it stamps each related `KippoCustomerComplianceCheck`: `verified=True`, `verified_datetime=now`, `verified_by=<acting admin>` (plus `updated_by`). Already-completed checks are skipped so their original verifier/datetime are preserved.
- The 反社チェック column now shows an inline reminder when the check is **not** completed — `反社チェックが未完了です。完了後、「反社チェック完了」アクションで更新してください。` — and a check mark (✓) when completed (replaces the bare boolean icon). The wording mirrors the action label so admins can find it in the actions dropdown.

### 2. Active-projects count expand/collapse + column-resize fix
- The active-project count gets an **expand/collapse caret** (▶ → ▼) as a clear affordance.
- The per-project detail renders **inline below the count**, with the column width reserved up front (`min-width`) and the detail table at `width:100%` + `table-layout:fixed`, so expanding/collapsing **no longer resizes the column**. This supersedes the earlier partial fixes in #327 / #329, where a fixed-`em` detail table overflowed the cell content box by its padding and still widened the column.
- Kept **in-flow** (not an absolutely-positioned popover): the admin wraps the changelist in `.results { overflow-x: auto }`, which would clip an absolutely-positioned dropdown.

## Testing
- `customers.tests.test_admin` — 35 tests pass. Added coverage for the action (stamps verified fields; preserves already-verified) and the caret/reminder rendering.
- `ruff` clean (pre-commit hooks pass).

Note: visual behavior (caret rotation, no-resize, no-clipping) was reasoned through against Django admin's changelist CSS; a quick manual check on the deployed admin changelist is worthwhile before merge.