### PR TITLE
:sparkles: auto-generate billing entries when a contract is created

### DIFF
--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -324,7 +324,7 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         from decimal import Decimal
 
         from django.utils import timezone
-        from projects.models import KippoProjectBillingEntry, KippoProjectContract
+        from projects.models import KippoProjectContract
 
         # Fiscal year starts in January → current FY = this (JST) calendar year.
         self.organization.fiscalyear_start_month = 1
@@ -342,9 +342,12 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
             created_by=self.github_manager,
             updated_by=self.github_manager,
         )
-        KippoProjectBillingEntry.objects.create(
-            contract=in_fy_contract, billing_date=date(today.year, 6, 30), amount=Decimal("500000"), is_received=True
-        )
+        # the contract auto-generates a 2,000,000 entry at its end_date on creation; record a 500,000
+        # partial receipt against it (planned stays 2,000,000 from the terms)
+        in_fy_entry = in_fy_contract.billing_entries.get(billing_date=date(today.year, 6, 30))
+        in_fy_entry.amount = Decimal("500000")
+        in_fy_entry.is_received = True
+        in_fy_entry.save()
         # contract ending in a PRIOR FY → excluded from count / planned / received
         prior = self._make_customer_project("prior-fy", self.customer, fy_start - timedelta(days=1))
         KippoProjectContract.objects.create(

--- a/kippo/customers/tests/test_viewset.py
+++ b/kippo/customers/tests/test_viewset.py
@@ -370,9 +370,12 @@ class KippoCustomerChangelistParityTestCase(TestCase):
         # delivery contract ending in March → whole total in its end month; received entry counted
         delivery = self._make_project("delivery", self.customer, date(self.today.year, 3, 31))
         delivery_contract = self._make_contract(delivery, "3000000", date(self.today.year, 3, 31))
-        KippoProjectBillingEntry.objects.create(
-            contract=delivery_contract, billing_date=date(self.today.year, 3, 31), amount=Decimal("1000000"), is_received=True
-        )
+        # the contract auto-generates a 3,000,000 entry at end-of-March on creation; record a
+        # 1,000,000 partial receipt against it (planned stays 3,000,000 from the terms)
+        entry = delivery_contract.billing_entries.get(billing_date=date(self.today.year, 3, 31))
+        entry.amount = Decimal("1000000")
+        entry.is_received = True
+        entry.save()
         # monthly fixed Apr–Jun (3 months) → 1,200,000 split 400,000/month
         monthly = self._make_project("monthly", self.customer, date(self.today.year, 6, 30))
         self._make_contract(monthly, "1200000", date(self.today.year, 6, 30), billing_type="monthly", start_date=date(self.today.year, 4, 1))

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -921,7 +921,13 @@ class KippoProjectContract(UserCreatedBaseModel):
             self.start_date = self.project.start_date
         if not self.end_date:
             self.end_date = self.project.target_date
+        is_initial_creation = self._state.adding
         super().save(*args, **kwargs)
+        # Populate the billing ledger from the terms on initial creation so the user does not have to
+        # run the generate_billing_entries admin action by hand. Idempotent and safe to re-run later
+        # (as months elapse or effort accrues) via the still-available action / API.
+        if is_initial_creation:
+            self.generate_billing_entries(created_by=self.created_by)
 
     def _contract_months(self) -> list[datetime.date]:
         """First-of-month dates for each calendar month the contract period [start_date, end_date]

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1936,10 +1936,13 @@ class ContractAdminBillingEntryReceivedByTestCase(KippoProjectAdminFixtureTestCa
     def setUp(self):
         super().setUp()
         self.project = self.make_project("received-by-project")
+        # effort/no-effort -> empty ledger on creation, so the entry added via the formset below is
+        # the only one (a fixed contract would auto-generate one at 2026-09-30 and collide)
         self.contract = KippoProjectContract.objects.create(
             project=self.project,
             billing_type="delivery",
-            total_amount="1000000",
+            pricing_basis="effort",
+            total_amount=None,
             end_date=date(2026, 9, 30),
             created_by=self.github_manager,
             updated_by=self.github_manager,

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -1411,11 +1411,12 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_billing_entry_crud_and_received_by_stamp(self):
+        # effort/no-effort -> empty ledger on creation, so the POSTed entry below is the only one
         KippoProjectContract.objects.create(
             project=self.project,
             billing_type="delivery",
-            pricing_basis="fixed",
-            total_amount=1000000,
+            pricing_basis="effort",
+            total_amount=None,
             end_date="2026-09-30",
             created_by=self.user,
             updated_by=self.user,
@@ -1469,11 +1470,12 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_duplicate_billing_entry_rejected_cleanly(self):
+        # effort/no-effort -> empty ledger on creation, so the first POST below is the only entry
         KippoProjectContract.objects.create(
             project=self.project,
             billing_type="delivery",
-            pricing_basis="fixed",
-            total_amount=1000000,
+            pricing_basis="effort",
+            total_amount=None,
             end_date="2026-09-30",
             created_by=self.user,
             updated_by=self.user,

--- a/kippo/projects/tests/test_models_billing.py
+++ b/kippo/projects/tests/test_models_billing.py
@@ -128,12 +128,29 @@ class MonthlyContractGenerationTestCase(TestCase):
             total_amount=Decimal(total_amount),
             start_date=start,
             end_date=end,
+            created_by=self.user,
+            updated_by=self.user,
         )
 
+    def test_billing_entries_generated_on_contract_creation(self):
+        # creating the contract populates the ledger from the terms — the user does not run the
+        # generate_billing_entries action by hand
+        contract = self._make_contract(datetime.date(2026, 1, 1), datetime.date(2026, 3, 31), total_amount="900000")
+        self.assertEqual(
+            [(entry.billing_date, entry.amount) for entry in contract.billing_entries.all()],
+            [
+                (datetime.date(2026, 1, 31), Decimal("300000")),
+                (datetime.date(2026, 2, 28), Decimal("300000")),
+                (datetime.date(2026, 3, 31), Decimal("300000")),
+            ],
+        )
+        self.assertTrue(all(entry.created_by == self.user for entry in contract.billing_entries.all()))  # contract's created_by
+        self.assertTrue(all(entry.is_manual is False for entry in contract.billing_entries.all()))  # generated, not hand-added
+
     def test_multi_month_contract_generates_month_end_entry_per_month(self):
-        # 1,200,000 over Jan..Apr (4 months) -> 300,000 each
+        # 1,200,000 over Jan..Apr (4 months) -> 300,000 each, generated on creation
         contract = self._make_contract(datetime.date(2026, 1, 15), datetime.date(2026, 4, 10), total_amount="1200000")
-        created = contract.generate_billing_entries(created_by=self.user)
+        created = list(contract.billing_entries.all())
         # each accrual month is billed at month-end (月末)
         self.assertEqual(
             [entry.billing_date for entry in created],
@@ -153,7 +170,7 @@ class MonthlyContractGenerationTestCase(TestCase):
     def test_total_amount_split_remainder_lands_on_final_month(self):
         # 1,000,000 over 3 months -> 333,333 / 333,333 / 333,334 (remainder on last); sums to total
         contract = self._make_contract(datetime.date(2026, 1, 1), datetime.date(2026, 3, 31), total_amount="1000000")
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual(
             [entry.amount for entry in created],
             [Decimal("333333"), Decimal("333333"), Decimal("333334")],
@@ -162,14 +179,14 @@ class MonthlyContractGenerationTestCase(TestCase):
 
     def test_single_month_contract(self):
         contract = self._make_contract(datetime.date(2026, 3, 1), datetime.date(2026, 3, 31), total_amount="300000")
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual(len(created), 1)
         self.assertEqual(created[0].billing_date, datetime.date(2026, 3, 31))
         self.assertEqual(created[0].amount, Decimal("300000"))
 
     def test_contract_spanning_year_boundary(self):
         contract = self._make_contract(datetime.date(2025, 11, 1), datetime.date(2026, 2, 28))
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual(
             [entry.billing_date for entry in created],
             [
@@ -189,15 +206,14 @@ class MonthlyContractGenerationTestCase(TestCase):
             billing_type=BILLING_TYPE_MONTHLY,
             total_amount=Decimal("900000"),
         )
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual(len(created), 3)
 
     def test_generation_is_idempotent(self):
+        # entries are generated on contract creation; re-running the action creates nothing new
         contract = self._make_contract(datetime.date(2026, 1, 1), datetime.date(2026, 3, 31))
-        first = contract.generate_billing_entries()
-        self.assertEqual(len(first), 3)
-        second = contract.generate_billing_entries()
-        self.assertEqual(second, [])
+        self.assertEqual(contract.billing_entries.count(), 3)
+        self.assertEqual(contract.generate_billing_entries(), [])
         self.assertEqual(contract.billing_entries.count(), 3)
 
     def test_generation_preserves_manual_adjustments(self):
@@ -256,7 +272,7 @@ class DeliveryContractGenerationTestCase(TestCase):
             total_amount=Decimal("2000000"),
             end_date=datetime.date(2026, 9, 30),
         )
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual(len(created), 1)
         self.assertEqual(created[0].billing_date, datetime.date(2026, 9, 30))
         self.assertEqual(created[0].amount, Decimal("2000000"))
@@ -271,18 +287,19 @@ class DeliveryContractGenerationTestCase(TestCase):
             billing_type=BILLING_TYPE_DELIVERY,
             total_amount=Decimal("2000000"),
         )
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual(len(created), 1)
         self.assertEqual(created[0].billing_date, datetime.date(2026, 9, 30))
 
     def test_delivery_generation_is_idempotent(self):
+        # the single delivery entry is generated on creation; re-running the action creates nothing new
         contract = KippoProjectContract.objects.create(
             project=self.project,
             billing_type=BILLING_TYPE_DELIVERY,
             total_amount=Decimal("2000000"),
             end_date=datetime.date(2026, 9, 30),
         )
-        self.assertEqual(len(contract.generate_billing_entries()), 1)
+        self.assertEqual(contract.billing_entries.count(), 1)
         self.assertEqual(contract.generate_billing_entries(), [])
         self.assertEqual(contract.billing_entries.count(), 1)
 
@@ -342,11 +359,14 @@ class RevenueEntriesTestCase(TestCase):
         self.assertEqual(entries, [])
 
     def test_manual_entry_included_in_revenue(self):
-        # hand-added entries (is_manual) count toward revenue like generated ones
+        # hand-added entries (is_manual) count toward revenue like generated ones.
+        # effort pricing with no logged effort leaves the ledger empty on creation, so the manual
+        # entry below is the only one.
         contract = KippoProjectContract.objects.create(
             project=self.project,
             billing_type=BILLING_TYPE_DELIVERY,
-            total_amount=Decimal("500000"),
+            pricing_basis=PRICING_BASIS_EFFORT,
+            total_amount=None,
             end_date=datetime.date(2026, 9, 30),
         )
         KippoProjectBillingEntry.objects.create(
@@ -597,7 +617,7 @@ class EffortContractGenerationTestCase(TestCase):
         self._log_effort(datetime.date(2026, 1, 19), 8)  # 1 day  -> Jan total 6 days = 600,000
         self._log_effort(datetime.date(2026, 2, 2), 16)  # 2 days -> Feb 200,000
         contract = self._effort_contract(BILLING_TYPE_MONTHLY, datetime.date(2026, 1, 1), datetime.date(2026, 2, 28))
-        created = contract.generate_billing_entries(created_by=self.user)
+        created = list(contract.billing_entries.all())
         self.assertEqual(
             [(e.billing_date, e.amount) for e in created],
             [(datetime.date(2026, 1, 31), Decimal("600000")), (datetime.date(2026, 2, 28), Decimal("200000"))],
@@ -610,14 +630,14 @@ class EffortContractGenerationTestCase(TestCase):
         self._assign_role(datetime.date(2026, 1, 1), ProjectRoles.TESTER.value)
         self._log_effort(datetime.date(2026, 1, 5), 40)  # 5 days × 50,000 = 250,000
         contract = self._effort_contract(BILLING_TYPE_MONTHLY, datetime.date(2026, 1, 1), datetime.date(2026, 1, 31))
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual([(e.billing_date, e.amount) for e in created], [(datetime.date(2026, 1, 31), Decimal("250000"))])
 
     def test_effort_missing_rate_falls_back_to_default(self):
         # no ProjectAssignmentRate rows -> developer role resolves to settings.DEFAULT_PROJECT_DAILY_RATE
         self._log_effort(datetime.date(2026, 1, 5), 40)  # 5 days × 180,000
         contract = self._effort_contract(BILLING_TYPE_MONTHLY, datetime.date(2026, 1, 1), datetime.date(2026, 1, 31))
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         expected = Decimal(5 * settings.DEFAULT_PROJECT_DAILY_RATE)  # 900,000
         self.assertEqual([(e.billing_date, e.amount) for e in created], [(datetime.date(2026, 1, 31), expected)])
 
@@ -626,7 +646,7 @@ class EffortContractGenerationTestCase(TestCase):
         self._log_effort(datetime.date(2026, 1, 5), 40)  # 5 days
         self._log_effort(datetime.date(2026, 2, 2), 16)  # 2 days -> total 7 days = 700,000
         contract = self._effort_contract(BILLING_TYPE_DELIVERY, datetime.date(2026, 1, 1), datetime.date(2026, 2, 28))
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual([(e.billing_date, e.amount) for e in created], [(datetime.date(2026, 2, 28), Decimal("700000"))])
 
     def test_effort_monthly_zero_effort_month_creates_nothing(self):
@@ -634,7 +654,7 @@ class EffortContractGenerationTestCase(TestCase):
         self._log_effort(datetime.date(2026, 1, 5), 40)  # Jan only
         self._log_effort(datetime.date(2026, 3, 2), 8)  # Mar only; Feb has no logged effort
         contract = self._effort_contract(BILLING_TYPE_MONTHLY, datetime.date(2026, 1, 1), datetime.date(2026, 3, 31))
-        created = contract.generate_billing_entries()
+        created = list(contract.billing_entries.all())
         self.assertEqual(
             [(e.billing_date, e.amount) for e in created],
             [(datetime.date(2026, 1, 31), Decimal("500000")), (datetime.date(2026, 3, 31), Decimal("100000"))],
@@ -644,7 +664,8 @@ class EffortContractGenerationTestCase(TestCase):
         self._set_rate(ProjectRoles.DEVELOPER.value, 100_000)
         self._log_effort(datetime.date(2026, 1, 5), 40)
         contract = self._effort_contract(BILLING_TYPE_MONTHLY, datetime.date(2026, 1, 1), datetime.date(2026, 1, 31))
-        self.assertEqual(len(contract.generate_billing_entries()), 1)
+        # the entry is generated on creation (effort already logged above); re-running creates nothing new
+        self.assertEqual(contract.billing_entries.count(), 1)
         self.assertEqual(contract.generate_billing_entries(), [])
         self.assertEqual(contract.billing_entries.count(), 1)
 
@@ -666,10 +687,13 @@ class BillingEntryReceivedTrackingTestCase(TestCase):
         created = setup_basic_project()
         self.project: KippoProject = created["KippoProject"]
         self.user = created["KippoUser"]
+        # effort pricing with no logged effort leaves the ledger empty on creation, so each test below
+        # controls its own single entry via _entry() without colliding with an auto-generated one
         self.contract = KippoProjectContract.objects.create(
             project=self.project,
             billing_type=BILLING_TYPE_DELIVERY,
-            total_amount=Decimal("1000000"),
+            pricing_basis=PRICING_BASIS_EFFORT,
+            total_amount=None,
             end_date=datetime.date(2026, 9, 30),
         )
 


### PR DESCRIPTION
## What

`KippoProjectContract.save()` now populates the billing ledger from the contract terms **on initial creation**, so a user no longer has to run the `generate_billing_entries` admin action by hand after creating a project's contract.

```python
is_initial_creation = self._state.adding
super().save(*args, **kwargs)
if is_initial_creation:
    self.generate_billing_entries(created_by=self.created_by)
```

## Why

Creating a contract (in the admin inline, via the REST API, or a script) is the natural moment the billing schedule is known. Requiring a separate manual action was an easy step to forget, leaving projects with empty ledgers.

## Behaviour

- **Only on first creation** (`self._state.adding`). Updates and fixture loads (`save_base`) are unaffected — no duplicate generation.
- **Idempotent / non-destructive.** `generate_billing_entries` skips dates that already have an entry and creates nothing for zero/None amounts, so the still-available admin action / API call can be re-run later (as months elapse or effort accrues) without overwriting adjusted or manual entries.
- **Attribution.** Entries are stamped with the contract's `created_by` (set by the admin `save_formset` and the API `perform_create` before `save()`).
- Fixed monthly → per-month month-end entries; fixed delivery → one entry at `end_date`; effort → Σ logged effort (nothing yet at creation, generated as effort is logged).

## Tests

- New `test_billing_entries_generated_on_contract_creation`.
- Existing generation tests now assert on the contract's ledger (populated on creation) instead of the return value of the now-no-op explicit `generate_billing_entries()` call.
- Partial-receipt and billing-entry CRUD fixtures use effort pricing (empty ledger on creation) or edit the auto-generated entry, to avoid colliding with it on the unique `(contract, billing_date)` constraint.

All affected suites pass: `projects.tests.test_models_billing`, `projects.tests.test_api_rest`, `projects.tests.test_admin`, `customers.tests.test_viewset`, `customers.tests.test_admin`.