### PR TITLE
:sparkles: add customer changelist-parity API (#45)

### DIFF
--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -1,6 +1,5 @@
 import datetime
 import urllib.parse
-from collections import defaultdict
 from collections.abc import Iterator
 
 from accounts.models import KippoOrganization, KippoUser
@@ -11,8 +10,7 @@ from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.contrib.admin.views.main import ChangeList
 from django.db import models
-from django.db.models import Count, IntegerField, OuterRef, Prefetch, Subquery, Sum
-from django.db.models.functions import Coalesce
+from django.db.models import Prefetch
 from django.forms import BaseFormSet, Form
 from django.http import request as DjangoRequest  # noqa: N812
 from django.urls import reverse
@@ -21,34 +19,19 @@ from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 from projects.admin import RETURN_TO_PARAM
 from projects.functions import get_user_session_organization
-from projects.models import KippoProject, KippoProjectBillingEntry, KippoProjectContract
+from projects.models import KippoProject, KippoProjectBillingEntry
 
+from customers.functions import (
+    ACTIVE_PROJECT_COUNT,
+    active_projects_contract_total,
+    fiscal_year_org_summaries,
+    project_received_total_current_fy,
+    shift_fiscal_year,
+)
 from customers.models import KippoCustomer, KippoCustomerComplianceCheck
 
-# A customer's active (open + display_as_active) project count. A correlated Subquery (a scalar
-# expression), NOT an aggregate: Django 5.2 forbids ordering by an aggregate that isn't also in
-# annotate(), and get_ordering() is applied to bare manager querysets (no annotation) when Django
-# builds FK form fields via get_field_queryset(). A scalar Subquery orders correctly anywhere.
-# Coalesce(..., 0) so customers with no active projects sort/display as 0 rather than NULL.
-ACTIVE_PROJECT_COUNT = Coalesce(
-    Subquery(
-        KippoProject.objects.filter(customer=OuterRef("pk"), is_closed=False, display_as_active=True)
-        .order_by()
-        .values("customer")
-        .annotate(count=Count("pk"))
-        .values("count"),
-        output_field=IntegerField(),
-    ),
-    0,
-)
-
-
-MONTHS_PER_YEAR = 12
-
-
-def _shift_fiscal_year(fiscal_year_start: datetime.date, years: int) -> datetime.date:
-    """The fiscal-year boundary ``years`` away from ``fiscal_year_start`` (same month, day 1)."""
-    return datetime.date(fiscal_year_start.year + years, fiscal_year_start.month, 1)
+# The reusable fiscal-year / summary / per-project computations live in customers.functions (shared
+# with KippoCustomerViewSet). This admin formats their raw values as ¥-strings for the changelist.
 
 
 def _visible_organizations(user: KippoUser) -> models.QuerySet:
@@ -88,8 +71,8 @@ class CustomerEndingProjectsFilter(admin.SimpleListFilter):
         for organization in _visible_organizations(request.user):
             fiscal_year_start = organization.current_fiscal_year_start()
             # last two fiscal years = previous FY start (one year back) through current FY end (one year forward)
-            window_start = _shift_fiscal_year(fiscal_year_start, -1)
-            window_end = _shift_fiscal_year(fiscal_year_start, 1)
+            window_start = shift_fiscal_year(fiscal_year_start, -1)
+            window_end = shift_fiscal_year(fiscal_year_start, 1)
             qualifying = (
                 KippoCustomer.objects.filter(
                     organization=organization,
@@ -303,13 +286,8 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # organization fiscalyear_start_month, relative to today in the organization's timezone).
         fiscal_year_start = obj.organization.current_fiscal_year_start()
         active_projects = getattr(obj, "active_projects", ())
-        # Sum of each active project's contract total (契約金額). Projects without a contract, or whose
-        # contract leaves total_amount blank (effort pricing), contribute 0 — so the parenthesised total
-        # next to the count is Σ contracted amounts across the customer's active projects.
-        contract_total = sum(
-            (project.contract.total_amount for project in active_projects if getattr(project, "contract", None) and project.contract.total_amount),
-            0,
-        )
+        # Σ each active project's contract total (契約金額) — the parenthesised total next to the count.
+        contract_total = active_projects_contract_total(list(active_projects))
         rows = format_html_join(
             "",
             "<tr><td>{}</td><td style='text-align:right'>{}</td><td style='text-align:right'>{}</td><td>{}</td></tr>",
@@ -339,7 +317,7 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         or after the fiscal-year start so the total is the current fiscal year's received revenue.
         """
         contract = getattr(project, "contract", None)
-        received = sum((entry.amount for entry in contract.billing_entries.all() if entry.billing_date >= fiscal_year_start), 0) if contract else 0
+        received = project_received_total_current_fy(project, fiscal_year_start)
         name_link = format_html('<a href="{}">{}</a>', project.get_admin_url(), project.name)
         total_display = _yen(contract.total_amount) if contract else "-"
         end_display = contract.end_date.isoformat() if contract and contract.end_date else "-"
@@ -354,81 +332,27 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         return response
 
     @staticmethod
-    def _fiscal_year_months(fiscal_year_start: datetime.date) -> list[datetime.date]:
-        """The 12 first-of-month dates of the fiscal year starting at ``fiscal_year_start``."""
-        months = []
-        month = fiscal_year_start
-        for offset in range(MONTHS_PER_YEAR):
-            month_index = (fiscal_year_start.month - 1 + offset) % MONTHS_PER_YEAR + 1
-            year = fiscal_year_start.year + (fiscal_year_start.month - 1 + offset) // MONTHS_PER_YEAR
-            month = datetime.date(year, month_index, 1)
-            months.append(month)
-        return months
-
-    @classmethod
-    def _monthly_planned_breakdown(cls, customer_pks: list, fiscal_year_start: datetime.date, fiscal_year_end: datetime.date) -> list[dict]:
-        """Per-month planned contract totals across ``customer_pks`` contracts for the current FY.
-
-        Each contract's planned billing schedule (monthly contracts spread per month, delivery at
-        end_date — KippoProjectContract.planned_billing_schedule) is bucketed into the FY month its
-        billing_date falls in. Contracts that bill outside the FY contribute nothing.
-        """
-        fiscal_year_months = cls._fiscal_year_months(fiscal_year_start)
-        monthly_totals = dict.fromkeys(fiscal_year_months, 0)
-        # Only contracts that can bill on/after the FY start are relevant — one ending before it bills
-        # nothing in the FY. Bounds the per-contract schedule work (effort contracts compute per month).
-        contracts = (
-            KippoProjectContract.objects.filter(project__customer__in=customer_pks, end_date__gte=fiscal_year_start)
-            .select_related("project__organization")
-            .prefetch_related("project__assignment_rates")
-        )
-        for contract in contracts:
-            for billing_date, amount in contract.planned_billing_schedule():
-                if amount and fiscal_year_start <= billing_date < fiscal_year_end:
-                    monthly_totals[datetime.date(billing_date.year, billing_date.month, 1)] += amount
-        return [{"month": month.strftime("%Y/%m"), "amount_display": _yen(monthly_totals[month])} for month in fiscal_year_months]
-
-    @classmethod
-    def _fiscal_year_org_summaries(cls, customers: models.QuerySet) -> list[dict]:
+    def _fiscal_year_org_summaries(customers: models.QuerySet) -> list[dict]:
         """Per-organization current-fiscal-year summary for the header, scoped to the (filtered)
-        ``customers`` shown on the changelist. Per org: customer count; 'contracts planned to complete
-        this FY' = those customers' contracts whose end_date falls in the current FY; planned total =
-        Σ their total_amount; received total = Σ their received billing-entry amounts; and a
-        month-by-month planned-billing breakdown across the FY.
+        ``customers`` shown on the changelist. The raw per-org aggregates come from the shared
+        customers.functions.fiscal_year_org_summaries (the source of truth shared with the API); this
+        formats them into the ¥-strings the header template renders.
         """
-        customer_pks_by_org: dict = defaultdict(list)
-        for customer_pk, organization_id in customers.values_list("pk", "organization_id"):
-            customer_pks_by_org[organization_id].append(customer_pk)
-
-        organizations = {org.pk: org for org in KippoOrganization.objects.filter(pk__in=customer_pks_by_org)}
-        summaries = []
-        for organization_id, customer_pks in customer_pks_by_org.items():
-            organization = organizations[organization_id]
-            fiscal_year_start = organization.current_fiscal_year_start()
-            fiscal_year_end = _shift_fiscal_year(fiscal_year_start, 1)
-            contracts = KippoProjectContract.objects.filter(
-                project__customer__in=customer_pks,
-                end_date__gte=fiscal_year_start,
-                end_date__lt=fiscal_year_end,
-            )
-            # count + planned total are over the same contracts queryset → one aggregate query
-            contract_summary = contracts.aggregate(count=Count("pk"), total=Sum("total_amount"))
-            received_total = (
-                KippoProjectBillingEntry.objects.filter(contract__in=contracts, is_received=True).aggregate(total=Sum("amount"))["total"] or 0
-            )
-            summaries.append(
-                {
-                    "organization": organization.name,
-                    "fiscal_year_start": fiscal_year_start,
-                    "fiscal_year_end": fiscal_year_end,
-                    "customer_count": len(customer_pks),
-                    "project_count": contract_summary["count"],
-                    "received_total_display": _yen(received_total),
-                    "planned_total_display": _yen(contract_summary["total"] or 0),
-                    "monthly_planned_breakdown": cls._monthly_planned_breakdown(customer_pks, fiscal_year_start, fiscal_year_end),
-                }
-            )
-        return sorted(summaries, key=lambda summary: summary["organization"])
+        return [
+            {
+                "organization": summary["organization"].name,
+                "fiscal_year_start": summary["fiscal_year_start"],
+                "fiscal_year_end": summary["fiscal_year_end"],
+                "customer_count": summary["customer_count"],
+                "project_count": summary["project_count"],
+                "received_total_display": _yen(summary["received_total"]),
+                "planned_total_display": _yen(summary["planned_total"]),
+                "monthly_planned_breakdown": [
+                    {"month": row["month"], "amount_display": _yen(row["amount"])} for row in summary["monthly_planned_breakdown"]
+                ],
+            }
+            for summary in fiscal_year_org_summaries(customers)
+        ]
 
     @admin.display(boolean=True, description=_("反社チェック"))
     def get_compliance_verified(self, obj: KippoCustomer) -> bool:

--- a/kippo/customers/functions.py
+++ b/kippo/customers/functions.py
@@ -1,0 +1,135 @@
+"""Reusable fiscal-year / summary / per-project computations for the customer changelist parity.
+
+The single source of truth for the customer-changelist aggregates shared by ``KippoCustomerAdmin``
+(which formats the raw values as ``¥``-strings) and ``KippoCustomerViewSet`` (which returns the raw
+decimals/numbers for the UI to format). Keeping the math here avoids drift between the two surfaces.
+"""
+
+import datetime
+from collections import defaultdict
+from decimal import Decimal
+
+from accounts.models import KippoOrganization
+from django.db import models
+from django.db.models import Count, IntegerField, OuterRef, Subquery, Sum
+from django.db.models.functions import Coalesce
+from projects.models import KippoProject, KippoProjectBillingEntry, KippoProjectContract
+
+MONTHS_PER_YEAR = 12
+
+# A customer's active (open + display_as_active) project count as a correlated scalar Subquery (NOT
+# an aggregate), so it orders/annotates correctly on any queryset. Coalesce(..., 0) so customers
+# with no active projects render 0 rather than NULL. (Mirrors admin.ACTIVE_PROJECT_COUNT.)
+ACTIVE_PROJECT_COUNT = Coalesce(
+    Subquery(
+        KippoProject.objects.filter(customer=OuterRef("pk"), is_closed=False, display_as_active=True)
+        .order_by()
+        .values("customer")
+        .annotate(count=Count("pk"))
+        .values("count"),
+        output_field=IntegerField(),
+    ),
+    0,
+)
+
+
+def shift_fiscal_year(fiscal_year_start: datetime.date, years: int) -> datetime.date:
+    """The fiscal-year boundary ``years`` away from ``fiscal_year_start`` (same month, day 1)."""
+    return datetime.date(fiscal_year_start.year + years, fiscal_year_start.month, 1)
+
+
+def fiscal_year_months(fiscal_year_start: datetime.date) -> list[datetime.date]:
+    """The 12 first-of-month dates of the fiscal year starting at ``fiscal_year_start``."""
+    months = []
+    for offset in range(MONTHS_PER_YEAR):
+        month_index = (fiscal_year_start.month - 1 + offset) % MONTHS_PER_YEAR + 1
+        year = fiscal_year_start.year + (fiscal_year_start.month - 1 + offset) // MONTHS_PER_YEAR
+        months.append(datetime.date(year, month_index, 1))
+    return months
+
+
+def active_projects_contract_total(active_projects: list) -> Decimal:
+    """Σ contract ``total_amount`` across the given active projects. Projects without a contract, or
+    whose contract leaves ``total_amount`` blank (effort pricing), contribute 0.
+    """
+    return sum(
+        (project.contract.total_amount for project in active_projects if getattr(project, "contract", None) and project.contract.total_amount),
+        Decimal(0),
+    )
+
+
+def project_received_total_current_fy(project: KippoProject, fiscal_year_start: datetime.date) -> Decimal:
+    """Σ a project's received billing-entry amounts billed on/after ``fiscal_year_start``.
+
+    Expects the project's contract billing_entries to already be filtered to ``is_received=True``
+    (the changelist prefetch does this); the fiscal-year cutoff is applied here per entry.
+    """
+    contract = getattr(project, "contract", None)
+    if not contract:
+        return Decimal(0)
+    return sum((entry.amount for entry in contract.billing_entries.all() if entry.billing_date >= fiscal_year_start), Decimal(0))
+
+
+def monthly_planned_breakdown(customer_pks: list, fiscal_year_start: datetime.date, fiscal_year_end: datetime.date) -> dict[datetime.date, Decimal]:
+    """Per-FY-month planned contract totals across ``customer_pks`` contracts, keyed by first-of-month.
+
+    Each contract's planned billing schedule (KippoProjectContract.planned_billing_schedule) is
+    bucketed into the FY month its billing_date falls in. Contracts billing outside the FY contribute
+    nothing. Every FY month is present (0 when nothing bills that month).
+    """
+    months = fiscal_year_months(fiscal_year_start)
+    monthly_totals: dict[datetime.date, Decimal] = {month: Decimal(0) for month in months}
+    # Only contracts that can bill on/after the FY start are relevant; bounds the per-contract schedule work.
+    contracts = (
+        KippoProjectContract.objects.filter(project__customer__in=customer_pks, end_date__gte=fiscal_year_start)
+        .select_related("project__organization")
+        .prefetch_related("project__assignment_rates")
+    )
+    for contract in contracts:
+        for billing_date, amount in contract.planned_billing_schedule():
+            if amount and fiscal_year_start <= billing_date < fiscal_year_end:
+                monthly_totals[datetime.date(billing_date.year, billing_date.month, 1)] += amount
+    return monthly_totals
+
+
+def fiscal_year_org_summaries(customers: models.QuerySet) -> list[dict]:
+    """Per-organization current-fiscal-year summary scoped to the (filtered) ``customers``, with RAW
+    decimal/number values (no ``¥`` formatting). Per org: customer count; contracts whose end_date
+    falls in the current FY (count + planned total); received total; month-by-month planned breakdown.
+    Sorted by organization name.
+
+    The shared source of truth — ``KippoCustomerAdmin`` formats these raw values; the API returns them.
+    """
+    customer_pks_by_org: dict = defaultdict(list)
+    for customer_pk, organization_id in customers.values_list("pk", "organization_id"):
+        customer_pks_by_org[organization_id].append(customer_pk)
+
+    organizations = {org.pk: org for org in KippoOrganization.objects.filter(pk__in=customer_pks_by_org)}
+    summaries = []
+    for organization_id, customer_pks in customer_pks_by_org.items():
+        organization = organizations[organization_id]
+        fiscal_year_start = organization.current_fiscal_year_start()
+        fiscal_year_end = shift_fiscal_year(fiscal_year_start, 1)
+        contracts = KippoProjectContract.objects.filter(
+            project__customer__in=customer_pks,
+            end_date__gte=fiscal_year_start,
+            end_date__lt=fiscal_year_end,
+        )
+        contract_summary = contracts.aggregate(count=Count("pk"), total=Sum("total_amount"))
+        received_total = KippoProjectBillingEntry.objects.filter(contract__in=contracts, is_received=True).aggregate(total=Sum("amount"))[
+            "total"
+        ] or Decimal(0)
+        breakdown = monthly_planned_breakdown(customer_pks, fiscal_year_start, fiscal_year_end)
+        summaries.append(
+            {
+                "organization": organization,
+                "fiscal_year_start": fiscal_year_start,
+                "fiscal_year_end": fiscal_year_end,
+                "customer_count": len(customer_pks),
+                "project_count": contract_summary["count"],
+                "planned_total": contract_summary["total"] or Decimal(0),
+                "received_total": received_total,
+                "monthly_planned_breakdown": [{"month": month.strftime("%Y/%m"), "amount": amount} for month, amount in breakdown.items()],
+            }
+        )
+    return sorted(summaries, key=lambda summary: summary["organization"].name)

--- a/kippo/customers/serializers.py
+++ b/kippo/customers/serializers.py
@@ -1,7 +1,9 @@
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from rest_framework import serializers
 
+from customers.functions import active_projects_contract_total
 from customers.models import KippoCustomer
 
 if TYPE_CHECKING:
@@ -9,9 +11,17 @@ if TYPE_CHECKING:
 
 
 class KippoCustomerSerializer(serializers.ModelSerializer):
-    """Serializer for KippoCustomer model."""
+    """Serializer for KippoCustomer model.
+
+    Changelist-parity read-only additions (kippo#45): ``active_project_count`` (annotated scalar
+    Subquery in the viewset), ``active_projects_contract_total`` (Σ active projects' contract totals,
+    from the prefetched active-projects set), and ``compliance_verified``.
+    """
 
     organization_name = serializers.CharField(source="organization.name", read_only=True)
+    active_project_count = serializers.IntegerField(read_only=True)
+    active_projects_contract_total = serializers.SerializerMethodField()
+    compliance_verified = serializers.SerializerMethodField()
 
     class Meta:
         model = KippoCustomer
@@ -26,10 +36,30 @@ class KippoCustomerSerializer(serializers.ModelSerializer):
             "document_url",
             "contract_folder_url",
             "notes",
+            "active_project_count",
+            "active_projects_contract_total",
+            "compliance_verified",
             "created_datetime",
             "updated_datetime",
         ]
-        read_only_fields = ["id", "organization_name", "created_datetime", "updated_datetime"]
+        read_only_fields = [
+            "id",
+            "organization_name",
+            "active_project_count",
+            "active_projects_contract_total",
+            "compliance_verified",
+            "created_datetime",
+            "updated_datetime",
+        ]
+
+    def get_active_projects_contract_total(self, obj: KippoCustomer) -> Decimal:
+        # ``active_projects`` is prefetched by the viewset (to_attr); fall back to () so a detail/create
+        # response (no prefetch) returns 0 rather than raising.
+        return active_projects_contract_total(list(getattr(obj, "active_projects", ())))
+
+    def get_compliance_verified(self, obj: KippoCustomer) -> bool:
+        compliance_check = getattr(obj, "compliance_check", None)
+        return bool(compliance_check and compliance_check.verified)
 
     def validate_organization(self, value: "KippoOrganization") -> "KippoOrganization":
         request = self.context.get("request")
@@ -39,3 +69,48 @@ class KippoCustomerSerializer(serializers.ModelSerializer):
         if value.id not in user_org_ids:
             raise serializers.ValidationError("You can only create/update customers in organizations you belong to.")
         return value
+
+
+class CustomerActiveProjectSerializer(serializers.Serializer):
+    """One active project row for GET /api/customers/{id}/active-projects/ (mirrors the admin's
+    expandable active-project detail). ``received_total_current_fy`` is set by the viewset.
+    """
+
+    id = serializers.UUIDField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    contract_amount = serializers.SerializerMethodField()
+    contract_end_date = serializers.SerializerMethodField()
+    received_total_current_fy = serializers.DecimalField(max_digits=14, decimal_places=0, read_only=True)
+
+    def get_contract_amount(self, obj) -> Decimal | None:  # noqa: ANN001 (obj is a KippoProject; left unannotated so drf-spectacular need not import it)
+        contract = getattr(obj, "contract", None)
+        return contract.total_amount if contract else None
+
+    def get_contract_end_date(self, obj) -> str | None:  # noqa: ANN001
+        contract = getattr(obj, "contract", None)
+        return contract.end_date.isoformat() if contract and contract.end_date else None
+
+
+class FiscalYearMonthlyBreakdownSerializer(serializers.Serializer):
+    """One FY-month planned-billing total: {"month": "YYYY/MM", "amount": decimal}."""
+
+    month = serializers.CharField()
+    amount = serializers.DecimalField(max_digits=16, decimal_places=0)
+
+
+class FiscalYearSummaryOrganizationSerializer(serializers.Serializer):
+    id = serializers.UUIDField()
+    name = serializers.CharField()
+
+
+class FiscalYearSummarySerializer(serializers.Serializer):
+    """Per-organization current-fiscal-year summary for GET /api/customers/fiscal-year-summary/."""
+
+    organization = FiscalYearSummaryOrganizationSerializer()
+    fiscal_year_start = serializers.DateField()
+    fiscal_year_end = serializers.DateField()
+    customer_count = serializers.IntegerField()
+    project_count = serializers.IntegerField()
+    planned_total = serializers.DecimalField(max_digits=16, decimal_places=0)
+    received_total = serializers.DecimalField(max_digits=16, decimal_places=0)
+    monthly_planned_breakdown = FiscalYearMonthlyBreakdownSerializer(many=True)

--- a/kippo/customers/tests/test_viewset.py
+++ b/kippo/customers/tests/test_viewset.py
@@ -1,9 +1,13 @@
+from datetime import date, timedelta
+from decimal import Decimal
 from http import HTTPStatus
 
 from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
-from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from commons.tests import DEFAULT_COLUMNSET_PK, DEFAULT_FIXTURES, default_project_category, setup_basic_project
 from django.conf import settings
 from django.test import TestCase
+from django.utils import timezone
+from projects.models import KippoProject, KippoProjectBillingEntry, KippoProjectContract, ProjectColumnSet
 from rest_framework.test import APIClient
 
 from customers.models import KippoCustomer
@@ -193,3 +197,240 @@ class KippoCustomerViewSetTestCase(TestCase):
         response = self.client.delete(url)
         self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertFalse(KippoCustomer.objects.filter(id=self.customer.id).exists())
+
+
+class KippoCustomerChangelistParityTestCase(TestCase):
+    """Changelist-parity API additions (kippo#45): list aggregates + compliance, recent_ending filter,
+    active-projects action, and the per-organization fiscal-year-summary action.
+    """
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        # FY starts in January → current FY = this (JST) calendar year; predictable date math.
+        self.organization.fiscalyear_start_month = 1
+        self.organization.save()
+        self.user = created["KippoUser"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+        self.columnset = ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK)
+
+        # second org + a user who only belongs to it (for org-scoping checks)
+        self.other_organization = KippoOrganization.objects.create(
+            name="other-test-org",
+            github_organization_name="other-test-org",
+            fiscalyear_start_month=1,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_user = KippoUser.objects.create(username="otheruser", github_login="otheruser", email="otheruser@example.com", is_staff=True)
+        OrganizationMembership.objects.create(
+            user=self.other_user,
+            organization=self.other_organization,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+            is_developer=True,
+        )
+
+        self.customer = KippoCustomer.objects.create(organization=self.organization, name="Acme Corp", created_by=self.user, updated_by=self.user)
+        self.empty_customer = KippoCustomer.objects.create(
+            organization=self.organization, name="Zeta (no projects)", created_by=self.user, updated_by=self.user
+        )
+        self.other_customer = KippoCustomer.objects.create(
+            organization=self.other_organization, name="Globex", created_by=self.github_manager, updated_by=self.github_manager
+        )
+        self.today = timezone.localdate()
+        self.fy_start = date(self.today.year, 1, 1)
+        self.client = APIClient()
+
+    def _make_project(self, name: str, customer: KippoCustomer, target_date: date, **kwargs) -> KippoProject:
+        return KippoProject.objects.create(
+            organization=customer.organization,
+            name=name,
+            category=default_project_category(),
+            columnset=self.columnset,
+            customer=customer,
+            target_date=target_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+            **kwargs,
+        )
+
+    def _make_contract(self, project: KippoProject, total: str | None, end_date: date, **kwargs) -> KippoProjectContract:
+        return KippoProjectContract.objects.create(
+            project=project,
+            billing_type=kwargs.pop("billing_type", "delivery"),
+            pricing_basis=kwargs.pop("pricing_basis", "fixed" if total else "effort"),
+            total_amount=Decimal(total) if total is not None else None,
+            end_date=end_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+            **kwargs,
+        )
+
+    def _result_for(self, data: dict, customer: KippoCustomer) -> dict:
+        return next(r for r in data["results"] if r["id"] == str(customer.id))
+
+    # --- (a) list scalar fields ------------------------------------------------------------------
+
+    def test_list_returns_new_scalar_fields_for_customer_with_active_projects(self):
+        active = self._make_project("acme-active", self.customer, date(self.today.year, 9, 30))
+        self._make_contract(active, "1500000", date(self.today.year, 9, 30))
+        # a closed project should not count toward active_project_count / contract total
+        closed = self._make_project("acme-closed", self.customer, date(self.today.year, 8, 31), is_closed=True)
+        self._make_contract(closed, "9999999", date(self.today.year, 8, 31))
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        row = self._result_for(response.json(), self.customer)
+        self.assertEqual(row["active_project_count"], 1)
+        self.assertEqual(Decimal(row["active_projects_contract_total"]), Decimal("1500000"))
+        self.assertFalse(row["compliance_verified"])
+
+    def test_list_zero_aggregates_for_customer_without_projects(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/")
+        row = self._result_for(response.json(), self.empty_customer)
+        self.assertEqual(row["active_project_count"], 0)
+        self.assertEqual(Decimal(row["active_projects_contract_total"]), Decimal("0"))
+
+    def test_list_compliance_verified_true_when_check_verified(self):
+        check = self.customer.compliance_check
+        check.verified = True
+        check.save()
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/")
+        self.assertTrue(self._result_for(response.json(), self.customer)["compliance_verified"])
+
+    # --- (b) recent_ending filter ----------------------------------------------------------------
+
+    def test_recent_ending_includes_customer_with_project_in_window(self):
+        # target_date in the current FY → within [prev-FY-start, current-FY-end)
+        self._make_project("acme-this-fy", self.customer, date(self.today.year, 6, 30))
+        # other customer's project ends well outside the window (next FY) → excluded
+        self._make_project("zeta-future", self.empty_customer, date(self.today.year + 2, 6, 30))
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/?recent_ending=true")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        ids = [r["id"] for r in response.json()["results"]]
+        self.assertIn(str(self.customer.id), ids)
+        self.assertNotIn(str(self.empty_customer.id), ids)
+
+    def test_recent_ending_excludes_project_before_window(self):
+        # target_date one day before the previous-FY start → outside the 2-FY window
+        prev_fy_start = date(self.today.year - 1, 1, 1)
+        self._make_project("acme-old", self.customer, prev_fy_start - timedelta(days=1))
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/?recent_ending=true")
+        self.assertNotIn(str(self.customer.id), [r["id"] for r in response.json()["results"]])
+
+    # --- (c) active-projects action --------------------------------------------------------------
+
+    def test_active_projects_action_rows_and_received_total_honors_fy_cutoff(self):
+        project = self._make_project("acme-billed", self.customer, date(self.today.year, 9, 30))
+        contract = self._make_contract(project, "2000000", date(self.today.year, 9, 30))
+        # received on/after FY start → counted
+        KippoProjectBillingEntry.objects.create(contract=contract, billing_date=self.fy_start, amount=Decimal("500000"), is_received=True)
+        # received but before FY start → excluded by the cutoff
+        KippoProjectBillingEntry.objects.create(
+            contract=contract, billing_date=self.fy_start - timedelta(days=1), amount=Decimal("900000"), is_received=True
+        )
+        # within FY but not received → excluded
+        KippoProjectBillingEntry.objects.create(
+            contract=contract, billing_date=self.fy_start + timedelta(days=5), amount=Decimal("700000"), is_received=False
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/{self.customer.id}/active-projects/")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        rows = response.json()
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["id"], str(project.id))
+        self.assertEqual(row["name"], "acme-billed")
+        self.assertEqual(Decimal(row["contract_amount"]), Decimal("2000000"))
+        self.assertEqual(row["contract_end_date"], date(self.today.year, 9, 30).isoformat())
+        self.assertEqual(Decimal(row["received_total_current_fy"]), Decimal("500000"))
+
+    def test_active_projects_action_null_contract_fields_without_contract(self):
+        self._make_project("acme-no-contract", self.customer, date(self.today.year, 9, 30))
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/{self.customer.id}/active-projects/")
+        row = response.json()[0]
+        self.assertIsNone(row["contract_amount"])
+        self.assertIsNone(row["contract_end_date"])
+        self.assertEqual(Decimal(row["received_total_current_fy"]), Decimal("0"))
+
+    # --- (d) fiscal-year-summary action ----------------------------------------------------------
+
+    def test_fiscal_year_summary_totals_and_monthly_breakdown(self):
+        # delivery contract ending in March → whole total in its end month; received entry counted
+        delivery = self._make_project("delivery", self.customer, date(self.today.year, 3, 31))
+        delivery_contract = self._make_contract(delivery, "3000000", date(self.today.year, 3, 31))
+        KippoProjectBillingEntry.objects.create(
+            contract=delivery_contract, billing_date=date(self.today.year, 3, 31), amount=Decimal("1000000"), is_received=True
+        )
+        # monthly fixed Apr–Jun (3 months) → 1,200,000 split 400,000/month
+        monthly = self._make_project("monthly", self.customer, date(self.today.year, 6, 30))
+        self._make_contract(monthly, "1200000", date(self.today.year, 6, 30), billing_type="monthly", start_date=date(self.today.year, 4, 1))
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/fiscal-year-summary/")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        summary = next(s for s in response.json() if s["organization"]["name"] == self.organization.name)
+        self.assertEqual(summary["organization"]["id"], str(self.organization.id))
+        self.assertEqual(summary["fiscal_year_start"], self.fy_start.isoformat())
+        self.assertEqual(summary["fiscal_year_end"], date(self.today.year + 1, 1, 1).isoformat())
+        self.assertEqual(summary["project_count"], 2)  # both contracts end this FY
+        self.assertEqual(Decimal(summary["planned_total"]), Decimal("4200000"))
+        self.assertEqual(Decimal(summary["received_total"]), Decimal("1000000"))
+        breakdown = {row["month"]: Decimal(row["amount"]) for row in summary["monthly_planned_breakdown"]}
+        self.assertEqual(len(summary["monthly_planned_breakdown"]), 12)
+        self.assertEqual(breakdown[f"{self.today.year}/03"], Decimal("3000000"))
+        self.assertEqual(breakdown[f"{self.today.year}/04"], Decimal("400000"))
+        self.assertEqual(breakdown[f"{self.today.year}/05"], Decimal("400000"))
+        self.assertEqual(breakdown[f"{self.today.year}/06"], Decimal("400000"))
+        self.assertEqual(breakdown[f"{self.today.year}/01"], Decimal("0"))
+
+    def test_fiscal_year_summary_respects_recent_ending(self):
+        # customer A: a project ending this FY (qualifies for recent_ending) + a contract ending this FY
+        ending = self._make_project("acme-ending", self.customer, date(self.today.year, 6, 30))
+        self._make_contract(ending, "2000000", date(self.today.year, 6, 30))
+        # customer B (empty_customer): a contract ending this FY but its project ends far in the future
+        # → excluded by recent_ending, so its planned total drops out of the summary
+        far = self._make_project("zeta-far", self.empty_customer, date(self.today.year + 2, 6, 30))
+        self._make_contract(far, "5000000", date(self.today.year, 6, 30))
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/fiscal-year-summary/?recent_ending=true")
+        summary = next(s for s in response.json() if s["organization"]["name"] == self.organization.name)
+        self.assertEqual(summary["customer_count"], 1)  # only customer A is in scope
+        self.assertEqual(Decimal(summary["planned_total"]), Decimal("2000000"))
+
+    # --- (e) org-scoping -------------------------------------------------------------------------
+
+    def test_other_org_customer_excluded_from_list_and_summary(self):
+        self._make_project("globex-proj", self.other_customer, date(self.today.year, 6, 30))
+        self.client.force_authenticate(user=self.user)
+        list_ids = [r["id"] for r in self.client.get(f"{settings.URL_PREFIX}/api/customers/").json()["results"]]
+        self.assertNotIn(str(self.other_customer.id), list_ids)
+        summary = self.client.get(f"{settings.URL_PREFIX}/api/customers/fiscal-year-summary/").json()
+        self.assertNotIn(self.other_organization.name, [s["organization"]["name"] for s in summary])
+
+    def test_active_projects_other_org_customer_returns_404(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/{self.other_customer.id}/active-projects/")
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    # --- (f) auth --------------------------------------------------------------------------------
+
+    def test_unauthenticated_list_rejected(self):
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/")
+        self.assertIn(response.status_code, (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))
+
+    def test_unauthenticated_fiscal_year_summary_rejected(self):
+        response = self.client.get(f"{settings.URL_PREFIX}/api/customers/fiscal-year-summary/")
+        self.assertIn(response.status_code, (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))

--- a/kippo/customers/viewsets.py
+++ b/kippo/customers/viewsets.py
@@ -1,14 +1,40 @@
 from typing import Any
 
+from accounts.models import KippoOrganization
+from django.db.models import Prefetch, Q
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
+from projects.models import KippoProject, KippoProjectBillingEntry
 from projects.permissions import IsSuperuserOrReadUpdateCreateOwn
 from rest_framework import viewsets
+from rest_framework.decorators import action
 from rest_framework.filters import SearchFilter
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from customers.functions import ACTIVE_PROJECT_COUNT, fiscal_year_org_summaries, project_received_total_current_fy, shift_fiscal_year
 from customers.models import KippoCustomer
-from customers.serializers import KippoCustomerSerializer
+from customers.serializers import (
+    CustomerActiveProjectSerializer,
+    FiscalYearSummarySerializer,
+    KippoCustomerSerializer,
+)
+
+
+def _active_projects_prefetch() -> Prefetch:
+    """Active (open + display_as_active) projects with their contract + received billing entries —
+    backing the list aggregates and the active-projects detail action. Mirrors the admin prefetch.
+    """
+    return Prefetch(
+        "projects",
+        queryset=(
+            KippoProject.objects.filter(is_closed=False, display_as_active=True)
+            .select_related("contract")
+            .prefetch_related(Prefetch("contract__billing_entries", queryset=KippoProjectBillingEntry.objects.filter(is_received=True)))
+            .order_by("name")
+        ),
+        to_attr="active_projects",
+    )
 
 
 class KippoCustomerViewSet(viewsets.ModelViewSet):
@@ -21,6 +47,8 @@ class KippoCustomerViewSet(viewsets.ModelViewSet):
 
     **Filtering:**
     - organization: UUID filter (still intersected with user's memberships).
+    - recent_ending: when ``true``, only customers with 1+ project whose ``target_date`` falls in the
+      last two fiscal years (previous + current FY) of the customer's organization.
     - search: SearchFilter on `name`, `email`.
 
     **Permissions:**
@@ -40,14 +68,51 @@ class KippoCustomerViewSet(viewsets.ModelViewSet):
         parameters=[
             OpenApiParameter(name="organization", description="Filter by organization UUID", required=False, type=str),
             OpenApiParameter(name="search", description="Search on name, email", required=False, type=str),
+            OpenApiParameter(
+                name="recent_ending",
+                description="When true, only customers with 1+ project ending in the previous or current fiscal year.",
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
         ]
     )
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
         return super().list(request, *args, **kwargs)
 
+    def _scoped_organizations(self) -> "list[KippoOrganization]":
+        """Organizations in scope for the current request (all for a superuser, else the user's)."""
+        user = self.request.user
+        if user.is_superuser:
+            return list(KippoOrganization.objects.all())
+        return list(user.organizations)
+
+    def _recent_ending_filter(self) -> Q:
+        """Q matching customers with 1+ project whose target_date falls in the previous-or-current
+        fiscal year of the customer's own organization (mirrors CustomerEndingProjectsFilter).
+        """
+        query = Q(pk__in=[])  # matches nothing by default
+        for organization in self._scoped_organizations():
+            fiscal_year_start = organization.current_fiscal_year_start()
+            window_start = shift_fiscal_year(fiscal_year_start, -1)
+            window_end = shift_fiscal_year(fiscal_year_start, 1)
+            query |= Q(
+                organization=organization,
+                projects__target_date__gte=window_start,
+                projects__target_date__lt=window_end,
+            )
+        return query
+
     def get_queryset(self):
-        """Filter by user organization memberships, plus the `organization` query param."""
-        queryset = super().get_queryset()
+        """Org-scoped queryset with changelist-parity annotations/prefetches, the `organization`
+        query param, and the `recent_ending` filter.
+        """
+        queryset = (
+            super()
+            .get_queryset()
+            .select_related("compliance_check")
+            .annotate(active_project_count=ACTIVE_PROJECT_COUNT)
+            .prefetch_related(_active_projects_prefetch())
+        )
         user = self.request.user
         if not user.is_superuser and hasattr(user, "organizationmembership_set"):
             user_organizations = user.organizationmembership_set.values_list("organization", flat=True)
@@ -57,4 +122,56 @@ class KippoCustomerViewSet(viewsets.ModelViewSet):
         if organization:
             queryset = queryset.filter(organization=organization)
 
+        if self.request.query_params.get("recent_ending", "").lower() == "true":
+            queryset = queryset.filter(self._recent_ending_filter()).distinct()
+
         return queryset
+
+    @extend_schema(responses=CustomerActiveProjectSerializer(many=True))
+    @action(detail=True, methods=["get"], url_path="active-projects")
+    def active_projects(self, request: Request, pk: str | None = None) -> Response:
+        """List the customer's active (open + display_as_active) projects with contract amount, end
+        date, and current-FY received-billing total (mirrors the admin's active-project detail rows).
+        """
+        customer = self.get_object()
+        fiscal_year_start = customer.organization.current_fiscal_year_start()
+        projects = getattr(customer, "active_projects", [])
+        for project in projects:
+            project.received_total_current_fy = project_received_total_current_fy(project, fiscal_year_start)
+        serializer = CustomerActiveProjectSerializer(projects, many=True)
+        return Response(serializer.data)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name="organization", description="Filter by organization UUID", required=False, type=str),
+            OpenApiParameter(
+                name="recent_ending",
+                description="Restrict to customers with projects ending this/prev FY.",
+                required=False,
+                type=OpenApiTypes.BOOL,
+            ),
+        ],
+        responses=FiscalYearSummarySerializer(many=True),
+    )
+    @action(detail=False, methods=["get"], url_path="fiscal-year-summary")
+    def fiscal_year_summary(self, request: Request) -> Response:
+        """Per-organization current-fiscal-year summary over the filtered in-scope customers (same
+        org-scope + organization + recent_ending filters as list).
+        """
+        customers = self.filter_queryset(self.get_queryset())
+        summaries = fiscal_year_org_summaries(customers)
+        payload = [
+            {
+                "organization": {"id": summary["organization"].id, "name": summary["organization"].name},
+                "fiscal_year_start": summary["fiscal_year_start"],
+                "fiscal_year_end": summary["fiscal_year_end"],
+                "customer_count": summary["customer_count"],
+                "project_count": summary["project_count"],
+                "planned_total": summary["planned_total"],
+                "received_total": summary["received_total"],
+                "monthly_planned_breakdown": summary["monthly_planned_breakdown"],
+            }
+            for summary in summaries
+        ]
+        serializer = FiscalYearSummarySerializer(payload, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
## Summary

Extends the customers API so the kippo-ui Customers list can reach `KippoCustomerAdmin`
changelist parity (kiconiaworks/kippo#42). Implements kiconiaworks/kippo#45.

All computation mirrors `KippoCustomerAdmin` exactly; the FY/summary/per-project math is
extracted into **`customers/functions.py`** as the single source of truth, shared by the admin
(which formats values as `¥`-strings) and the API (which returns raw decimals/numbers).

## Added

- **`KippoCustomerSerializer`** (read-only): `active_project_count`, `active_projects_contract_total`
  (Σ active-project 契約金額), `compliance_verified`.
- **`?recent_ending=true`** list filter — customers with ≥1 project whose `target_date` falls in the
  previous-or-current fiscal year of the customer's org (mirrors `CustomerEndingProjectsFilter`).
- **`GET /api/customers/{id}/active-projects/`** — per-project detail: `id`, `name`, `contract_amount`,
  `contract_end_date`, `received_total_current_fy` (current-FY received billing).
- **`GET /api/customers/fiscal-year-summary/`** — per-org current-FY summary over the filtered
  in-scope customers: `customer_count`, `project_count` (contracts ending this FY), `planned_total`,
  `received_total`, `monthly_planned_breakdown` (12 months). Respects org-scope + `?organization` +
  `?recent_ending`.

Org-scoping/permissions unchanged (`IsSuperuserOrReadUpdateCreateOwn`; non-superusers scoped to
their orgs). New endpoints/fields appear in the OpenAPI schema for the next `pnpm update:api`.

## Tests

`customers.tests.test_viewset` + `customers.tests.test_admin` — **67 passed**. Covers the new
scalars, the `recent_ending` window, the `active-projects` detail (incl. FY cutoff), the
`fiscal-year-summary` totals + monthly breakdown, org-scoping, and unauth. `uv run poe check` clean;
the admin refactor keeps existing admin tests green.

Refs kiconiaworks/kippo#45
Part of kiconiaworks/kippo#42
