### PR TITLE
:sparkles: Expose parent_project, enable_cost_report, meeting fields + name search on the project API

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -287,6 +287,20 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         required=False,
         help_text="ProjectColumnSet for this project. Defaults to the organization's default columnset when omitted.",
     )
+    # parent_project (親プロジェクト) — original project for upsell projects (admin parity). Writable
+    # FK; a cross-org or self-referencing parent is rejected in validate(). parent_project_name is the
+    # read-only label so clients can render the selection without a second lookup.
+    parent_project = serializers.PrimaryKeyRelatedField(
+        queryset=KippoProject.objects.all(),
+        required=False,
+        allow_null=True,
+        help_text="Original (parent) project for upsell projects.",
+    )
+    parent_project_name = serializers.CharField(source="parent_project.name", read_only=True, allow_null=True)
+    # MTG calendar template URL + dsearch tag — read-only, mirroring the admin's
+    # meeting_calendar_url_field / meeting_description_tag_field display methods.
+    meeting_calendar_url = serializers.SerializerMethodField()
+    meeting_description_tag = serializers.SerializerMethodField()
 
     class Meta:
         model = KippoProject
@@ -309,8 +323,11 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "monthly_billing_schedule",
             "slack_channel_name",
             "slack_notification_channel_name",
+            "enable_cost_report",
             "project_manager",
             "project_manager_username",
+            "parent_project",
+            "parent_project_name",
             "is_closed",
             "closed_datetime",
             "display_as_active",
@@ -328,6 +345,8 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "document_folder_url",
             "docbase_tag",
             "problem_definition",
+            "meeting_calendar_url",
+            "meeting_description_tag",
             "survey_issued",
             "assignment_rates",
             "has_requirements",
@@ -344,6 +363,9 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "organization_name",
             "customer_name",
             "project_manager_username",
+            "parent_project_name",  # read-only label for the parent_project FK
+            "meeting_calendar_url",  # MTG calendar template URL (admin parity)
+            "meeting_description_tag",  # dsearch tag for meeting minutes (admin parity)
             "customer_document_url",  # linked customer's contract-folder URL (kippo#34 / T04)
             "phase_display",  # human-readable status label (kippo#37 / T10)
             "category_label",  # human-readable category label (kippo#39 / T14)
@@ -391,6 +413,9 @@ class KippoProjectSerializer(serializers.ModelSerializer):
                 )
             attrs["columnset"] = columnset
 
+        self._validate_parent_project(attrs, organization)
+        self._validate_enable_cost_report(attrs)
+
         # Required-field validation at project registration (kippo#40 / T19). Create-only — edits of
         # existing rows (and existing data) are unaffected. category/phase always carry model defaults,
         # so the enforced gaps are the genuinely-optional fields. 請求方法 (billing method) lives on
@@ -402,6 +427,41 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             if missing:
                 raise serializers.ValidationError(missing)
         return attrs
+
+    def _validate_parent_project(self, attrs: dict, organization: "KippoOrganization | None") -> None:
+        """parent_project (upsell) must be same-org and not the project itself (admin parity)."""
+        parent_project = attrs.get("parent_project")
+        if parent_project is None:
+            return
+        if self.instance is not None and parent_project.id == self.instance.id:
+            raise serializers.ValidationError({"parent_project": "A project cannot be its own parent project."})
+        if organization is not None and parent_project.organization_id != organization.id:
+            raise serializers.ValidationError({"parent_project": "Parent project must belong to the project's organization."})
+
+    def _validate_enable_cost_report(self, attrs: dict) -> None:
+        """enable_cost_report requires a slack_channel_name (mirrors KippoProject.clean()). Falls back
+        to the stored values for fields absent from this (partial) update.
+        """
+        enable_cost_report = attrs.get("enable_cost_report")
+        if enable_cost_report is None and self.instance is not None:
+            enable_cost_report = self.instance.enable_cost_report
+        if not enable_cost_report:
+            return
+        slack_channel_name = attrs.get("slack_channel_name")
+        if slack_channel_name is None and self.instance is not None:
+            slack_channel_name = self.instance.slack_channel_name
+        if not slack_channel_name:
+            raise serializers.ValidationError({"enable_cost_report": "slack_channel_name is required when enable_cost_report is True."})
+
+    @extend_schema_field(serializers.CharField())
+    def get_meeting_calendar_url(self, obj: KippoProject) -> str:
+        """Google Calendar event-template URL pre-filled for this project (admin parity)."""
+        return obj.get_meeting_calendar_template_url()
+
+    @extend_schema_field(serializers.CharField())
+    def get_meeting_description_tag(self, obj: KippoProject) -> str:
+        """Dsearch sentinel tag embedding the project id, for meeting-minutes discovery (admin parity)."""
+        return obj.get_dsearch_tag()
 
     @extend_schema_field(serializers.FloatField(allow_null=True))
     def get_allocated_effort_hours(self, obj: KippoProject) -> float | None:

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -441,6 +441,70 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertIn(str(self.project.id), all_ids)
         self.assertIn(str(non_project.id), all_ids)
 
+    def test_search_filters_by_name_substring(self):
+        """Test the `search` query parameter filters projects by case-insensitive name substring."""
+        match = KippoProject.objects.create(
+            name="Demand Forecasting Platform",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        url = f"{settings.URL_PREFIX}/api/projects/?search=forecasting"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        result_ids = [result["id"] for result in response.json()["results"]]
+        self.assertIn(str(match.id), result_ids)
+        self.assertNotIn(str(self.project.id), result_ids)
+
+    def test_parent_project_is_writable_and_exposes_name(self):
+        """Test parent_project can be set (same org) and parent_project_name is returned read-only."""
+        parent = KippoProject.objects.create(
+            name="Parent Project",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(url, {"parent_project": str(parent.id)}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        data = response.json()
+        self.assertEqual(data["parent_project"], str(parent.id))
+        self.assertEqual(data["parent_project_name"], "Parent Project")
+
+    def test_parent_project_cross_organization_rejected(self):
+        """Test a parent_project from a different organization is rejected."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        # self.other_project belongs to other_organization; superuser-free user can still send the id.
+        response = self.client.patch(url, {"parent_project": str(self.other_project.id)}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("parent_project", response.json())
+
+    def test_enable_cost_report_requires_slack_channel(self):
+        """Test enable_cost_report cannot be turned on without a slack_channel_name (model.clean parity)."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        self.project.slack_channel_name = ""
+        self.project.save()
+        rejected = self.client.patch(url, {"enable_cost_report": True}, format="json")
+        self.assertEqual(rejected.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("enable_cost_report", rejected.json())
+        # With a slack channel supplied in the same request it succeeds.
+        accepted = self.client.patch(url, {"enable_cost_report": True, "slack_channel_name": "proj-costs"}, format="json")
+        self.assertEqual(accepted.status_code, HTTPStatus.OK, accepted.content)
+        self.assertTrue(accepted.json()["enable_cost_report"])
+
+    def test_meeting_fields_exposed_read_only(self):
+        """Test meeting_calendar_url + meeting_description_tag are exposed and read-only."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        data = self.client.get(url).json()
+        self.assertIn(f'[dsearch]{{"project":"{self.project.id}"}}[/dsearch]', data["meeting_description_tag"])
+        self.assertIn("calendar.google.com", data["meeting_calendar_url"])
+        # Read-only: attempting to write them is ignored (value stays derived).
+        response = self.client.patch(url, {"meeting_description_tag": "tampered"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertNotEqual(response.json()["meeting_description_tag"], "tampered")
+
     def test_user_cannot_access_other_organization_projects(self):
         """Test that users can only access projects from their organizations."""
         url = f"{settings.URL_PREFIX}/api/projects/{self.other_project.id}/"

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -156,6 +156,12 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
                 required=False,
                 type=str,
             ),
+            OpenApiParameter(
+                name="search",
+                description="Case-insensitive substring match on the project name (for name-search pickers).",
+                required=False,
+                type=str,
+            ),
         ]
     )
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
@@ -195,6 +201,11 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
         exclude_category = self.request.query_params.get("exclude_category", None)
         if exclude_category is not None:
             queryset = queryset.exclude(category__key=exclude_category)
+
+        # Case-insensitive name substring search (powers name-search pickers, e.g. parent_project).
+        search = self.request.query_params.get("search", None)
+        if search:
+            queryset = queryset.filter(name__icontains=search)
 
         return queryset
 


### PR DESCRIPTION
## Summary

Extends `KippoProjectSerializer` and `KippoProjectViewSet` so the kippo-ui in-SPA KippoProject `/edit` page can reach parity with the `KippoProjectAdmin` change form (kiconiaworks/kippo#42). These fields exist on the model / admin but were not exposed by the REST API.

### `KippoProjectSerializer`
- **`parent_project`** — writable FK (upsell parent), plus read-only **`parent_project_name`** label. A cross-organization or self-referencing parent is rejected in `validate()` (admin parity).
- **`enable_cost_report`** — writable boolean. Enabling it requires a `slack_channel_name`, mirroring `KippoProject.clean()` (falls back to stored values on partial update).
- **`meeting_calendar_url`** + **`meeting_description_tag`** — read-only, sourced from the model's `get_meeting_calendar_template_url()` / `get_dsearch_tag()` (the admin's `meeting_calendar_url_field` / `meeting_description_tag_field`).

### `KippoProjectViewSet`
- **`?search=`** — case-insensitive substring match on project name, for name-search pickers (e.g. the kippo-ui `parent_project` selector). Documented via `OpenApiParameter`.

## Tests
Added to `KippoProjectViewSetTestCase` (`projects/tests/test_api_rest.py`):
- `parent_project` writable + `parent_project_name` exposed
- cross-organization `parent_project` rejected (400)
- `enable_cost_report` requires `slack_channel_name` (400, then 200 with channel)
- `meeting_calendar_url` / `meeting_description_tag` exposed and read-only
- `?search=` filters by name substring

`projects.tests.test_api_rest` — 92 passed. `ruff check` / `ruff format` clean.

## Follow-up
A kippo release is needed before kippo-ui can consume these via `pnpm update:api` and wire the remaining fields into the project `/edit` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)