### PR TITLE
:sparkles: Add customer filter to the project list endpoint

### DIFF
--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -457,6 +457,33 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertIn(str(match.id), result_ids)
         self.assertNotIn(str(self.project.id), result_ids)
 
+    def test_filter_by_customer(self):
+        """Test the `customer` query parameter filters projects by the customer UUID (exact match)."""
+        from customers.models import KippoCustomer
+
+        customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="Filter Co",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        with_customer = KippoProject.objects.create(
+            name="With Customer",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            customer=customer,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        url = f"{settings.URL_PREFIX}/api/projects/?customer={customer.id}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        result_ids = [result["id"] for result in response.json()["results"]]
+        self.assertIn(str(with_customer.id), result_ids)
+        # self.project has no customer → excluded by the filter.
+        self.assertNotIn(str(self.project.id), result_ids)
+
     def test_parent_project_is_writable_and_exposes_name(self):
         """Test parent_project can be set (same org) and parent_project_name is returned read-only."""
         parent = KippoProject.objects.create(

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -162,6 +162,12 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
                 required=False,
                 type=str,
             ),
+            OpenApiParameter(
+                name="customer",
+                description="Filter by customer UUID (exact match on KippoProject.customer).",
+                required=False,
+                type=str,
+            ),
         ]
     )
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
@@ -206,6 +212,12 @@ class KippoProjectViewSet(viewsets.ModelViewSet):
         search = self.request.query_params.get("search", None)
         if search:
             queryset = queryset.filter(name__icontains=search)
+
+        # Filter by customer (exact match on the customer UUID) — efficient FK lookup; lets the
+        # parent_project picker scope candidates to the project's customer server-side.
+        customer = self.request.query_params.get("customer", None)
+        if customer:
+            queryset = queryset.filter(customer=customer)
 
         return queryset
 


### PR DESCRIPTION
## Summary

Adds a `customer` query parameter to `KippoProjectViewSet.list` so clients can scope the project list to a single `KippoCustomer` server-side.

- **`?customer=<uuid>`** — exact-match FK lookup on `KippoProject.customer`. `customer` is already `select_related` + indexed, so the filter is efficient (no extra joins/scans).

## Motivation

The kippo-ui in-SPA project `/edit` page (kiconiaworks/kippo#42) has a `parent_project` picker that must list only projects sharing the project's customer. Today it filters a name-search page client-side; this lets it filter server-side via `?search=&customer=`, which is correct for customers with many projects.

## Tests
`projects/tests/test_api_rest.py::KippoProjectViewSetTestCase::test_filter_by_customer` — a project with the customer is returned; a project without it is excluded. `projects.tests.test_api_rest` — 30 passed. `ruff check` / `ruff format` clean.

## Follow-up
After release, kippo-ui runs `pnpm update:api` and switches the parent_project picker to pass `?customer=` (dropping the client-side customer filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)