### PR TITLE
fix: KippoCustomerAdmin — active-projects column resize, leaking comment, + compliance reminder in inline

### DIFF
--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -162,13 +162,25 @@ class KippoCustomerComplianceCheckInline(AllowIsStaffAdminMixin, admin.StackedIn
     extra = 0
     max_num = 1
     can_delete = False
-    fields = ("verified", "verified_datetime", "verified_by", "notes")
+    fields = ("completion_notice", "verified", "verified_datetime", "verified_by", "notes")
     # verified_datetime / verified_by are auto-managed (stamped when verified is ticked, cleared when
-    # unticked) — shown read-only so typed values can't be silently discarded.
-    readonly_fields = ("verified_datetime", "verified_by")
+    # unticked) — shown read-only so typed values can't be silently discarded. completion_notice is a
+    # read-only reminder rendered when the check is not yet completed.
+    readonly_fields = ("completion_notice", "verified_datetime", "verified_by")
 
     def has_add_permission(self, request: DjangoRequest, obj: models.Model | None = None) -> bool:
         return False  # one is auto-created per customer via the post_save signal
+
+    @admin.display(description=_("ステータス"))
+    def completion_notice(self, obj: KippoCustomerComplianceCheck | None):
+        # Not yet completed → remind the admin to mark it complete via the 「反社チェック完了」 changelist
+        # action (the wording mirrors the action label so it is findable). Completed → a check mark.
+        if obj and obj.verified:
+            return format_html('<span style="color:#447e3c">✓ 反社チェック済み</span>')
+        return format_html(
+            '<span style="color:#ba2121">{}</span>',
+            _("反社チェックが未完了です。完了後、「反社チェック完了」アクションで更新してください。"),
+        )
 
 
 @admin.register(KippoCustomer)
@@ -347,19 +359,11 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             )
         return sorted(summaries, key=lambda summary: summary["organization"])
 
-    @admin.display(description=_("反社チェック"))
-    def get_compliance_verified(self, obj: KippoCustomer):
-        # Verified → a check mark. Not verified → an inline reminder telling the admin to run the
-        # 「反社チェック完了」 action once the check is done (the wording mirrors the action's label so
-        # it is findable in the actions dropdown). The compliance_check is auto-created via signal;
-        # guard against its absence anyway.
+    @admin.display(boolean=True, description=_("反社チェック"))
+    def get_compliance_verified(self, obj: KippoCustomer) -> bool:
+        # The compliance_check is auto-created via signal; guard against its absence anyway.
         compliance_check = getattr(obj, "compliance_check", None)
-        if compliance_check and compliance_check.verified:
-            return format_html('<span style="color:#447e3c">✓</span>')
-        return format_html(
-            '<span style="color:#ba2121">{}</span>',
-            _("反社チェックが未完了です。完了後、「反社チェック完了」アクションで更新してください。"),
-        )
+        return bool(compliance_check and compliance_check.verified)
 
     @admin.action(description=_("反社チェック完了（ComplianceCheck Completed）"))
     def mark_compliance_check_completed(self, request: DjangoRequest, queryset: models.QuerySet) -> None:

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -269,8 +269,8 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     def get_active_project_count(self, obj: KippoCustomer) -> int | str:
         # Default: the count. A non-zero count renders a caret toggle that expands a per-project
         # detail table inline below the count (the toggle script + caret styling are inlined in
-        # change_list.html; the column width is reserved up front so expanding never resizes it).
-        # 0 renders plainly (nothing to expand).
+        # change_list.html; the detail stays in layout in both states — collapsed via CSS max-height —
+        # so expanding never resizes the column). 0 renders plainly (nothing to expand).
         count = obj.active_project_count
         if not count:
             return count
@@ -285,7 +285,7 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         return format_html(
             '<a href="#" class="active-projects-toggle" role="button" aria-expanded="false">'
             '<span class="active-projects-caret" aria-hidden="true"></span>{}</a>'
-            '<div class="active-projects-detail" hidden>'
+            '<div class="active-projects-detail">'
             "<table>"
             "<thead><tr><th>{}</th><th>{}</th><th>{}</th><th>{}</th></tr></thead>"
             "<tbody>{}</tbody></table></div>",

--- a/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
+++ b/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
@@ -32,21 +32,23 @@
 {{ block.super }}
 {% endblock %}
 {% block extrahead %}{{ block.super }}
-{# A caret toggle expands the per-project detail inline below the count. The column width is reserved
-   up front (min-width) and the detail table fills it exactly (width:100% + fixed layout), so expanding
-   the detail can never widen the column. In-flow (not an absolutely-positioned popover) so it is never
-   clipped by the admin's `.results { overflow-x: auto }` container. #}
+{% comment %}
+A caret toggles the per-project detail inline below the アクティブプロジェクト count. The detail is kept
+in layout in BOTH states — collapsed via max-height:0 (NOT display:none) — so its width contribution to
+the column is identical open or closed; the column therefore cannot change width on expand/collapse
+(display:none would drop the detail from the collapsed layout and let the column grow when it reopens).
+The detail table is width:100% so it fills the cell without clipping, and its cells ellipsis-clip so long
+names never widen it. In-flow (not an absolutely positioned popover) so it is never clipped by the admin's
+`.results { overflow-x: auto }` container. NOTE: this is a comment-tag block on purpose — a multi-line
+Django single-line comment leaks its text into the rendered page, so do not convert this back to one.
+{% endcomment %}
 <style>
-  #result_list th.column-get_active_project_count,
-  #result_list td.field-get_active_project_count {
-    min-width: 32em;
-  }
   a.active-projects-toggle {
     cursor: pointer;
     white-space: nowrap;
   }
   .active-projects-caret::before {
-    content: "\25B6"; /* ▶ collapsed; rotates to ▼ when expanded */
+    content: "\25B6"; /* collapsed caret; rotates 90deg to point down when expanded */
     display: inline-block;
     margin-right: .4em;
     font-size: .75em;
@@ -56,15 +58,21 @@
     transform: rotate(90deg);
   }
   td.field-get_active_project_count .active-projects-detail {
-    margin-top: .4em;
+    /* collapsed: clipped to 0 height but still laid out (width preserved) so the column width is the
+       same whether open or closed — expanding can never resize the column. */
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height .15s ease;
+  }
+  td.field-get_active_project_count .active-projects-detail.open {
+    max-height: 60em;
   }
   td.field-get_active_project_count .active-projects-detail table {
-    /* width:100% fills the reserved cell content box exactly (a fixed em would overflow by the cell
-       padding and widen the column); table-layout:fixed engages because the cell width is definite
-       via the column min-width, so the detail never forces the column wider. */
+    /* fills the cell so the detail is never clipped; because the detail is laid out in BOTH states
+       (collapsed via max-height:0), its width contribution is identical open/closed → no column resize. */
     width: 100%;
     table-layout: fixed;
-    margin: 0;
+    margin: .4em 0 0;
   }
   td.field-get_active_project_count .active-projects-detail th,
   td.field-get_active_project_count .active-projects-detail td {
@@ -83,8 +91,8 @@
         event.preventDefault();
         var detail = toggle.parentElement.querySelector(".active-projects-detail");
         if (detail) {
-          detail.hidden = !detail.hidden;
-          toggle.setAttribute("aria-expanded", detail.hidden ? "false" : "true");
+          var open = detail.classList.toggle("open");
+          toggle.setAttribute("aria-expanded", open ? "true" : "false");
         }
       });
     });

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -105,6 +105,21 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIn("compliance_check-0-verified", response.content.decode())
 
+    def test_compliance_inline_shows_not_completed_notice_when_unverified(self):
+        # The 反社チェック inline (add/change UI) shows the reminder while the check is not completed.
+        url = reverse("admin:customers_kippocustomer_change", args=[self.customer.id])
+        content = self.client.get(url).content.decode()
+        self.assertIn("反社チェックが未完了です", content)
+        self.assertIn("反社チェック完了", content)  # references the changelist action
+
+    def test_compliance_inline_hides_notice_when_completed(self):
+        check = self.customer.compliance_check
+        check.verified = True
+        check.save()
+        url = reverse("admin:customers_kippocustomer_change", args=[self.customer.id])
+        content = self.client.get(url).content.decode()
+        self.assertNotIn("未完了", content)  # reminder gone once completed
+
     def test_compliance_inline_save_stamps_verified_by_and_datetime(self):
         from customers.admin import KippoCustomerComplianceCheckInline
 
@@ -500,22 +515,22 @@ class KippoCustomerAdminComplianceDisplayTestCase(IsStaffModelAdminTestCaseBase)
     def test_compliance_column_in_list_display(self):
         self.assertIn("get_compliance_verified", KippoCustomerAdmin.list_display)
 
-    def test_compliance_display_shows_not_completed_message_when_unverified(self):
+    def test_compliance_display_method_is_boolean(self):
         modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
-        # Auto-created compliance_check is unverified → render the reminder pointing at the action.
-        rendered = modeladmin.get_compliance_verified(self.customer)
-        self.assertIn("未完了", rendered)
-        self.assertIn("反社チェック完了", rendered)  # references the action label
+        self.assertTrue(modeladmin.get_compliance_verified.boolean)
 
-    def test_compliance_display_shows_checkmark_when_verified(self):
+    def test_compliance_display_false_when_unverified(self):
+        modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
+        # Auto-created compliance_check is unverified.
+        self.assertFalse(modeladmin.get_compliance_verified(self.customer))
+
+    def test_compliance_display_true_when_verified(self):
         modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)
         check = self.customer.compliance_check
         check.verified = True
         check.save()
         refreshed = KippoCustomer.objects.get(pk=self.customer.pk)
-        rendered = modeladmin.get_compliance_verified(refreshed)
-        self.assertIn("✓", rendered)
-        self.assertNotIn("未完了", rendered)
+        self.assertTrue(modeladmin.get_compliance_verified(refreshed))
 
     def test_queryset_selects_related_compliance_check(self):
         modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)


### PR DESCRIPTION
Follow-up to #333. Two related fixes to the `KippoCustomerAdmin` changelist.

## 1. Active-projects column no longer resizes on expand/collapse
The アクティブプロジェクト detail used the `hidden` attribute (`display:none`), so the **collapsed** column was sized *without* the detail; reopening could grow the column whenever the inner table's fixed layout didn't fully engage (the intermittent resize reported across #327/#329/#333).

Now the detail is kept **in layout in both states** and collapsed via `max-height:0; overflow:hidden`, so its width contribution is identical open/closed — the column physically cannot resize. The toggle script flips an `.open` class instead of the `hidden` attribute.

**Verified in a real browser** (admin changelist, viewports 1600→800px): column width identical collapsed vs expanded at every width (e.g. 576→576, 256→256, 139→139px); the next column's left edge does not move; the detail fills the cell (not clipped); caret rotates 90°.

## 2. Leaking template comment
A multi-line Django `{# #}` comment introduced in #333 was rendering its text at the top of the changelist (Django `{# #}` is single-line only). Switched to `{% comment %}`/`{% endcomment %}`.

## 3. Compliance reminder moved into the inline (the original #334 change)
- The changelist `反社チェック` column is back to the boolean (✓/✗) display.
- The "not completed" reminder now renders in the compliance-check inline on the customer add/change page (read-only `completion_notice` field): `反社チェックが未完了です。完了後、「反社チェック完了」アクションで更新してください。` while incomplete, `✓ 反社チェック済み` once completed.

## Testing
- `customers.tests.test_admin` — 38 tests pass; `ruff` clean (pre-commit hooks pass).
- Manual browser smoke test against the local docker-compose env (screenshots captured for collapsed/expanded).