### PR TITLE
:sparkles: expose contract_folder_url on KippoCustomerSerializer

### DIFF
--- a/kippo/customers/serializers.py
+++ b/kippo/customers/serializers.py
@@ -24,6 +24,7 @@ class KippoCustomerSerializer(serializers.ModelSerializer):
             "phone",
             "website",
             "document_url",
+            "contract_folder_url",
             "notes",
             "created_datetime",
             "updated_datetime",

--- a/kippo/customers/tests/test_viewset.py
+++ b/kippo/customers/tests/test_viewset.py
@@ -150,6 +150,23 @@ class KippoCustomerViewSetTestCase(TestCase):
         self.assertEqual(data["organization"], str(self.organization.id))
         self.assertEqual(data["organization_name"], self.organization.name)
 
+    def test_contract_folder_url_roundtrips_through_api(self):
+        """A contract_folder_url set via PATCH is returned by GET."""
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/customers/{self.customer.id}/"
+        contract_folder_url = "https://drive.example.com/contracts/acme"
+        patch_response = self.client.patch(
+            url,
+            {"contract_folder_url": contract_folder_url},
+            format="json",
+        )
+        self.assertEqual(patch_response.status_code, HTTPStatus.OK)
+        self.assertEqual(patch_response.json()["contract_folder_url"], contract_folder_url)
+
+        get_response = self.client.get(url)
+        self.assertEqual(get_response.status_code, HTTPStatus.OK)
+        self.assertEqual(get_response.json()["contract_folder_url"], contract_folder_url)
+
     def test_non_superuser_patch_cannot_reassign_organization(self):
         """Non-superuser PATCH cannot reassign customer to an org they don't belong to."""
         self.client.force_authenticate(user=self.user)


### PR DESCRIPTION
## What

Adds `contract_folder_url` to `KippoCustomerSerializer.Meta.fields`, placed right after `document_url`.

The field already exists on the `KippoCustomer` model as `URLField(blank=True, default="")` but was not exposed by the API serializer, so the kippo-ui Customers form could neither read nor edit it. It is a writable optional field (not added to `read_only_fields`).

## Why

Unblocks the kippo-ui Customers form so it can read and edit the customer's contract documents folder URL.

## Tests

Added `test_contract_folder_url_roundtrips_through_api` to `customers/tests/test_viewset.py`: PATCHes a `contract_folder_url` onto an existing customer and asserts both the PATCH response and a subsequent GET return the value. All 10 viewset tests pass.

Refs kiconiaworks/kippo#44
Part of kiconiaworks/kippo#42
