### PR TITLE
:lipstick: fix collapsed nested-admin inline header double-height (KippoProjectAdmin)

### DIFF
--- a/kippo/projects/templates/admin/projects/kippoproject/change_form.html
+++ b/kippo/projects/templates/admin/projects/kippoproject/change_form.html
@@ -8,6 +8,12 @@
     .kippo-copy-status { font-size: 12px; color: #4f8a10; opacity: 0; transition: opacity 0.15s ease; }
     .kippo-copy-status.is-visible { opacity: 1; }
     .kippo-copy-status--error { color: #ba2121; }
+    /* Collapsed nested-admin inline section dividers. When an inline is collapsed, Django/nested_admin
+       wraps the inline's section <h2> (which already carries its own ~8px section-bar padding) inside a
+       <summary> that adds padding again, so the divider renders ~double height (≈69px) vs the project's
+       own collapsible fieldset sections (≈36px, whose <h2> is a padding-less, inline .fieldset-heading).
+       Mirror that: make the inline h2 inline + padding-less so the <summary>'s own padding sizes the bar. */
+    .djn-fieldset details > summary > h2 { display: inline; padding: 0; margin: 0; }
 </style>
 <script>
 'use strict';


### PR DESCRIPTION
## Summary

Fixes the **collapsed** nested-admin inline section dividers on the `KippoProjectAdmin` change
form rendering at ~double height (≈69px) vs the other section dividers (≈36px).

## Root cause

When an inline is collapsed, Django/`nested_admin` wraps the inline's section `<h2>` — which already
carries its own ~8px section-bar padding — inside a `<summary>` that adds padding **again**, so the
divider bar is double-padded. The project's *own* collapsible fieldset sections (`Details`/`Extra`)
don't have this because their heading is a padding-less, inline `.fieldset-heading`.

## Fix

One scoped CSS rule in the change form's existing `extrahead` `<style>`:

```css
.djn-fieldset details > summary > h2 { display: inline; padding: 0; margin: 0; }
```

This makes the collapsed inline header behave like `.fieldset-heading`, so the `<summary>`'s own
padding sizes the bar.

## Verified (headless, measured)

Every collapsed section divider — `Details`, `Extra`, `PROJECT MONTHLY ASSIGNMENTS`,
`GITHUB REPOSITORIES`, `プロジェクト週間稼働量`, `KIPPO PROJECT STATUS` — now renders at **36px**
(was ~69px for the inlines). Open inline section headers (33/34) and the project's own fieldset
section headers (36) are unaffected — the rule is scoped to `.djn-fieldset details > summary > h2`.

Template-only change (no Python/logic).
