### PR TITLE
Fix 反社チェック inline visibility, add contract columns to project inline, reorder status inline

### DIFF
--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -133,8 +133,8 @@ class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
     can_delete = False
     verbose_name = _("プロジェクト")
     verbose_name_plural = _("プロジェクト")
-    fields = ("get_project_link", "start_date", "target_date")
-    readonly_fields = ("get_project_link", "start_date", "target_date")
+    fields = ("get_project_link", "start_date", "target_date", "get_contract_type", "get_contract_end_date", "get_contract_total")
+    readonly_fields = ("get_project_link", "start_date", "target_date", "get_contract_type", "get_contract_end_date", "get_contract_total")
     # Wraps the default tabular inline and appends a "プロジェクトを追加" link that redirects to the
     # ActiveKippoProject add form (project creation is rich — GitHub project, columnset, etc. — so
     # it is never created inline). Scoped to this inline only; the global tabular template is
@@ -145,12 +145,34 @@ class KippoProjectReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
         return False
 
     def get_queryset(self, request: DjangoRequest):
-        # earliest target_date first
-        return super().get_queryset(request).order_by("target_date")
+        # earliest target_date first; select_related the OneToOne contract so the contract columns
+        # below don't issue a per-project query.
+        return super().get_queryset(request).select_related("contract").order_by("target_date")
 
     @admin.display(description=KippoProject._meta.get_field("name").verbose_name)
     def get_project_link(self, obj: KippoProject):
         return format_html('<a href="{}">{}</a>', obj.get_admin_url(), obj.name)
+
+    @admin.display(description=_("契約種別"))
+    def get_contract_type(self, obj: KippoProject) -> str:
+        # 請求方法 / 料金体系 (e.g. 納品 / 固定) — both halves describe the contract terms. "-" with no contract.
+        contract = getattr(obj, "contract", None)
+        if not contract:
+            return "-"
+        return f"{contract.get_billing_type_display()} / {contract.get_pricing_basis_display()}"
+
+    @admin.display(description=_("契約終了日"))
+    def get_contract_end_date(self, obj: KippoProject) -> str:
+        contract = getattr(obj, "contract", None)
+        return contract.end_date.isoformat() if contract and contract.end_date else "-"
+
+    @admin.display(description=_("契約金額"))
+    def get_contract_total(self, obj: KippoProject) -> str:
+        # No contract → "-". Effort pricing leaves total_amount blank (billed on actuals) → 実績.
+        contract = getattr(obj, "contract", None)
+        if not contract:
+            return "-"
+        return _yen(contract.total_amount) if contract.total_amount is not None else _("実績")
 
 
 class KippoCustomerComplianceCheckInline(AllowIsStaffAdminMixin, admin.StackedInline):
@@ -401,6 +423,10 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         extra_context = extra_context or {}
         customer = self.get_object(request, unquote(object_id))
         if customer is not None:
+            # Backfill the 反社チェック record for customers that predate the auto-create signal — without
+            # it the inline (extra=0, no add permission) renders an empty section and the completion
+            # notice never shows. get_or_create is idempotent for customers that already have one.
+            KippoCustomerComplianceCheck.objects.get_or_create(customer=customer)
             params = {
                 "customer": str(customer.pk),
                 "organization": str(customer.organization_id),

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -11,7 +11,7 @@ from projects.models import KippoProject
 from projects.tests.test_admin import KippoProjectAdminFixtureTestCaseBase
 
 from customers.admin import KippoCustomerAdmin, KippoProjectReadOnlyInline
-from customers.models import KippoCustomer
+from customers.models import KippoCustomer, KippoCustomerComplianceCheck
 
 
 class IsStaffOrganizationKippoCustomerAdminTestCase(IsStaffModelAdminTestCaseBase):
@@ -87,8 +87,54 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertFalse(inline.can_delete)
         # every displayed field is read-only
         self.assertEqual(set(inline.fields), set(inline.readonly_fields))
-        for fieldname in ("get_project_link", "start_date", "target_date"):
+        for fieldname in ("get_project_link", "start_date", "target_date", "get_contract_type", "get_contract_end_date", "get_contract_total"):
             self.assertIn(fieldname, inline.fields)
+
+    def test_inline_shows_contract_type_end_date_and_total(self):
+        from decimal import Decimal
+
+        from projects.models import KippoProjectContract
+
+        project = self._make_customer_project("acme-contract", self.customer, date(2026, 9, 30))
+        KippoProjectContract.objects.create(
+            project=project,
+            billing_type="delivery",
+            pricing_basis="fixed",
+            total_amount=Decimal("1500000"),
+            end_date=date(2026, 9, 30),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        inline = KippoProjectReadOnlyInline(KippoCustomer, self.site)
+        self.assertEqual(inline.get_contract_type(project), "納品 / 固定")
+        self.assertEqual(inline.get_contract_end_date(project), "2026-09-30")
+        self.assertEqual(inline.get_contract_total(project), "¥1,500,000")
+
+    def test_inline_contract_columns_blank_without_contract(self):
+        # A project with no contract renders "-" in each contract column (no crash on the reverse O2O).
+        project = self._make_customer_project("acme-no-contract", self.customer, date(2026, 9, 30))
+        inline = KippoProjectReadOnlyInline(KippoCustomer, self.site)
+        self.assertEqual(inline.get_contract_type(project), "-")
+        self.assertEqual(inline.get_contract_end_date(project), "-")
+        self.assertEqual(inline.get_contract_total(project), "-")
+
+    def test_inline_contract_total_shows_jisseki_for_effort_pricing(self):
+        # Effort pricing leaves total_amount blank (billed on actuals) → 実績, not a crash on _yen(None).
+        from projects.models import KippoProjectContract
+
+        project = self._make_customer_project("acme-effort", self.customer, date(2026, 9, 30))
+        KippoProjectContract.objects.create(
+            project=project,
+            billing_type="monthly",
+            pricing_basis="effort",
+            total_amount=None,
+            end_date=date(2026, 9, 30),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        inline = KippoProjectReadOnlyInline(KippoCustomer, self.site)
+        self.assertEqual(inline.get_contract_total(project), "実績")
+        self.assertEqual(inline.get_contract_type(project), "月額 / 実績")
 
     def test_compliance_check_inline_registered_and_editable(self):
         from customers.admin import KippoCustomerComplianceCheckInline
@@ -119,6 +165,18 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         url = reverse("admin:customers_kippocustomer_change", args=[self.customer.id])
         content = self.client.get(url).content.decode()
         self.assertNotIn("未完了", content)  # reminder gone once completed
+
+    def test_change_view_backfills_missing_compliance_record_and_shows_notice(self):
+        # Customers predating the auto-create signal have no compliance_check; with extra=0 and no add
+        # permission the inline would render empty and hide the notice. change_view backfills the record.
+        self.customer.compliance_check.delete()
+        self.assertFalse(KippoCustomerComplianceCheck.objects.filter(customer=self.customer).exists())
+        url = reverse("admin:customers_kippocustomer_change", args=[self.customer.id])
+        content = self.client.get(url).content.decode()
+        # the record is created on view, so the inline form and its completion notice now render
+        self.assertTrue(KippoCustomerComplianceCheck.objects.filter(customer=self.customer).exists())
+        self.assertIn("compliance_check-0-verified", content)
+        self.assertIn("反社チェックが未完了です", content)
 
     def test_compliance_inline_save_stamps_verified_by_and_datetime(self):
         from customers.admin import KippoCustomerComplianceCheckInline

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1005,8 +1005,8 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         KippoProjectContractInline,
         GithubRepositoryProjectInline,
         ProjectWeeklyEffortReadOnlyInine,
-        KippoProjectStatusReadOnlyInine,
         ProjectWeeklyEffortAdminInline,
+        KippoProjectStatusReadOnlyInine,
         KippoProjectStatusAdminInline,
     ]
     # copy-to-clipboard handler + toast for the MTG calendar link readonly fields (kippo#13)


### PR DESCRIPTION
## Summary

Three KippoCustomerAdmin / KippoProjectAdmin improvements:

### 1. 反社チェック inline message not showing (fix)
On `/admin/customers/kippocustomer/{id}/change/`, the compliance-check inline rendered empty for customers that predate the auto-create signal — with `extra=0` and no add permission the section showed nothing, so the completion notice never appeared. `KippoCustomerAdmin.change_view` now backfills the record via `get_or_create` (idempotent; same call the signal makes), so the inline form and its notice always render.

### 2. Contract columns on the project inline
`KippoProjectReadOnlyInline` (shown on the customer change page) gains three read-only columns:

| Column | Source | Empty/edge |
|---|---|---|
| **契約種別** | `請求方法 / 料金体系` (e.g. `納品 / 固定`) | `-` when no contract |
| **契約終了日** | `contract.end_date` | `-` when no contract/date |
| **契約金額** | `_yen(contract.total_amount)` | `-` (no contract); **実績** (effort pricing, blank `total_amount`) |

`select_related("contract")` added to the inline queryset to avoid an N+1.

### 3. Status inline order
`KippoProjectBaseAdmin.inlines`: moved the readonly `KippoProjectStatus` inline directly above the status-entry inline, grouping the status pair the same way the weekly-effort pair is grouped (previously `ProjectWeeklyEffortAdminInline` sat between them).

## Tests

- `test_change_view_backfills_missing_compliance_record_and_shows_notice` — deletes the record, asserts the change view recreates it and renders the notice.
- `test_inline_shows_contract_type_end_date_and_total`, `test_inline_contract_columns_blank_without_contract`, `test_inline_contract_total_shows_jisseki_for_effort_pricing`.
- Updated `test_inline_registered_and_read_only` for the new fields.

`customers.tests.test_admin` (43) and `projects.tests.test_admin` (122) pass; ruff clean.