### PR TITLE
Rename KippoCustomerAdmin header column 完了予定プロジェクト数 → 完了予定契約数

### DIFF
--- a/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
+++ b/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
@@ -9,7 +9,7 @@
         <th>組織</th>
         <th>会計年度</th>
         <th style="text-align:right">顧客数</th>
-        <th style="text-align:right">完了予定プロジェクト数</th>
+        <th style="text-align:right">完了予定契約数</th>
         <th style="text-align:right">入金済合計</th>
         <th style="text-align:right">契約予定合計</th>
       </tr>


### PR DESCRIPTION
## Summary

The fiscal-year summary header column on `KippoCustomerAdmin` is renamed **完了予定プロジェクト数 → 完了予定契約数**.

That value counts `KippoProjectContract` rows whose `end_date` falls in the current fiscal year — not projects (a project without a contract is not counted). The old label read as a project count, which is misleading; 完了予定契約数 reflects that it is a contract count.

Follow-up to #335.

## Changes

- `kippo/customers/templates/admin/customers/kippocustomer/change_list.html` — header column label renamed.