### PR TITLE
:sparkles: add project-categories list API (org-scoped)

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -166,6 +166,15 @@ class ProjectAssignmentRateSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "project_name", "created_datetime", "updated_datetime"]
 
 
+class KippoProjectOrganizationCategorySerializer(serializers.ModelSerializer):
+    """Read-only serializer for KippoProjectOrganizationCategory (project category picker)."""
+
+    class Meta:
+        model = KippoProjectOrganizationCategory
+        fields = ["id", "key", "label", "organization", "sort_order", "is_active"]
+        read_only_fields = fields
+
+
 class KippoProjectContractSerializer(serializers.ModelSerializer):
     """The project's contract (kippo#31) — billing terms. project is set from the nested route."""
 

--- a/kippo/projects/tests/test_projectcategory_viewset.py
+++ b/kippo/projects/tests/test_projectcategory_viewset.py
@@ -1,0 +1,126 @@
+"""Tests for GET /api/project-categories/ — kippo#43.
+
+Read-only, org-scoped list of selectable project categories. Backs the kippo-ui
+project create/edit form category picker (part of kippo#42).
+"""
+
+from http import HTTPStatus
+
+from accounts.models import KippoOrganization, KippoUser
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
+from django.test import TestCase
+from rest_framework.response import Response
+from rest_framework.test import APIClient
+
+from projects.models import KippoProjectOrganizationCategory
+
+
+class ProjectCategoryViewSetTestCase(TestCase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.user = created["KippoUser"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        # Another organization the user does NOT belong to.
+        self.other_org = KippoOrganization.objects.create(
+            name="other-org-for-category-test",
+            github_organization_name="otherorg-category",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        # Own-org category (active) and another active row; another-org category; an inactive own-org category.
+        self.own_category = KippoProjectOrganizationCategory.objects.create(
+            organization=self.organization,
+            key="own-active",
+            label="Own Active",
+            sort_order=10,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_category = KippoProjectOrganizationCategory.objects.create(
+            organization=self.other_org,
+            key="other-active",
+            label="Other Active",
+            sort_order=10,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.inactive_category = KippoProjectOrganizationCategory.objects.create(
+            organization=self.organization,
+            key="own-inactive",
+            label="Own Inactive",
+            sort_order=20,
+            is_active=False,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.url = f"{settings.URL_PREFIX}/api/project-categories/"
+
+    def _keys(self, response: Response) -> set[str]:
+        payload = response.json()
+        rows = payload["results"] if isinstance(payload, dict) and "results" in payload else payload
+        return {row["key"] for row in rows}
+
+    def test_unauthenticated_returns_401(self):
+        anon = APIClient()
+        response = anon.get(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_lists_globals_and_own_org_but_not_other_org(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        keys = self._keys(response)
+        # Global default category (seeded by migration, organization=null)
+        self.assertIn("other", keys)
+        # Own-org active category present
+        self.assertIn("own-active", keys)
+        # Another org's category is hidden
+        self.assertNotIn("other-active", keys)
+
+    def test_excludes_inactive_categories(self):
+        response = self.client.get(self.url)
+        keys = self._keys(response)
+        self.assertNotIn("own-inactive", keys)
+
+    def test_organization_filter_narrows_to_own_org_plus_globals(self):
+        response = self.client.get(self.url, {"organization": str(self.organization.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        keys = self._keys(response)
+        self.assertIn("own-active", keys)
+        self.assertIn("other", keys)  # globals always included
+        self.assertNotIn("other-active", keys)
+
+    def test_organization_filter_for_non_member_org_excludes_that_orgs_categories(self):
+        response = self.client.get(self.url, {"organization": str(self.other_org.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        keys = self._keys(response)
+        # User is not a member of other_org — its category must not appear, globals still do.
+        self.assertNotIn("other-active", keys)
+        self.assertIn("other", keys)
+
+    def test_response_shape(self):
+        response = self.client.get(self.url)
+        payload = response.json()
+        rows = payload["results"] if isinstance(payload, dict) and "results" in payload else payload
+        sample = next(row for row in rows if row["key"] == "own-active")
+        for field in ["id", "key", "label", "organization", "sort_order", "is_active"]:
+            self.assertIn(field, sample)
+        self.assertEqual(sample["organization"], str(self.organization.id))
+
+    def test_superuser_sees_all_active_categories(self):
+        superuser = KippoUser.objects.create(username="cat-superuser", email="su@example.com", is_superuser=True, is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        response = client.get(self.url)
+        keys = self._keys(response)
+        self.assertIn("own-active", keys)
+        self.assertIn("other-active", keys)
+        self.assertNotIn("own-inactive", keys)

--- a/kippo/projects/urls.py
+++ b/kippo/projects/urls.py
@@ -17,6 +17,7 @@ from .views import (
 from .viewsets import (
     KippoProjectBillingEntryViewSet,
     KippoProjectContractViewSet,
+    KippoProjectOrganizationCategoryViewSet,
     KippoProjectUserStatisfactionResultViewSet,
     KippoProjectViewSet,
     ProjectAssignmentRateViewSet,
@@ -29,6 +30,7 @@ from .viewsets import (
 # REST Framework router for API viewsets
 router = DefaultRouter()
 router.register(r"projects", KippoProjectViewSet, basename="kippoproject")
+router.register(r"project-categories", KippoProjectOrganizationCategoryViewSet, basename="projectcategory")
 router.register(r"assignment-rates", ProjectAssignmentRateViewSet, basename="projectassignmentrate")
 router.register(r"monthly-assignments", ProjectMonthlyAssignmentViewSet, basename="projectmonthlyassignment")
 router.register(r"monthly-costs", ProjectMonthlyCostViewSet, basename="projectmonthlycost")

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from accounts.models import KippoUser
 from django.conf import settings
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -23,6 +23,7 @@ from .models import (
     KippoProject,
     KippoProjectBillingEntry,
     KippoProjectContract,
+    KippoProjectOrganizationCategory,
     KippoProjectUserStatisfactionResult,
     ProjectAssignmentRate,
     ProjectMonthlyAssignment,
@@ -34,6 +35,7 @@ from .permissions import IsSuperuserOrOwnOrgReadUpdateCreate, IsSuperuserOrReadU
 from .serializers import (
     KippoProjectBillingEntrySerializer,
     KippoProjectContractSerializer,
+    KippoProjectOrganizationCategorySerializer,
     KippoProjectSerializer,
     KippoProjectUserStatisfactionResultSerializer,
     OrganizationMemberSerializer,
@@ -47,6 +49,53 @@ from .serializers import (
 from .services.autoassign import auto_create_future_assignments
 from .services.forecast import ProjectAssignmentForecastManager
 from .services.suggest import ProjectAssignmentSuggestionManager
+
+
+class KippoProjectOrganizationCategoryViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Read-only list of selectable project categories (kippo#43).
+
+    Backs the kippo-ui project create/edit form category picker.
+
+    **Organization Scoping:**
+    - Regular users see global default categories plus the categories of organizations they belong to.
+    - Superusers see all active categories.
+
+    **Filtering:**
+    - organization: UUID filter — narrows to that organization's categories (intersected with the
+      user's memberships) while still including the global defaults.
+
+    **Permissions:**
+    - Read (GET): Authenticated users (organization-scoped for regular users).
+    """
+
+    serializer_class = KippoProjectOrganizationCategorySerializer
+    permission_classes = [IsAuthenticated]
+    queryset = KippoProjectOrganizationCategory.objects.filter(is_active=True).order_by("sort_order", "label")
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name="organization", description="Filter by organization UUID (globals always included)", required=False, type=str),
+        ]
+    )
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
+        return super().list(request, *args, **kwargs)
+
+    def get_queryset(self):
+        """Globals + the user's organization categories; superusers see all active categories."""
+        queryset = super().get_queryset()
+        user = self.request.user
+        organization = self.request.query_params.get("organization", None)
+
+        if user.is_superuser:
+            if organization:
+                queryset = queryset.filter(Q(organization__isnull=True) | Q(organization=organization))
+            return queryset
+
+        user_organizations = list(user.organizationmembership_set.values_list("organization", flat=True))
+        if organization and organization in {str(org_id) for org_id in user_organizations}:
+            return queryset.filter(Q(organization__isnull=True) | Q(organization=organization))
+        return queryset.filter(Q(organization__isnull=True) | Q(organization__in=user_organizations))
 
 
 class KippoProjectViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary

Adds a read-only, org-scoped `GET /api/project-categories/` list endpoint so the kippo-ui project create/edit form can populate its category picker.

## Endpoint

`GET /api/project-categories/` (deployed: `/prod/api/project-categories/`)

- ViewSet: `KippoProjectOrganizationCategoryViewSet` (`ReadOnlyModelViewSet`, `IsAuthenticated`).
- Serializer: `KippoProjectOrganizationCategorySerializer` exposing `id`, `key`, `label`, `organization` (nullable), `sort_order`, `is_active` (all read-only).
- Backed by the existing `KippoProjectOrganizationCategory` model — no migration needed.

## Org scoping

- Only active categories (`is_active=True`) are returned.
- Regular users see global default categories (`organization=null`) plus the categories of organizations they belong to; another org's categories are hidden.
- Superusers see all active categories.
- Optional `?organization=<uuid>` narrows to that organization (intersected with the user's memberships) while always including the global defaults.

Follows the existing `KippoCustomerViewSet` pattern (drf-spectacular `extend_schema`/`OpenApiParameter`, org-membership-filtered `get_queryset`).

## Tests

Adds `projects/tests/test_projectcategory_viewset.py` (7 tests, all passing): globals + own-org visible, other-org hidden, inactive excluded, `?organization=` narrowing (member + non-member orgs), response shape, superuser sees all, unauthenticated -> 401.

This unblocks the kippo-ui project category picker.

Refs kiconiaworks/kippo#43
Part of kiconiaworks/kippo#42