### PR TITLE
:wrench: customer changelist-parity API polish — number amounts + plain-array action schemas

### DIFF
--- a/kippo/customers/serializers.py
+++ b/kippo/customers/serializers.py
@@ -80,7 +80,7 @@ class CustomerActiveProjectSerializer(serializers.Serializer):
     name = serializers.CharField(read_only=True)
     contract_amount = serializers.SerializerMethodField()
     contract_end_date = serializers.SerializerMethodField()
-    received_total_current_fy = serializers.DecimalField(max_digits=14, decimal_places=0, read_only=True)
+    received_total_current_fy = serializers.DecimalField(max_digits=14, decimal_places=0, coerce_to_string=False, read_only=True)
 
     def get_contract_amount(self, obj) -> Decimal | None:  # noqa: ANN001 (obj is a KippoProject; left unannotated so drf-spectacular need not import it)
         contract = getattr(obj, "contract", None)
@@ -95,7 +95,7 @@ class FiscalYearMonthlyBreakdownSerializer(serializers.Serializer):
     """One FY-month planned-billing total: {"month": "YYYY/MM", "amount": decimal}."""
 
     month = serializers.CharField()
-    amount = serializers.DecimalField(max_digits=16, decimal_places=0)
+    amount = serializers.DecimalField(max_digits=16, decimal_places=0, coerce_to_string=False)
 
 
 class FiscalYearSummaryOrganizationSerializer(serializers.Serializer):
@@ -111,6 +111,6 @@ class FiscalYearSummarySerializer(serializers.Serializer):
     fiscal_year_end = serializers.DateField()
     customer_count = serializers.IntegerField()
     project_count = serializers.IntegerField()
-    planned_total = serializers.DecimalField(max_digits=16, decimal_places=0)
-    received_total = serializers.DecimalField(max_digits=16, decimal_places=0)
+    planned_total = serializers.DecimalField(max_digits=16, decimal_places=0, coerce_to_string=False)
+    received_total = serializers.DecimalField(max_digits=16, decimal_places=0, coerce_to_string=False)
     monthly_planned_breakdown = FiscalYearMonthlyBreakdownSerializer(many=True)

--- a/kippo/customers/viewsets.py
+++ b/kippo/customers/viewsets.py
@@ -128,7 +128,8 @@ class KippoCustomerViewSet(viewsets.ModelViewSet):
         return queryset
 
     @extend_schema(responses=CustomerActiveProjectSerializer(many=True))
-    @action(detail=True, methods=["get"], url_path="active-projects")
+    # pagination_class=None → bare-array response (matches the runtime; no paginated {results} wrapper)
+    @action(detail=True, methods=["get"], url_path="active-projects", pagination_class=None)
     def active_projects(self, request: Request, pk: str | None = None) -> Response:
         """List the customer's active (open + display_as_active) projects with contract amount, end
         date, and current-FY received-billing total (mirrors the admin's active-project detail rows).
@@ -153,7 +154,7 @@ class KippoCustomerViewSet(viewsets.ModelViewSet):
         ],
         responses=FiscalYearSummarySerializer(many=True),
     )
-    @action(detail=False, methods=["get"], url_path="fiscal-year-summary")
+    @action(detail=False, methods=["get"], url_path="fiscal-year-summary", pagination_class=None)
     def fiscal_year_summary(self, request: Request) -> Response:
         """Per-organization current-fiscal-year summary over the filtered in-scope customers (same
         org-scope + organization + recent_ending filters as list).


### PR DESCRIPTION
## Summary

Two `#45` polish fixes for the customers changelist-parity API (follow-up to #342), so the
kippo-ui client is clean on the next `pnpm update:api`:

### 1. Amounts serialize as numbers (not strings)
The parity `DecimalField`s coerced to strings (DRF default `COERCE_DECIMAL_TO_STRING`), while
sibling amounts (`active_projects_contract_total`, `contract_amount`) were already JSON numbers.
Set `coerce_to_string=False` on:
- `CustomerActiveProjectSerializer.received_total_current_fy`
- `FiscalYearMonthlyBreakdownSerializer.amount`
- `FiscalYearSummarySerializer.planned_total`, `received_total`

### 2. Plain-array (non-paginated) schema for the two list-actions
`/customers/{id}/active-projects/` and `/customers/fiscal-year-summary/` return bare JSON arrays
at runtime, but drf-spectacular auto-wrapped their schema as paginated (`{count, results}`),
producing misleading `Paginated*` client types. `pagination_class=None` on each `@action` makes
the schema a plain `array` matching the runtime (verified: schema now `type: array`, `Paginated*`
refs gone, 0 schema errors).

## Tests
`customers.tests.test_viewset` — 23 passed. `Decimal(...)`-wrapped assertions accept numbers and
strings, so they remain valid. `uv run poe check` clean.

Refs kiconiaworks/kippo#45
Part of kiconiaworks/kippo#42
