### PR TITLE
KippoProject admin: remove problem-definition column; add multi-select phase filter to active projects

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -912,7 +912,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         "id",
         "get_customer_name",
         "name",
-        "get_problem_definition_display",
         "get_confidence_display",
         "get_projectstatus_display",
         "get_latest_kippoprojectstatus_comment",
@@ -1090,13 +1089,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
     @admin.display(description=KippoCustomer._meta.verbose_name, ordering="customer__name")
     def get_customer_name(self, obj: KippoProject) -> str:
         return obj.customer.name if obj.customer else ""
-
-    @admin.display(description=_("プロジェクト課題定義"))
-    def get_problem_definition_display(self, obj: KippoProject) -> str:
-        # truncated problem definition shown as the project intro in the changelist (kippo#29 / T07)
-        limit = 60
-        text = obj.problem_definition or ""
-        return f"{text[:limit]}…" if len(text) > limit else text
 
     @admin.display(description=_("カテゴリ"), ordering="category__sort_order")
     def get_category_label(self, obj: KippoProject) -> str:

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -58,6 +58,7 @@ from .functions import (
 from .models import (
     _COMPUTE,
     PHASE_CONFIDENCE,
+    VALID_PROJECT_PHASES,
     ActiveKippoProject,
     CollectIssuesAction,
     KippoMilestone,
@@ -78,6 +79,8 @@ from .models import (
 )
 
 if TYPE_CHECKING:
+    from django.contrib.admin.views.main import ChangeList
+
     from .services.forecast import ForecastResult
 
 CLOSE_PROJECT_NO_UPSELL_VALUE = "__no_upsell__"
@@ -1636,11 +1639,63 @@ class KippoProjectAdmin(KippoProjectBaseAdmin):
     list_display = (*KippoProjectBaseAdmin.list_display, "display_as_active")
 
 
+# Phases pre-selected on the active-project changelist when the フェーズ filter has no query param —
+# the two "in-flight" phases (口頭受注 / 契約(稼働中)). An explicit (even empty) param overrides these,
+# so the "全て" option can still show every active project.
+DEFAULT_ACTIVE_PROJECT_PHASES = ("verbal-order", "under-contract")
+
+
+class PhaseMultiSelectListFilter(admin.SimpleListFilter):
+    """Multi-select フェーズ filter for the active-project changelist.
+
+    Django's built-in field filter is single-select; this renders each phase as a toggle so several
+    can be active at once. With no `phase` query param the two in-flight phases are pre-selected
+    (DEFAULT_ACTIVE_PROJECT_PHASES); the 全て option clears to an explicit empty param so the defaults
+    don't re-apply.
+    """
+
+    title = _("フェーズ")
+    parameter_name = "phase"
+
+    def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
+        return list(VALID_PROJECT_PHASES)
+
+    def selected_phases(self) -> list[str]:
+        # value() is None only when the param is absent -> fall back to the defaults; an empty string
+        # (user cleared the selection via 全て or by deselecting the last phase) means "no filter".
+        value = self.value()
+        if value is None:
+            return list(DEFAULT_ACTIVE_PROJECT_PHASES)
+        return [phase for phase in value.split(",") if phase]
+
+    def queryset(self, request: DjangoRequest, queryset: models.QuerySet) -> models.QuerySet:
+        selected = self.selected_phases()
+        return queryset.filter(phase__in=selected) if selected else queryset
+
+    def choices(self, changelist: "ChangeList"):
+        selected = set(self.selected_phases())
+        yield {
+            "selected": not selected,
+            "query_string": changelist.get_query_string({self.parameter_name: ""}),
+            "display": _("全て"),
+        }
+        for lookup, title in self.lookup_choices:
+            phase = str(lookup)
+            toggled = selected ^ {phase}  # add if absent, remove if present
+            yield {
+                "selected": phase in selected,
+                "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
+                "display": title,
+            }
+
+
 @admin.register(ActiveKippoProject)
 class ActiveKippoProjectAdmin(KippoProjectBaseAdmin):
     # Identical to the base except the queryset: the ActiveKippoProjectManager (proxy default
     # manager) restricts it to open + display_as_active projects. The only form difference is
     # below — closure fields never apply to an active project.
+    # Multi-select フェーズ filter, defaulting to the two in-flight phases (kippo new filter).
+    list_filter = (PhaseMultiSelectListFilter,)
 
     def get_exclude(self, request: DjangoRequest, obj: KippoProject | None = None):
         excluded: list[str] = list(super().get_exclude(request, obj) or ())

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -46,6 +46,7 @@ from tasks.periodic.tasks import collect_github_project_issues
 
 from .definitions import NON_PROJECT_CATEGORY_VALUE, UPSELL_CATEGORY_VALUES, WEEKLY_EFFORT_CLOSED_MESSAGE, ProjectProgressStatus, ProjectRoles
 from .exceptions import GithubMilestoneAlreadyExistsError, SlackChannelNotFoundError
+from .filters import PhaseMultiSelectListFilter
 from .functions import (
     generate_kippoprojectusermonthlystatisfaction_csv,
     generate_kippoprojectuserstatisfactionresult_csv,
@@ -58,7 +59,6 @@ from .functions import (
 from .models import (
     _COMPUTE,
     PHASE_CONFIDENCE,
-    VALID_PROJECT_PHASES,
     ActiveKippoProject,
     CollectIssuesAction,
     KippoMilestone,
@@ -79,8 +79,6 @@ from .models import (
 )
 
 if TYPE_CHECKING:
-    from django.contrib.admin.views.main import ChangeList
-
     from .services.forecast import ForecastResult
 
 CLOSE_PROJECT_NO_UPSELL_VALUE = "__no_upsell__"
@@ -1637,56 +1635,6 @@ class KippoProjectAdmin(KippoProjectBaseAdmin):
     # All projects, including closed/inactive — keep display_as_active so the active/closed state
     # is visible at a glance (the only column that differs from the active admin).
     list_display = (*KippoProjectBaseAdmin.list_display, "display_as_active")
-
-
-# Phases pre-selected on the active-project changelist when the フェーズ filter has no query param —
-# the two "in-flight" phases (口頭受注 / 契約(稼働中)). An explicit (even empty) param overrides these,
-# so the "全て" option can still show every active project.
-DEFAULT_ACTIVE_PROJECT_PHASES = ("verbal-order", "under-contract")
-
-
-class PhaseMultiSelectListFilter(admin.SimpleListFilter):
-    """Multi-select フェーズ filter for the active-project changelist.
-
-    Django's built-in field filter is single-select; this renders each phase as a toggle so several
-    can be active at once. With no `phase` query param the two in-flight phases are pre-selected
-    (DEFAULT_ACTIVE_PROJECT_PHASES); the 全て option clears to an explicit empty param so the defaults
-    don't re-apply.
-    """
-
-    title = _("フェーズ")
-    parameter_name = "phase"
-
-    def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
-        return list(VALID_PROJECT_PHASES)
-
-    def selected_phases(self) -> list[str]:
-        # value() is None only when the param is absent -> fall back to the defaults; an empty string
-        # (user cleared the selection via 全て or by deselecting the last phase) means "no filter".
-        value = self.value()
-        if value is None:
-            return list(DEFAULT_ACTIVE_PROJECT_PHASES)
-        return [phase for phase in value.split(",") if phase]
-
-    def queryset(self, request: DjangoRequest, queryset: models.QuerySet) -> models.QuerySet:
-        selected = self.selected_phases()
-        return queryset.filter(phase__in=selected) if selected else queryset
-
-    def choices(self, changelist: "ChangeList"):
-        selected = set(self.selected_phases())
-        yield {
-            "selected": not selected,
-            "query_string": changelist.get_query_string({self.parameter_name: ""}),
-            "display": _("全て"),
-        }
-        for lookup, title in self.lookup_choices:
-            phase = str(lookup)
-            toggled = selected ^ {phase}  # add if absent, remove if present
-            yield {
-                "selected": phase in selected,
-                "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
-                "display": title,
-            }
 
 
 @admin.register(ActiveKippoProject)

--- a/kippo/projects/filters.py
+++ b/kippo/projects/filters.py
@@ -1,0 +1,60 @@
+from typing import TYPE_CHECKING
+
+from django.contrib import admin
+from django.db import models
+from django.http import request as DjangoRequest  # noqa: N812
+from django.utils.translation import gettext_lazy as _
+
+from .models import VALID_PROJECT_PHASES
+
+if TYPE_CHECKING:
+    from django.contrib.admin.views.main import ChangeList
+
+# Phases pre-selected on the active-project changelist when the フェーズ filter has no query param —
+# the two "in-flight" phases (口頭受注 / 契約(稼働中)). An explicit (even empty) param overrides these,
+# so the "全て" option can still show every active project.
+DEFAULT_ACTIVE_PROJECT_PHASES = ("verbal-order", "under-contract")
+
+
+class PhaseMultiSelectListFilter(admin.SimpleListFilter):
+    """Multi-select フェーズ filter for the active-project changelist.
+
+    Django's built-in field filter is single-select; this renders each phase as a toggle so several
+    can be active at once. With no `phase` query param the two in-flight phases are pre-selected
+    (DEFAULT_ACTIVE_PROJECT_PHASES); the 全て option clears to an explicit empty param so the defaults
+    don't re-apply.
+    """
+
+    title = _("フェーズ")
+    parameter_name = "phase"
+
+    def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
+        return list(VALID_PROJECT_PHASES)
+
+    def selected_phases(self) -> list[str]:
+        # value() is None only when the param is absent -> fall back to the defaults; an empty string
+        # (user cleared the selection via 全て or by deselecting the last phase) means "no filter".
+        value = self.value()
+        if value is None:
+            return list(DEFAULT_ACTIVE_PROJECT_PHASES)
+        return [phase for phase in value.split(",") if phase]
+
+    def queryset(self, request: DjangoRequest, queryset: models.QuerySet) -> models.QuerySet:
+        selected = self.selected_phases()
+        return queryset.filter(phase__in=selected) if selected else queryset
+
+    def choices(self, changelist: "ChangeList"):
+        selected = set(self.selected_phases())
+        yield {
+            "selected": not selected,
+            "query_string": changelist.get_query_string({self.parameter_name: ""}),
+            "display": _("全て"),
+        }
+        for lookup, title in self.lookup_choices:
+            phase = str(lookup)
+            toggled = selected ^ {phase}  # add if absent, remove if present
+            yield {
+                "selected": phase in selected,
+                "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
+                "display": title,
+            }

--- a/kippo/projects/filters.py
+++ b/kippo/projects/filters.py
@@ -5,15 +5,10 @@ from django.db import models
 from django.http import request as DjangoRequest  # noqa: N812
 from django.utils.translation import gettext_lazy as _
 
-from .models import VALID_PROJECT_PHASES
+from .models import DEFAULT_ACTIVE_PROJECT_PHASES, VALID_PROJECT_PHASES
 
 if TYPE_CHECKING:
     from django.contrib.admin.views.main import ChangeList
-
-# Phases pre-selected on the active-project changelist when the フェーズ filter has no query param —
-# the two "in-flight" phases (口頭受注 / 契約(稼働中)). An explicit (even empty) param overrides these,
-# so the "全て" option can still show every active project.
-DEFAULT_ACTIVE_PROJECT_PHASES = ("verbal-order", "under-contract")
 
 
 class PhaseMultiSelectListFilter(admin.SimpleListFilter):

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -175,6 +175,9 @@ VALID_PROJECT_PHASES = (
     ("completed", _("完了")),
     ("lost", _("失注")),
 )
+# Phases pre-selected on the active-project admin changelist when the フェーズ filter has no query
+# param — the two "in-flight" phases. See projects.filters.PhaseMultiSelectListFilter.
+DEFAULT_ACTIVE_PROJECT_PHASES = ("verbal-order", "under-contract")
 # phase -> confidence (確度). under-contract/completed == 100 keep the monthly-assignment confirm gate working.
 PHASE_CONFIDENCE = {
     "keep-in-touch": 0,  # KIT = "keep in touch": proposal did not succeed

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -25,19 +25,18 @@ from django.urls import reverse
 from django.utils import timezone
 
 from projects.admin import (
-    DEFAULT_ACTIVE_PROJECT_PHASES,
     ActiveKippoProjectAdmin,
     KippoMilestoneAdmin,
     KippoProjectAdmin,
     KippoProjectAdminForm,
     KippoProjectBaseAdmin,
     KippoProjectContractInline,
-    PhaseMultiSelectListFilter,
     ProjectAssignmentRateInline,
     ProjectWeeklyEffortAdminInline,
     _next_upsell_project_name,
     _start_of_next_month,
 )
+from projects.filters import DEFAULT_ACTIVE_PROJECT_PHASES, PhaseMultiSelectListFilter
 from projects.models import (
     VALID_PROJECT_PHASES,
     ActiveKippoProject,

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -195,17 +195,6 @@ class IsStaffOrganizationKippoProjectAdminTestCase(IsStaffModelAdminTestCaseBase
         self.assertEqual(contract.start_date, date(2026, 3, 15))
         self.assertEqual(contract.end_date, date(2026, 5, 15))
 
-    def test_problem_definition_display_truncates_long_text(self):
-        # changelist column shows a truncated problem_definition as the project intro (kippo#29 / T07)
-        modeladmin = KippoProjectAdmin(KippoProject, self.site)
-        self.project1.problem_definition = "x" * 100
-        self.assertEqual(modeladmin.get_problem_definition_display(self.project1), "x" * 60 + "…")
-
-    def test_problem_definition_display_short_text_untruncated(self):
-        modeladmin = KippoProjectAdmin(KippoProject, self.site)
-        self.project1.problem_definition = "short intro"
-        self.assertEqual(modeladmin.get_problem_definition_display(self.project1), "short intro")
-
     def test_contract_inline_extra_form_prefilled_with_project_period(self):
         # the blank "add contract" row shows the project's dates as initial values
         self.project1.start_date = date(2026, 2, 1)

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -36,8 +36,9 @@ from projects.admin import (
     _next_upsell_project_name,
     _start_of_next_month,
 )
-from projects.filters import DEFAULT_ACTIVE_PROJECT_PHASES, PhaseMultiSelectListFilter
+from projects.filters import PhaseMultiSelectListFilter
 from projects.models import (
+    DEFAULT_ACTIVE_PROJECT_PHASES,
     VALID_PROJECT_PHASES,
     ActiveKippoProject,
     KippoMilestone,

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -25,18 +25,21 @@ from django.urls import reverse
 from django.utils import timezone
 
 from projects.admin import (
+    DEFAULT_ACTIVE_PROJECT_PHASES,
     ActiveKippoProjectAdmin,
     KippoMilestoneAdmin,
     KippoProjectAdmin,
     KippoProjectAdminForm,
     KippoProjectBaseAdmin,
     KippoProjectContractInline,
+    PhaseMultiSelectListFilter,
     ProjectAssignmentRateInline,
     ProjectWeeklyEffortAdminInline,
     _next_upsell_project_name,
     _start_of_next_month,
 )
 from projects.models import (
+    VALID_PROJECT_PHASES,
     ActiveKippoProject,
     KippoMilestone,
     KippoProject,
@@ -2034,3 +2037,72 @@ class KippoProjectChangelistQueryCountTestCase(IsStaffModelAdminTestCaseBase):
             many_query_count,
             f"changelist query count scales with rows (3 rows: {few_query_count}, 9 rows: {many_query_count}) — N+1 regression",
         )
+
+
+class ActiveProjectPhaseFilterTestCase(IsStaffModelAdminTestCaseBase):
+    """PhaseMultiSelectListFilter on the ActiveKippoProject changelist (multi-select, default-selected phases)."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        super().setUp()
+        columnset = ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK)
+        self.all_phases = ("verbal-order", "under-contract", "proposing-low", "completed")
+        # one active project per phase (display_as_active=True / is_closed=False by default => all active)
+        for phase in self.all_phases:
+            KippoProject.objects.create(
+                organization=self.organization,
+                name=f"project-{phase}",
+                phase=phase,
+                category=_global_category("other"),
+                columnset=columnset,
+                start_date=timezone.now().date(),
+                created_by=self.github_manager,
+                updated_by=self.github_manager,
+            )
+        self.modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+
+    def _changelist_phases(self, query: str = "") -> set:
+        request = RequestFactory().get(f"/admin/projects/activekippoproject/{query}")
+        request.user = self.superuser_no_org
+        changelist = self.modeladmin.get_changelist_instance(request)
+        return set(changelist.queryset.values_list("phase", flat=True))
+
+    def _phase_filter_choices(self, query: str = "") -> list:
+        request = RequestFactory().get(f"/admin/projects/activekippoproject/{query}")
+        request.user = self.superuser_no_org
+        changelist = self.modeladmin.get_changelist_instance(request)
+        spec = next(f for f in changelist.filter_specs if isinstance(f, PhaseMultiSelectListFilter))
+        return list(spec.choices(changelist))
+
+    def test_filter_registered_on_active_admin_only(self):
+        self.assertIn(PhaseMultiSelectListFilter, self.modeladmin.list_filter)
+        # the all-projects admin keeps the default (empty) list_filter — the filter is active-only
+        self.assertNotIn(PhaseMultiSelectListFilter, KippoProjectAdmin(KippoProject, self.site).list_filter)
+
+    def test_default_phases_preselected_when_no_param(self):
+        # no `phase` query param => only the two in-flight phases show
+        self.assertEqual(self._changelist_phases(), set(DEFAULT_ACTIVE_PROJECT_PHASES))
+
+    def test_single_phase_param_filters(self):
+        self.assertEqual(self._changelist_phases("?phase=completed"), {"completed"})
+
+    def test_multiple_phases_comma_separated(self):
+        self.assertEqual(self._changelist_phases("?phase=proposing-low,completed"), {"proposing-low", "completed"})
+
+    def test_empty_phase_param_shows_all_active(self):
+        # an explicit empty param (全て / all deselected) overrides the defaults and filters nothing
+        self.assertEqual(self._changelist_phases("?phase="), set(self.all_phases))
+
+    def test_default_phases_rendered_selected(self):
+        # the sidebar pre-highlights the two default phases when no param is present
+        phase_labels = dict(VALID_PROJECT_PHASES)
+        expected = {str(phase_labels[phase]) for phase in DEFAULT_ACTIVE_PROJECT_PHASES}
+        selected = {str(choice["display"]) for choice in self._phase_filter_choices() if choice["selected"]}
+        self.assertEqual(selected, expected)
+
+    def test_all_option_selected_when_param_empty(self):
+        choices = self._phase_filter_choices("?phase=")
+        self.assertEqual(str(choices[0]["display"]), "全て")
+        self.assertTrue(choices[0]["selected"])
+        self.assertFalse(any(choice["selected"] for choice in choices[1:]))


### PR DESCRIPTION
Two related tweaks to the project admin.

## 1. Remove the project problem definition column

Removes the **プロジェクト課題定義** (project problem definition) column from the `KippoProjectAdmin` changelist.

- Drops `get_problem_definition_display` from the shared `KippoProjectBaseAdmin.list_display` (removing it from both the all-projects and active-projects changelists).
- Deletes the now-unused `get_problem_definition_display` display method.

Only the changelist column is removed. The `problem_definition` field is unchanged elsewhere: still on the model and REST serializer, still on the admin add/change form (required at registration), still in `search_fields`. The separate `requirements.ProjectProblemDefinition` admin is untouched.

## 2. Multi-select phase filter on the active-project changelist

Adds `PhaseMultiSelectListFilter` to `ActiveKippoProjectAdmin` only.

- Unlike Django's single-select field filter, each **フェーズ** is a toggle so several phases can be active at once.
- With no `phase` query param the two in-flight phases — **口頭受注** (`verbal-order`) and **契約(稼働中)** (`under-contract`) — are pre-selected.
- A **全て** option (and deselecting the last phase) clears to an explicit empty param, so the defaults don't re-apply and all active projects show.

## Tests

- Removed the two changelist-column unit tests that exercised the deleted method.
- Added `ActiveProjectPhaseFilterTestCase` (7 tests): default pre-selection, single/multi/empty-param filtering, sidebar "selected" rendering, and active-admin-only registration.
- `projects.tests.test_admin` — 133 passed; ruff clean.