### PR TITLE
Contract period becomes the single source of project dates once a contract exists

### DIFF
--- a/kippo/customers/tests/test_viewset.py
+++ b/kippo/customers/tests/test_viewset.py
@@ -402,10 +402,11 @@ class KippoCustomerChangelistParityTestCase(TestCase):
         # customer A: a project ending this FY (qualifies for recent_ending) + a contract ending this FY
         ending = self._make_project("acme-ending", self.customer, date(self.today.year, 6, 30))
         self._make_contract(ending, "2000000", date(self.today.year, 6, 30))
-        # customer B (empty_customer): a contract ending this FY but its project ends far in the future
-        # → excluded by recent_ending, so its planned total drops out of the summary
+        # customer B (empty_customer): its contract — and therefore its project, since the contract
+        # period syncs onto the project dates — ends far in the future → excluded by recent_ending,
+        # so its planned total drops out of the summary
         far = self._make_project("zeta-far", self.empty_customer, date(self.today.year + 2, 6, 30))
-        self._make_contract(far, "5000000", date(self.today.year, 6, 30))
+        self._make_contract(far, "5000000", date(self.today.year + 2, 6, 30))
 
         self.client.force_authenticate(user=self.user)
         response = self.client.get(f"{settings.URL_PREFIX}/api/customers/fiscal-year-summary/?recent_ending=true")

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1066,6 +1066,13 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         # in save_model (see below). Hidden from the form for every user.
         if "columnset" not in excluded:
             excluded.append("columnset")
+        # Once a contract exists its period is the single source of truth (synced onto the project
+        # by KippoProjectContract._sync_project_period) — hide the project's own date fields; the
+        # contract inline is the editable input.
+        if obj is not None and obj.get_contract() is not None:
+            for fieldname in ("start_date", "target_date"):
+                if fieldname not in excluded:
+                    excluded.append(fieldname)
         return tuple(excluded)
 
     @staticmethod

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -206,13 +206,9 @@ class KippoProjectContractInline(LockWhenProjectClosedInlineMixin, AllowIsStaffA
     model = KippoProjectContract
     extra = 1
     max_num = 1  # OneToOne — one contract per project (kippo#31)
+    min_num = 0  # the contract is added on a later edit, not at registration (the inline is hidden on /add/)
     fields = ("billing_type", "pricing_basis", "total_amount", "estimated_monthly_amount", "start_date", "end_date", "note")
     inlines = (KippoProjectBillingEntryInline,)  # billing entries nested under the contract (django-nested-admin)
-
-    def get_min_num(self, request: DjangoRequest, obj: KippoProject | None = None, **kwargs):
-        # 請求方法 is required at project registration (kippo#40 / T19): require the contract on /add/.
-        # Editing an existing project is unaffected (existing contract-less projects still save).
-        return 1 if obj is None else 0
 
     def get_formset(self, request: DjangoRequest, obj: KippoProject | None = None, **kwargs):
         """Pre-fill the new contract row's period with the project's dates so the admin user
@@ -803,18 +799,15 @@ add_calendar_links_to_slack_channels_action.short_description = _("Add MTG calen
 
 
 class KippoProjectAdminForm(forms.ModelForm):
-    # Required at project registration (kippo#40 / T19; extended in kippo#41) — enforced create-only so
-    # existing rows/edits are unaffected. The model keeps these fields nullable; they are marked
-    # required on the add form (see __init__) so each renders with the required marker and is validated
-    # per-field. name/organization are NOT NULL and category/phase carry model defaults (already
-    # enforced by the model/ModelForm). allocated_staff_days is NOT here — it is conditionally required
-    # (see clean()). 請求方法 is enforced via the required contract inline (KippoProjectContractInline.get_min_num).
+    # Required at project registration (kippo#40 / T19; slimmed for the contract-driven flow) —
+    # enforced create-only so existing rows/edits are unaffected. The model keeps these fields
+    # nullable; they are marked required on the add form (see __init__) so each renders with the
+    # required marker and is validated per-field. name/organization are NOT NULL and category/phase
+    # carry model defaults (already enforced by the model/ModelForm). Everything else — PM,
+    # target_date, problem_definition, estimates, the contract — is added on a later edit.
     REQUIRED_AT_REGISTRATION = (
         "customer",
-        "project_manager",
         "start_date",
-        "target_date",
-        "problem_definition",
     )
 
     class Meta:
@@ -842,6 +835,10 @@ class KippoProjectAdminForm(forms.ModelForm):
         allocated_staff_days = cleaned_data.get("allocated_staff_days")
         is_non_project = getattr(category, "key", None) == NON_PROJECT_CATEGORY_VALUE
         needs_estimate = not self.instance.is_closed and not is_non_project and PHASE_CONFIDENCE.get(phase) == FULL_CONFIDENCE
+        # the slim /add/ form does not render allocated_staff_days — the estimate requirement is
+        # enforced on the later edit (add_error on an absent field would raise)
+        if "allocated_staff_days" not in self.fields:
+            needs_estimate = False
         if needs_estimate and (allocated_staff_days is None or allocated_staff_days <= 0):
             self.add_error(
                 "allocated_staff_days",
@@ -903,29 +900,28 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
     # attribute so tests and subclasses can reference the same source of truth.
     HIDDEN_ON_ADD_INLINES = (
         # Assignment rates use fixture defaults on /add/ (seeded in save_model); monthly assignments
-        # are managed after the project exists — both hidden on the add form.
+        # are managed after the project exists — both hidden on the add form. The contract is added
+        # on a later edit (registration collects only the slim ADD_FIELDS set).
         ProjectAssignmentRateInline,
         ProjectMonthlyAssignmentInline,
+        KippoProjectContractInline,
         GithubRepositoryProjectInline,
         ProjectWeeklyEffortReadOnlyInine,
         ProjectWeeklyEffortAdminInline,
         KippoProjectStatusReadOnlyInine,
         KippoProjectStatusAdminInline,
     )
-    # /add/ form (kippo#41): flat, no sections — only these required fields, in this order. The upsell
-    # close-wizard add (?_upsell_source=close) instead gets the full sectioned form (see get_fieldsets)
-    # so its prefilled optional fields (parent_project, slack, …) render and save.
+    # /add/ form (kippo#41, slimmed for the contract-driven flow): flat, no sections — registration
+    # collects only these fields; everything else (contract, PM, estimates, …) is added on a later
+    # edit. The upsell close-wizard add (?_upsell_source=close) instead gets the full sectioned form
+    # (see get_fieldsets) so its prefilled optional fields (parent_project, slack, …) render and save.
     ADD_FIELDS = (
         "organization",
         "customer",
         "name",
         "start_date",
-        "target_date",
         "phase",
         "category",
-        "project_manager",
-        "allocated_staff_days",
-        "problem_definition",
     )
     # Shared base columns. KippoProjectAdmin appends display_as_active (it lists closed/inactive
     # projects too); the active admin uses this set as-is.
@@ -1339,7 +1335,9 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         # closed projects: every field is readonly, so base_fields is empty — skip the editable-form tweaks
         if obj is not None and obj.is_closed:
             return form
-        form.base_fields["project_manager"].initial = request.user.id
+        # PM defaults to the acting user; the slim /add/ form doesn't render the field (added on edit)
+        if "project_manager" in form.base_fields:
+            form.base_fields["project_manager"].initial = request.user.id
         try:
             user_initial_organization, user_organizations = get_user_session_organization(request)
             user_memberships = request.user.memberships.all()

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -422,11 +422,20 @@ class KippoProject(UserCreatedBaseModel):
         # 契約(稼働中) requires the contract (with its period) to exist first: the project is created
         # (registration collects only the slim required set), the contract is added on a later edit,
         # and only then can the phase move to under-contract — at which point the contract period
-        # drives the project dates.
-        if self.phase == PHASE_UNDER_CONTRACT:
+        # drives the project dates. Gated on the TRANSITION into the phase only, so rows already
+        # persisted in 契約(稼働中) (legacy projects predating contracts) stay editable/saveable.
+        if self._is_entering_under_contract():
             contract = self.get_contract()
             if not (contract and contract.start_date and contract.end_date):
                 raise ValidationError({"phase": _("A contract (契約) with start/end dates must be saved before setting the phase to 契約(稼働中).")})
+
+    def _is_entering_under_contract(self) -> bool:
+        """True only when this save MOVES the phase into 契約(稼働中) (including a create directly in
+        that phase). A row already persisted in the phase is not re-gated, so legacy projects that
+        reached 契約(稼働中) before contracts existed remain editable. Uses the persisted-phase
+        snapshot taken in ``from_db`` (absent on an unsaved instance → treated as entering).
+        """
+        return self.phase == PHASE_UNDER_CONTRACT and getattr(self, "_confidence_synced_phase", None) != PHASE_UNDER_CONTRACT
 
     def revenue_entries(
         self,
@@ -985,6 +994,12 @@ class KippoProjectContract(UserCreatedBaseModel):
             project.target_date = self.end_date
             update_fields.append("target_date")
         if update_fields:
+            # Attribute the date change to whoever edited the contract (set on the contract by the
+            # viewset/admin), not the project's previous editor. Skip when the contract has no editor
+            # so a good project.updated_by is never overwritten with NULL.
+            if self.updated_by_id:
+                project.updated_by = self.updated_by
+                update_fields.append("updated_by")
             project.save(update_fields=[*update_fields, "updated_datetime"])
 
     def _contract_months(self) -> list[datetime.date]:

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -420,10 +420,10 @@ class KippoProject(UserCreatedBaseModel):
         if self.enable_cost_report and not self.slack_channel_name:
             raise ValidationError(_("slack_channel_name is required when enable_cost_report is True!"))
         # 契約(稼働中) requires the contract (with its period) to exist first: the project is created
-        # before the contract, but once on-going the contract period drives the project dates.
-        # Registration (add) is exempt — the admin add form creates the required contract inline in
-        # the same submit, after this validation runs.
-        if not self._state.adding and self.phase == PHASE_UNDER_CONTRACT:
+        # (registration collects only the slim required set), the contract is added on a later edit,
+        # and only then can the phase move to under-contract — at which point the contract period
+        # drives the project dates.
+        if self.phase == PHASE_UNDER_CONTRACT:
             contract = self.get_contract()
             if not (contract and contract.start_date and contract.end_date):
                 raise ValidationError({"phase": _("A contract (契約) with start/end dates must be saved before setting the phase to 契約(稼働中).")})

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -166,6 +166,9 @@ class ProjectColumn(models.Model):
 # user-editable). The old anon-project value is retired — non-projects are identified by category=="non-project".
 DEFAULT_PROJECT_PHASE = "proposing-low"
 PHASE_UNDER_CONTRACT = "under-contract"
+# Shared by KippoProject.clean() (admin) and KippoProjectSerializer (API) so the gate message stays
+# in one place (and translated) across both layers.
+UNDER_CONTRACT_REQUIRES_CONTRACT_MSG = _("A contract (契約) with start/end dates must be saved before setting the phase to 契約(稼働中).")
 VALID_PROJECT_PHASES = (
     ("keep-in-touch", "KIT"),
     ("proposing-low", _("提案(低)")),
@@ -426,8 +429,8 @@ class KippoProject(UserCreatedBaseModel):
         # persisted in 契約(稼働中) (legacy projects predating contracts) stay editable/saveable.
         if self._is_entering_under_contract():
             contract = self.get_contract()
-            if not (contract and contract.start_date and contract.end_date):
-                raise ValidationError({"phase": _("A contract (契約) with start/end dates must be saved before setting the phase to 契約(稼働中).")})
+            if not (contract and contract.has_complete_period()):
+                raise ValidationError({"phase": UNDER_CONTRACT_REQUIRES_CONTRACT_MSG})
 
     def _is_entering_under_contract(self) -> bool:
         """True only when this save MOVES the phase into 契約(稼働中) (including a create directly in
@@ -965,12 +968,15 @@ class KippoProjectContract(UserCreatedBaseModel):
             raise ValidationError({"estimated_monthly_amount": _("Estimated monthly amount (仮月額) only applies to effort + monthly contracts.")})
 
     def save(self, *args, **kwargs):
-        # auto-populate the contract period from the project when left blank
-        if not self.start_date:
-            self.start_date = self.project.start_date
-        if not self.end_date:
-            self.end_date = self.project.target_date
         is_initial_creation = self._state.adding
+        # auto-populate the contract period from the project when left blank AT CREATION only. On a
+        # later edit a blank date is honored (not re-filled), so end_date can be cleared to model an
+        # open-ended / retainer engagement with no fixed completion (T&M).
+        if is_initial_creation:
+            if not self.start_date:
+                self.start_date = self.project.start_date
+            if not self.end_date:
+                self.end_date = self.project.target_date
         super().save(*args, **kwargs)
         self._sync_project_period()
         # Populate the billing ledger from the terms on initial creation so the user does not have to
@@ -978,6 +984,12 @@ class KippoProjectContract(UserCreatedBaseModel):
         # (as months elapse or effort accrues) via the still-available action / API.
         if is_initial_creation:
             self.generate_billing_entries(created_by=self.created_by)
+
+    def has_complete_period(self) -> bool:
+        """True when both period endpoints are set — the contract can drive the project dates and
+        satisfy the 契約(稼働中) phase gate. Shared by the model gate and the API serializer.
+        """
+        return bool(self.start_date and self.end_date)
 
     def _sync_project_period(self) -> None:
         """Once a contract exists its period is the single source of truth: mirror start_date/end_date

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -165,13 +165,14 @@ class ProjectColumn(models.Model):
 # values are the sales/delivery status. `confidence` is derived from `phase` via PHASE_CONFIDENCE (no longer
 # user-editable). The old anon-project value is retired — non-projects are identified by category=="non-project".
 DEFAULT_PROJECT_PHASE = "proposing-low"
+PHASE_UNDER_CONTRACT = "under-contract"
 VALID_PROJECT_PHASES = (
     ("keep-in-touch", "KIT"),
     ("proposing-low", _("提案(低)")),
     ("proposing-mid", _("提案(中)")),
     ("proposing-high", _("提案(高)")),
     ("verbal-order", _("口頭受注")),
-    ("under-contract", _("契約(稼働中)")),
+    (PHASE_UNDER_CONTRACT, _("契約(稼働中)")),
     ("completed", _("完了")),
     ("lost", _("失注")),
 )
@@ -418,6 +419,14 @@ class KippoProject(UserCreatedBaseModel):
             raise ValidationError(_("Given date is in the future"))
         if self.enable_cost_report and not self.slack_channel_name:
             raise ValidationError(_("slack_channel_name is required when enable_cost_report is True!"))
+        # 契約(稼働中) requires the contract (with its period) to exist first: the project is created
+        # before the contract, but once on-going the contract period drives the project dates.
+        # Registration (add) is exempt — the admin add form creates the required contract inline in
+        # the same submit, after this validation runs.
+        if not self._state.adding and self.phase == PHASE_UNDER_CONTRACT:
+            contract = self.get_contract()
+            if not (contract and contract.start_date and contract.end_date):
+                raise ValidationError({"phase": _("A contract (契約) with start/end dates must be saved before setting the phase to 契約(稼働中).")})
 
     def revenue_entries(
         self,
@@ -954,11 +963,29 @@ class KippoProjectContract(UserCreatedBaseModel):
             self.end_date = self.project.target_date
         is_initial_creation = self._state.adding
         super().save(*args, **kwargs)
+        self._sync_project_period()
         # Populate the billing ledger from the terms on initial creation so the user does not have to
         # run the generate_billing_entries admin action by hand. Idempotent and safe to re-run later
         # (as months elapse or effort accrues) via the still-available action / API.
         if is_initial_creation:
             self.generate_billing_entries(created_by=self.created_by)
+
+    def _sync_project_period(self) -> None:
+        """Once a contract exists its period is the single source of truth: mirror start_date/end_date
+        onto the project's start_date/target_date so every consumer of the project columns
+        (autoassign, forecast, changelist ordering, UI sorting) keeps working unchanged.
+        Never clears a project date — a blank contract date leaves the project value as-is.
+        """
+        project = self.project
+        update_fields = []
+        if self.start_date and project.start_date != self.start_date:
+            project.start_date = self.start_date
+            update_fields.append("start_date")
+        if self.end_date and project.target_date != self.end_date:
+            project.target_date = self.end_date
+            update_fields.append("target_date")
+        if update_fields:
+            project.save(update_fields=[*update_fields, "updated_datetime"])
 
     def _contract_months(self) -> list[datetime.date]:
         """First-of-month dates for each calendar month the contract period [start_date, end_date]

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -433,10 +433,15 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         return attrs
 
     def _validate_contract_synced_dates(self, attrs: dict) -> None:
-        """Once a contract exists its period is the single source of truth — the project's
-        start_date/target_date are synced mirrors (KippoProjectContract._sync_project_period).
-        Reject a *changed* value here so date edits go through the contract endpoint; echoing the
-        stored values back (as the UI edit form does) stays valid.
+        """Once a contract has a period, that period is the single source of truth — the project's
+        start_date/target_date are synced mirrors (KippoProjectContract._sync_project_period). Reject
+        a project-side value that diverges from the contract period so date edits go through the
+        contract endpoint; a value equal to the contract's is a no-op and stays valid.
+
+        Compared against the CONTRACT period (not the stored project value): a project whose stored
+        date drifted from the contract can still be reconciled to the contract value, and a value
+        matching a stale stored date is no longer wrongly accepted. A blank contract date is not
+        managed, so that project field stays directly editable (e.g. a blank-period contract).
         """
         if self.instance is None:
             return
@@ -444,8 +449,8 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         if contract is None:
             return
         errors = {}
-        for field, current in (("start_date", self.instance.start_date), ("target_date", self.instance.target_date)):
-            if field in attrs and attrs[field] != current:
+        for field, contract_value in (("start_date", contract.start_date), ("target_date", contract.end_date)):
+            if contract_value and field in attrs and attrs[field] != contract_value:
                 errors[field] = "This project has a contract; its dates are managed by the contract period (update via the contract endpoint)."
         if errors:
             raise serializers.ValidationError(errors)
@@ -456,8 +461,14 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         directly in this phase is rejected; create in an earlier phase, add the contract, then
         update the phase.
         """
-        phase = attrs.get("phase", getattr(self.instance, "phase", None))
-        if phase != PHASE_UNDER_CONTRACT:
+        incoming_phase = attrs.get("phase", getattr(self.instance, "phase", None))
+        if incoming_phase != PHASE_UNDER_CONTRACT:
+            return
+        # Transition-only: a project already persisted in 契約(稼働中) (e.g. legacy rows created before
+        # contracts existed) stays editable — only a *move into* the phase is gated. Without this, any
+        # PATCH (even name-only, since the SPA always sends phase) would re-fire the gate and 400.
+        stored_phase = getattr(self.instance, "phase", None)
+        if self.instance is not None and stored_phase == PHASE_UNDER_CONTRACT:
             return
         contract = self.instance.get_contract() if self.instance is not None else None
         if not (contract and contract.start_date and contract.end_date):

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -417,13 +417,13 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         self._validate_parent_project(attrs, organization)
         self._validate_enable_cost_report(attrs)
 
-        # Required-field validation at project registration (kippo#40 / T19). Create-only — edits of
-        # existing rows (and existing data) are unaffected. category/phase always carry model defaults,
-        # so the enforced gaps are the genuinely-optional fields. 請求方法 (billing method) lives on
-        # KippoProjectContract since kippo#31; the API cannot attach a contract at project-create
-        # (no nested write), so that requirement is enforced on the admin registration form instead.
+        # Required-field validation at project registration (kippo#40 / T19; slimmed for the
+        # contract-driven flow). Create-only — edits of existing rows (and existing data) are
+        # unaffected. name/organization are NOT NULL and category/phase carry model defaults, so
+        # registration only additionally requires customer + start_date; everything else (PM,
+        # target_date, the contract, estimates) is added on a later edit.
         if self.instance is None:
-            required_at_registration = ("customer", "project_manager", "start_date", "target_date")
+            required_at_registration = ("customer", "start_date")
             missing = {field: "This field is required at project registration." for field in required_at_registration if not attrs.get(field)}
             if missing:
                 raise serializers.ValidationError(missing)

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -20,6 +20,7 @@ from .definitions import (
 )
 from .functions import previous_week_startdate
 from .models import (
+    PHASE_UNDER_CONTRACT,
     KippoProject,
     KippoProjectBillingEntry,
     KippoProjectContract,
@@ -426,7 +427,43 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             missing = {field: "This field is required at project registration." for field in required_at_registration if not attrs.get(field)}
             if missing:
                 raise serializers.ValidationError(missing)
+
+        self._validate_contract_synced_dates(attrs)
+        self._validate_under_contract_phase(attrs)
         return attrs
+
+    def _validate_contract_synced_dates(self, attrs: dict) -> None:
+        """Once a contract exists its period is the single source of truth — the project's
+        start_date/target_date are synced mirrors (KippoProjectContract._sync_project_period).
+        Reject a *changed* value here so date edits go through the contract endpoint; echoing the
+        stored values back (as the UI edit form does) stays valid.
+        """
+        if self.instance is None:
+            return
+        contract = self.instance.get_contract()
+        if contract is None:
+            return
+        errors = {}
+        for field, current in (("start_date", self.instance.start_date), ("target_date", self.instance.target_date)):
+            if field in attrs and attrs[field] != current:
+                errors[field] = "This project has a contract; its dates are managed by the contract period (update via the contract endpoint)."
+        if errors:
+            raise serializers.ValidationError(errors)
+
+    def _validate_under_contract_phase(self, attrs: dict) -> None:
+        """契約(稼働中) requires the contract (with its period) to exist first — mirrors
+        KippoProject.clean(). The API cannot attach a contract at project-create, so a create
+        directly in this phase is rejected; create in an earlier phase, add the contract, then
+        update the phase.
+        """
+        phase = attrs.get("phase", getattr(self.instance, "phase", None))
+        if phase != PHASE_UNDER_CONTRACT:
+            return
+        contract = self.instance.get_contract() if self.instance is not None else None
+        if not (contract and contract.start_date and contract.end_date):
+            raise serializers.ValidationError(
+                {"phase": "A contract (契約) with start/end dates must be saved before setting the phase to 契約(稼働中)."}
+            )
 
     def _validate_parent_project(self, attrs: dict, organization: "KippoOrganization | None") -> None:
         """parent_project (upsell) must be same-org and not the project itself (admin parity)."""

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -21,6 +21,7 @@ from .definitions import (
 from .functions import previous_week_startdate
 from .models import (
     PHASE_UNDER_CONTRACT,
+    UNDER_CONTRACT_REQUIRES_CONTRACT_MSG,
     KippoProject,
     KippoProjectBillingEntry,
     KippoProjectContract,
@@ -461,20 +462,16 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         directly in this phase is rejected; create in an earlier phase, add the contract, then
         update the phase.
         """
-        incoming_phase = attrs.get("phase", getattr(self.instance, "phase", None))
-        if incoming_phase != PHASE_UNDER_CONTRACT:
-            return
-        # Transition-only: a project already persisted in 契約(稼働中) (e.g. legacy rows created before
-        # contracts existed) stays editable — only a *move into* the phase is gated. Without this, any
-        # PATCH (even name-only, since the SPA always sends phase) would re-fire the gate and 400.
+        # Transition-only: gate only a *move into* 契約(稼働中). A row already persisted in the phase
+        # (e.g. legacy rows created before contracts existed) stays editable — otherwise any PATCH
+        # (even name-only, since the SPA always sends phase) would re-fire the gate and 400.
         stored_phase = getattr(self.instance, "phase", None)
-        if self.instance is not None and stored_phase == PHASE_UNDER_CONTRACT:
+        incoming_phase = attrs.get("phase", stored_phase)
+        if incoming_phase != PHASE_UNDER_CONTRACT or stored_phase == PHASE_UNDER_CONTRACT:
             return
         contract = self.instance.get_contract() if self.instance is not None else None
-        if not (contract and contract.start_date and contract.end_date):
-            raise serializers.ValidationError(
-                {"phase": "A contract (契約) with start/end dates must be saved before setting the phase to 契約(稼働中)."}
-            )
+        if not (contract and contract.has_complete_period()):
+            raise serializers.ValidationError({"phase": UNDER_CONTRACT_REQUIRES_CONTRACT_MSG})
 
     def _validate_parent_project(self, attrs: dict, organization: "KippoOrganization | None") -> None:
         """parent_project (upsell) must be same-org and not the project itself (admin parity)."""

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -799,23 +799,23 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
         form = KippoProjectAdminForm(data=self._form_data(category="other"))
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_registration_requires_customer_pm_and_dates(self):
-        # add-form missing the required registration fields is invalid (kippo#40 / T19)
+    def test_registration_requires_customer_and_start_date(self):
+        # add-form missing the slim required registration fields is invalid (kippo#40 / T19, slimmed)
         data = self._form_data(category="other")
-        for field in ("customer", "project_manager", "start_date", "target_date"):
+        for field in ("customer", "start_date"):
             del data[field]
         form = KippoProjectAdminForm(data=data)
         self.assertFalse(form.is_valid())
-        for field in ("customer", "project_manager", "start_date", "target_date"):
+        for field in ("customer", "start_date"):
             self.assertIn(field, form.errors)
 
-    def test_registration_requires_problem_definition(self):
-        # kippo#41: problem_definition is required at registration (allocated_staff_days is conditional)
+    def test_registration_does_not_require_pm_dates_or_problem_definition(self):
+        # slimmed registration: PM / target_date / problem_definition are added on a later edit
         data = self._form_data(category="other")
-        del data["problem_definition"]
+        for field in ("project_manager", "target_date", "problem_definition"):
+            del data[field]
         form = KippoProjectAdminForm(data=data)
-        self.assertFalse(form.is_valid())
-        self.assertIn("problem_definition", form.errors)
+        self.assertTrue(form.is_valid(), form.errors)
 
     def test_non_full_confidence_allows_zero_or_blank_allocated_staff_days(self):
         # phase proposing-low → confidence < 100 → allocated_staff_days need not be positive
@@ -904,11 +904,14 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
         form = KippoProjectAdminForm(instance=existing, data=data)
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_contract_inline_required_on_add_optional_on_change(self):
-        # 請求方法 required at registration via the contract inline (kippo#40 / T19)
+    def test_contract_inline_not_required_and_hidden_on_add(self):
+        # the contract is added on a later edit — nothing contract-related at registration
         inline = KippoProjectContractInline(parent_model=KippoProject, admin_site=self.site)
-        self.assertEqual(inline.get_min_num(request=self.super_user_request, obj=None), 1)
-        self.assertEqual(inline.get_min_num(request=self.super_user_request, obj=self.parent), 0)
+        self.assertFalse(inline.get_min_num(request=self.super_user_request, obj=None))
+        self.assertFalse(inline.get_min_num(request=self.super_user_request, obj=self.parent))
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        self.assertNotIn(KippoProjectContractInline, modeladmin.get_inlines(self.super_user_request, obj=None))
+        self.assertIn(KippoProjectContractInline, modeladmin.get_inlines(self.super_user_request, obj=self.parent))
 
     def test_change_form_with_upsell_category_uses_persisted_parent_when_field_omitted(self):
         # change form: parent_project is readonly so it isn't submitted in POST data;
@@ -1600,12 +1603,13 @@ class KippoProjectAdminContractPeriodFieldsTestCase(KippoProjectAdminFixtureTest
         self.assertNotIn("start_date", fields)
         self.assertNotIn("target_date", fields)
 
-    def test_add_form_keeps_dates(self):
-        # registration still collects the initial start/target dates (kippo#40 / T19)
+    def test_add_form_keeps_start_date(self):
+        # slim registration still collects the initial start_date; target_date arrives with the
+        # contract (or a later edit)
         modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
         fields = self._all_fieldset_fields(modeladmin.get_fieldsets(self.super_user_request, obj=None))
         self.assertIn("start_date", fields)
-        self.assertIn("target_date", fields)
+        self.assertNotIn("target_date", fields)
 
     def test_change_view_renders_with_contract(self):
         KippoProjectContract.objects.create(

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1568,6 +1568,60 @@ class KippoProjectAddFormBehaviorTestCase(KippoProjectAdminFixtureTestCaseBase):
         self.assertNotIsInstance(form.fields["customer"].widget, forms.HiddenInput)
 
 
+class KippoProjectAdminContractPeriodFieldsTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """start_date/target_date disappear from the project change form once a contract exists —
+    the contract period (synced onto the project) is the single editable input.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.existing_project = self.make_project("contract-period-project")
+
+    @staticmethod
+    def _all_fieldset_fields(fieldsets: list) -> list:
+        return [f for _label, opts in fieldsets for f in opts.get("fields", ())]
+
+    def test_dates_visible_without_contract(self):
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        fields = self._all_fieldset_fields(modeladmin.get_fieldsets(self.super_user_request, obj=self.existing_project))
+        self.assertIn("start_date", fields)
+        self.assertIn("target_date", fields)
+
+    def test_dates_hidden_with_contract(self):
+        KippoProjectContract.objects.create(
+            project=self.existing_project,
+            total_amount=100000,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        project = KippoProject.objects.get(pk=self.existing_project.pk)
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        fields = self._all_fieldset_fields(modeladmin.get_fieldsets(self.super_user_request, obj=project))
+        self.assertNotIn("start_date", fields)
+        self.assertNotIn("target_date", fields)
+
+    def test_add_form_keeps_dates(self):
+        # registration still collects the initial start/target dates (kippo#40 / T19)
+        modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        fields = self._all_fieldset_fields(modeladmin.get_fieldsets(self.super_user_request, obj=None))
+        self.assertIn("start_date", fields)
+        self.assertIn("target_date", fields)
+
+    def test_change_view_renders_with_contract(self):
+        KippoProjectContract.objects.create(
+            project=self.existing_project,
+            total_amount=100000,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        url = reverse("admin:projects_kippoproject_change", args=[self.existing_project.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        form = response.context["adminform"].form
+        self.assertNotIn("start_date", form.fields)
+        self.assertNotIn("target_date", form.fields)
+
+
 class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixtureTestCaseBase):
     """parent_project (kippo#41): absent from the flat /add/ form; exposed (hidden) only on the upsell
     close-wizard add; in the Details section (readonly) on change.

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -1636,6 +1636,28 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         self.project.refresh_from_db()
         self.assertEqual(self.project.target_date, datetime.date(2026, 12, 31))
 
+    def test_contract_end_date_clearable_via_api_for_open_ended(self):
+        """The contract endpoint can clear end_date (→ null) to model an open-ended engagement; the
+        blank is honored rather than re-filled from the project on update.
+        """
+        url = f"{self.base}/{self.project.id}/contract/"
+        resp = self.client.post(
+            url,
+            {
+                "billing_type": "delivery",
+                "pricing_basis": "fixed",
+                "total_amount": "1500000",
+                "start_date": "2026-01-01",
+                "end_date": "2026-09-30",
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, HTTPStatus.CREATED, resp.content)
+        contract_id = resp.json()["id"]
+        patch = self.client.patch(f"{url}{contract_id}/", {"end_date": None}, format="json")
+        self.assertEqual(patch.status_code, HTTPStatus.OK, patch.content)
+        self.assertIsNone(patch.json()["end_date"])
+
     def test_contract_write_rejected_on_closed_project(self):
         """A closed project's dates are final; the contract endpoint refuses update/delete so a
         contract save cannot silently shift the locked project period (admin parity).

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -1067,7 +1067,9 @@ class PermissionsTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
     def test_create_missing_required_registration_fields_rejected(self):
-        """Registration requires customer/PM/start_date/target_date (kippo#40 / T19)."""
+        """Registration requires customer + start_date (kippo#40 / T19, slimmed); PM / target_date /
+        the contract are added on a later edit.
+        """
         self.client.force_authenticate(user=self.superuser)
         url = f"{settings.URL_PREFIX}/api/projects/"
         data = {
@@ -1077,8 +1079,36 @@ class PermissionsTestCase(TestCase):
         }
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
-        for field in ("customer", "project_manager", "start_date", "target_date"):
+        for field in ("customer", "start_date"):
             self.assertIn(field, response.json())
+        for field in ("project_manager", "target_date"):
+            self.assertNotIn(field, response.json())
+
+    def test_create_with_only_slim_registration_fields_succeeds(self):
+        """A create sending only the slim required set (customer, name, start_date + org/phase/category
+        defaults) is accepted — everything else is added on a later edit.
+        """
+        from customers.models import KippoCustomer
+
+        customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="slim-reg-customer",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.client.force_authenticate(user=self.superuser)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Slim Registration Project",
+            "organization": str(self.organization.id),
+            "columnset": self.project.columnset.id,
+            "customer": str(customer.id),
+            "start_date": "2026-08-01",
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
+        created = KippoProject.objects.get(name="Slim Registration Project")
+        self.assertIsNone(created.project_manager)
 
     def test_edit_existing_project_not_blocked_by_registration_requirements(self):
         """The required-field validation is create-only; editing a contract-less / customer-less

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -219,10 +219,23 @@ class KippoProjectViewSetTestCase(TestCase):
         response = self.client.patch(url, {"confidence": 150}, format="json")
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
+    def _create_contract(self, **kwargs) -> KippoProjectContract:
+        """Contract for self.project — its period backfills from the project dates set in setUp."""
+        from decimal import Decimal
+
+        defaults = {
+            "project": self.project,
+            "total_amount": Decimal("900000"),
+            "created_by": self.github_manager,
+            "updated_by": self.github_manager,
+        }
+        return KippoProjectContract.objects.create(**{**defaults, **kwargs})
+
     def test_confidence_follows_phase_when_both_changed(self):
         """When an update also changes phase, confidence is re-derived from the new phase and any
         sent confidence is ignored (documented last-writer behavior).
         """
+        self._create_contract()  # phase under-contract requires a contract with a period
         url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
         response = self.client.patch(url, {"phase": "under-contract", "confidence": 42}, format="json")
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -230,6 +243,47 @@ class KippoProjectViewSetTestCase(TestCase):
         self.project.refresh_from_db()
         self.assertEqual(self.project.confidence, PHASE_CONFIDENCE["under-contract"])
         self.assertEqual(self.project.phase, "under-contract")
+
+    def test_patch_phase_under_contract_without_contract_rejected(self):
+        """契約(稼働中) requires an existing contract with a period."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(url, {"phase": "under-contract"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("phase", response.json())
+
+    def test_patch_project_dates_rejected_when_contract_exists(self):
+        """Once a contract exists its period is the single source of truth — a *changed*
+        start_date/target_date on the project is rejected (update the contract instead).
+        """
+        self._create_contract()  # period backfills to 2024-01-01 .. 2024-03-31
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(url, {"start_date": "2024-02-01"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("start_date", response.json())
+        response = self.client.patch(url, {"target_date": "2024-06-30"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("target_date", response.json())
+
+    def test_patch_project_dates_echoing_stored_values_accepted_with_contract(self):
+        """A client that sends the unchanged dates back (as the UI edit form does) still saves."""
+        self._create_contract()
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(
+            url,
+            {"name": "Renamed With Contract", "start_date": "2024-01-01", "target_date": "2024-03-31"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json()["name"], "Renamed With Contract")
+
+    def test_patch_project_dates_editable_without_contract(self):
+        """Pre-contract, the project dates stay directly editable."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(url, {"start_date": "2024-02-01", "target_date": "2024-08-31"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.start_date, datetime.date(2024, 2, 1))
+        self.assertEqual(self.project.target_date, datetime.date(2024, 8, 31))
 
     def test_list_exposes_category_label_and_billing_types(self):
         """List/detail expose category_label + the contract billing_type (kippo#39 / T14)."""
@@ -952,6 +1006,23 @@ class PermissionsTestCase(TestCase):
         self.assertEqual(created.created_by, self.user)
         self.assertEqual(created.updated_by, self.user)
 
+    def test_create_project_in_under_contract_phase_rejected(self):
+        """The API cannot attach a contract at project-create, so a create directly in 契約(稼働中)
+        is rejected — create in an earlier phase, add the contract, then update the phase.
+        """
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Under Contract At Create",
+            "organization": str(self.organization.id),
+            "columnset": self.project.columnset.id,
+            "phase": "under-contract",
+            **_registration_fields(self.organization, self.user),
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("phase", response.json())
+
     def test_regular_user_cannot_create_project_in_other_org(self):
         """Org-member cannot POST /api/projects/ for an org they don't belong to (kippo#284)."""
         other_org = KippoOrganization.objects.create(
@@ -1495,6 +1566,32 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         patch = self.client.patch(f"{url}{contract_id}/", {"total_amount": "2000000"}, format="json")
         self.assertEqual(patch.status_code, HTTPStatus.OK, patch.content)
         self.assertEqual(self.project.contract.total_amount, 2000000)
+
+    def test_contract_period_update_syncs_project_dates(self):
+        """The contract endpoint is the write path for the period once a contract exists — a PATCH
+        of the contract dates mirrors onto the project's start_date/target_date.
+        """
+        url = f"{self.base}/{self.project.id}/contract/"
+        resp = self.client.post(
+            url,
+            {
+                "billing_type": "delivery",
+                "pricing_basis": "fixed",
+                "total_amount": "1500000",
+                "start_date": "2026-01-01",
+                "end_date": "2026-09-30",
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, HTTPStatus.CREATED, resp.content)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.start_date, datetime.date(2026, 1, 1))
+        self.assertEqual(self.project.target_date, datetime.date(2026, 9, 30))
+        contract_id = resp.json()["id"]
+        patch = self.client.patch(f"{url}{contract_id}/", {"end_date": "2026-12-31"}, format="json")
+        self.assertEqual(patch.status_code, HTTPStatus.OK, patch.content)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.target_date, datetime.date(2026, 12, 31))
 
     def test_second_contract_rejected(self):
         url = f"{self.base}/{self.project.id}/contract/"

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -251,6 +251,19 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertIn("phase", response.json())
 
+    def test_patch_existing_under_contract_without_contract_not_blocked(self):
+        """A legacy project already in 契約(稼働中) with no contract (predating contracts) stays editable:
+        the phase gate fires only on the transition INTO the phase, not on every edit. The SPA always
+        sends phase, so a name-only edit round-trips phase='under-contract'.
+        """
+        KippoProject.objects.filter(pk=self.project.pk).update(phase="under-contract")
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.patch(url, {"name": "Legacy Renamed", "phase": "under-contract"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.name, "Legacy Renamed")
+        self.assertEqual(self.project.phase, "under-contract")
+
     def test_patch_project_dates_rejected_when_contract_exists(self):
         """Once a contract exists its period is the single source of truth — a *changed*
         start_date/target_date on the project is rejected (update the contract instead).
@@ -1622,6 +1635,29 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         self.assertEqual(patch.status_code, HTTPStatus.OK, patch.content)
         self.project.refresh_from_db()
         self.assertEqual(self.project.target_date, datetime.date(2026, 12, 31))
+
+    def test_contract_write_rejected_on_closed_project(self):
+        """A closed project's dates are final; the contract endpoint refuses update/delete so a
+        contract save cannot silently shift the locked project period (admin parity).
+        """
+        contract = KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type="delivery",
+            pricing_basis="fixed",
+            total_amount=1500000,
+            start_date="2026-01-01",
+            end_date="2026-09-30",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        KippoProject.objects.filter(pk=self.project.pk).update(is_closed=True)
+        url = f"{self.base}/{self.project.id}/contract/{contract.id}/"
+        resp = self.client.patch(url, {"end_date": "2026-12-31"}, format="json")
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST, resp.content)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.target_date, datetime.date(2026, 9, 30))  # unchanged
+        resp = self.client.delete(url)
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST, resp.content)
 
     def test_second_contract_rejected(self):
         url = f"{self.base}/{self.project.id}/contract/"

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -858,6 +858,14 @@ class KippoProjectUnderContractPhaseGateTestCase(TestCase):
             project.clean()
         self.assertIn("phase", context.exception.message_dict)
 
+    def test_clean_allows_legacy_under_contract_row_without_contract(self):
+        # a row already persisted in 契約(稼働中) with no contract (legacy data predating contracts) is
+        # NOT re-gated: the gate fires only on the TRANSITION into the phase, so the row stays editable
+        KippoProject.objects.filter(pk=self.project.pk).update(phase=PHASE_UNDER_CONTRACT)
+        project = KippoProject.objects.get(pk=self.project.pk)  # from_db snapshots phase=under-contract
+        project.name = "legacy edit"
+        project.clean()  # does not raise despite having no contract
+
     def test_clean_rejects_under_contract_phase_at_registration(self):
         # registration collects only the slim required set (no contract inline on /add/), so an
         # unsaved instance can never satisfy the gate — create first, add the contract, then flip

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -858,13 +858,15 @@ class KippoProjectUnderContractPhaseGateTestCase(TestCase):
             project.clean()
         self.assertIn("phase", context.exception.message_dict)
 
-    def test_clean_exempts_registration(self):
-        # the admin add form creates the required contract inline in the same submit, after this
-        # validation runs — an unsaved (adding) instance is exempt
+    def test_clean_rejects_under_contract_phase_at_registration(self):
+        # registration collects only the slim required set (no contract inline on /add/), so an
+        # unsaved instance can never satisfy the gate — create first, add the contract, then flip
         project = KippoProject(
             organization=self.project.organization,
             name="registration-under-contract",
             phase=PHASE_UNDER_CONTRACT,
             columnset=self.project.columnset,
         )
-        project.clean()  # does not raise
+        with self.assertRaises(ValidationError) as context:
+            project.clean()
+        self.assertIn("phase", context.exception.message_dict)

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -20,9 +20,11 @@ from projects.definitions import (
 from projects.models import (
     DEFAULT_PROJECT_PHASE,
     PHASE_CONFIDENCE,
+    PHASE_UNDER_CONTRACT,
     VALID_PROJECT_PHASES,
     KippoMilestone,
     KippoProject,
+    KippoProjectContract,
     KippoProjectOrganizationCategory,
 )
 
@@ -814,3 +816,55 @@ class KippoProjectPhaseStatusTestCase(TestCase):
     def test_only_contract_and_completed_reach_full_confidence(self):
         full = {phase for phase, conf in PHASE_CONFIDENCE.items() if conf == FULL_CONFIDENCE_PERCENTAGE}
         self.assertEqual(full, {"under-contract", "completed"})
+
+
+class KippoProjectUnderContractPhaseGateTestCase(TestCase):
+    """phase 契約(稼働中) requires an existing contract with a period — enforced in KippoProject.clean()
+    (admin change form) and mirrored in KippoProjectSerializer (API).
+    """
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.project = created["KippoProject"]
+        self.user = created["KippoUser"]
+
+    def test_clean_rejects_under_contract_phase_without_contract(self):
+        self.project.phase = PHASE_UNDER_CONTRACT
+        with self.assertRaises(ValidationError) as context:
+            self.project.clean()
+        self.assertIn("phase", context.exception.message_dict)
+
+    def test_clean_allows_under_contract_phase_with_contract_period(self):
+        self.project.start_date = datetime.date(2026, 1, 1)
+        self.project.target_date = datetime.date(2026, 6, 30)
+        self.project.save()
+        # contract period backfills from the project dates on save
+        KippoProjectContract.objects.create(project=self.project, total_amount=100000)
+        project = KippoProject.objects.get(pk=self.project.pk)
+        project.phase = PHASE_UNDER_CONTRACT
+        project.clean()  # does not raise
+
+    def test_clean_rejects_under_contract_phase_when_contract_period_incomplete(self):
+        # no project dates -> the contract period stays blank -> the gate still rejects
+        self.project.start_date = None
+        self.project.target_date = None
+        self.project.save()
+        KippoProjectContract.objects.create(project=self.project, total_amount=100000)
+        project = KippoProject.objects.get(pk=self.project.pk)
+        project.phase = PHASE_UNDER_CONTRACT
+        with self.assertRaises(ValidationError) as context:
+            project.clean()
+        self.assertIn("phase", context.exception.message_dict)
+
+    def test_clean_exempts_registration(self):
+        # the admin add form creates the required contract inline in the same submit, after this
+        # validation runs — an unsaved (adding) instance is exempt
+        project = KippoProject(
+            organization=self.project.organization,
+            name="registration-under-contract",
+            phase=PHASE_UNDER_CONTRACT,
+            columnset=self.project.columnset,
+        )
+        project.clean()  # does not raise

--- a/kippo/projects/tests/test_models_billing.py
+++ b/kippo/projects/tests/test_models_billing.py
@@ -82,6 +82,26 @@ class ContractFieldsTestCase(TestCase):
         self.assertEqual(contract.start_date, datetime.date(2026, 3, 1))
         self.assertEqual(contract.end_date, datetime.date(2026, 5, 31))
 
+    def test_contract_end_date_clearable_on_update_for_open_ended(self):
+        # open-ended / retainer engagement (T&M): after creation the contract end_date can be cleared
+        # and stays blank (not re-filled from the project), while the project keeps its planning
+        # target_date (the sync never clears a project date).
+        self.project.start_date = datetime.date(2026, 1, 1)
+        self.project.target_date = datetime.date(2026, 6, 30)
+        self.project.save()
+        contract = KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_MONTHLY,
+            total_amount=Decimal("1800000"),
+        )
+        self.assertEqual(contract.end_date, datetime.date(2026, 6, 30))  # backfilled at creation
+        contract.end_date = None
+        contract.save()  # update: blank is honored, not re-filled
+        contract.refresh_from_db()
+        self.assertIsNone(contract.end_date)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.target_date, datetime.date(2026, 6, 30))  # planning date preserved
+
     def test_clean_rejects_inverted_period(self):
         contract = KippoProjectContract(
             project=self.project,

--- a/kippo/projects/tests/test_models_billing.py
+++ b/kippo/projects/tests/test_models_billing.py
@@ -1,6 +1,7 @@
 import datetime
 from decimal import Decimal
 
+from accounts.models import KippoUser
 from commons.tests import DEFAULT_FIXTURES, setup_basic_project
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -142,6 +143,29 @@ class ContractFieldsTestCase(TestCase):
         self.project.refresh_from_db()
         self.assertEqual(self.project.start_date, datetime.date(2026, 2, 1))
         self.assertEqual(self.project.target_date, datetime.date(2026, 8, 31))
+
+    def test_period_sync_attributes_update_to_contract_editor(self):
+        # a project-date change driven by a contract edit is attributed to the contract's editor
+        # (updated_by), not the project's previous direct editor
+        project_editor = self.user
+        contract_editor = KippoUser.objects.get(username="github-manager")
+        self.assertNotEqual(project_editor, contract_editor)
+        self.project.start_date = datetime.date(2026, 1, 1)
+        self.project.target_date = datetime.date(2026, 6, 30)
+        self.project.updated_by = project_editor
+        self.project.save()
+        KippoProjectContract.objects.create(
+            project=KippoProject.objects.get(pk=self.project.pk),
+            billing_type=BILLING_TYPE_MONTHLY,
+            total_amount=Decimal("600000"),
+            start_date=datetime.date(2026, 2, 1),
+            end_date=datetime.date(2026, 8, 31),
+            created_by=contract_editor,
+            updated_by=contract_editor,
+        )
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.target_date, datetime.date(2026, 8, 31))  # sync happened
+        self.assertEqual(self.project.updated_by, contract_editor)  # attributed to the contract editor
 
     def test_blank_contract_period_does_not_clear_project_dates(self):
         # a contract date that stays blank (project had no dates to backfill from) must not

--- a/kippo/projects/tests/test_models_billing.py
+++ b/kippo/projects/tests/test_models_billing.py
@@ -110,6 +110,71 @@ class ContractFieldsTestCase(TestCase):
                 end_date=datetime.date(2026, 12, 31),
             )
 
+    def test_contract_period_synced_to_project_on_create(self):
+        # once a contract exists its period is the single source of truth — the project's
+        # start_date/target_date mirror it (KippoProjectContract._sync_project_period)
+        self.project.start_date = datetime.date(2026, 1, 1)
+        self.project.target_date = datetime.date(2026, 12, 31)
+        self.project.save()
+        KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_MONTHLY,
+            total_amount=Decimal("900000"),
+            start_date=datetime.date(2026, 3, 1),
+            end_date=datetime.date(2026, 5, 31),
+        )
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.start_date, datetime.date(2026, 3, 1))
+        self.assertEqual(self.project.target_date, datetime.date(2026, 5, 31))
+
+    def test_contract_period_synced_to_project_on_update(self):
+        self.project.start_date = datetime.date(2026, 1, 1)
+        self.project.target_date = datetime.date(2026, 6, 30)
+        self.project.save()
+        contract = KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_MONTHLY,
+            total_amount=Decimal("1800000"),
+        )
+        contract.start_date = datetime.date(2026, 2, 1)
+        contract.end_date = datetime.date(2026, 8, 31)
+        contract.save()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.start_date, datetime.date(2026, 2, 1))
+        self.assertEqual(self.project.target_date, datetime.date(2026, 8, 31))
+
+    def test_blank_contract_period_does_not_clear_project_dates(self):
+        # a contract date that stays blank (project had no dates to backfill from) must not
+        # null-out anything on the project
+        self.project.start_date = None
+        self.project.target_date = None
+        self.project.save()
+        KippoProjectContract.objects.create(
+            project=self.project,
+            billing_type=BILLING_TYPE_DELIVERY,
+            total_amount=Decimal("500000"),
+        )
+        self.project.refresh_from_db()
+        self.assertIsNone(self.project.start_date)
+        self.assertIsNone(self.project.target_date)
+
+    def test_period_sync_preserves_manual_confidence(self):
+        # the sync-back is a partial save (update_fields) — it must not re-derive confidence
+        self.project.start_date = datetime.date(2026, 1, 1)
+        self.project.target_date = datetime.date(2026, 6, 30)
+        self.project.save()
+        KippoProject.objects.filter(pk=self.project.pk).update(confidence=55)
+        contract = KippoProjectContract.objects.create(
+            project=KippoProject.objects.get(pk=self.project.pk),
+            billing_type=BILLING_TYPE_MONTHLY,
+            total_amount=Decimal("600000"),
+        )
+        contract.end_date = datetime.date(2026, 9, 30)
+        contract.save()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.target_date, datetime.date(2026, 9, 30))
+        self.assertEqual(self.project.confidence, 55)
+
 
 class MonthlyContractGenerationTestCase(TestCase):
     """Ledger generation from monthly contracts (kippo#31 / T12)."""

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -732,14 +732,29 @@ class KippoProjectContractViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(project_id=project_pk)
         return queryset
 
+    @staticmethod
+    def _reject_if_project_closed(project: KippoProject) -> None:
+        # A closed project's dates are final; the contract save mirrors its period onto the project
+        # (KippoProjectContract._sync_project_period), so a contract write on a closed project would
+        # silently shift locked dates. The admin blocks this via LockWhenProjectClosedInlineMixin;
+        # mirror that here so the API cannot bypass the closed-project immutability.
+        if project.is_closed:
+            raise ValidationError("This project is closed; its contract cannot be modified.")
+
     def perform_create(self, serializer: KippoProjectContractSerializer) -> None:
         project = get_object_or_404(_user_accessible_projects(self.request.user), pk=self.kwargs.get("project_pk"))
+        self._reject_if_project_closed(project)
         if KippoProjectContract.objects.filter(project=project).exists():
             raise ValidationError("This project already has a contract; edit it via PUT/PATCH.")
         serializer.save(project=project, created_by=self.request.user, updated_by=self.request.user)
 
     def perform_update(self, serializer: KippoProjectContractSerializer) -> None:
+        self._reject_if_project_closed(serializer.instance.project)
         serializer.save(updated_by=self.request.user)
+
+    def perform_destroy(self, instance: KippoProjectContract) -> None:
+        self._reject_if_project_closed(instance.project)
+        instance.delete()
 
 
 class KippoProjectBillingEntryViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary

`KippoProject` and `KippoProjectContract` both carry a period (`start_date`/`target_date` vs `start_date`/`end_date`), forcing double date entry and allowing drift. This PR makes the flow one-directional:

1. **Project registration** (pre-contract): the project's `start_date`/`target_date` are entered as before (required at registration, kippo#40).
2. **Contract creation**: the contract period pre-fills / backfills from the project dates (existing behavior, unchanged).
3. **Once a contract exists**: the contract period is the single source of truth — `KippoProjectContract.save()` mirrors its dates back onto the project's `start_date`/`target_date`, and the project's own date inputs disappear.

Keeping the project columns as a synced mirror (rather than delegating reads to the contract) leaves every existing consumer — autoassign month-walking, forecast, monthly-assignment signals, changelist ordering, the customers `recent_ending` filter, kippo-ui sorting — working unchanged.

## Changes

- **models**: `KippoProjectContract._sync_project_period()` called from `save()` — partial `update_fields` save (does not touch `confidence`), never clears a project date. New `PHASE_UNDER_CONTRACT` constant.
- **admin**: `start_date`/`target_date` are excluded from the project change form when a contract exists; the contract inline is the editable input. `/add/` is unaffected.
- **API**: a *changed* `start_date`/`target_date` on a project with a contract returns 400 pointing at the contract endpoint; echoing the stored values back (as the kippo-ui edit form does today) still saves, so existing clients don't break on unrelated edits.
- **Phase gate**: setting `phase` to 契約(稼働中) now requires an existing contract with both period dates (`KippoProject.clean()` + serializer). Registration is exempt — the admin add form creates the required contract inline in the same submit. Existing rows are unaffected until edited.

## Testing

- `manage.py test projects`: 619 tests, all pass except 12 pre-existing S3-environment errors (`reset_buckets`) unrelated to this change.
- New coverage: contract→project sync (create/update/blank/confidence-preservation), admin field hiding (change vs add), API date rejection + echo acceptance + pre-contract editability, contract-endpoint sync, phase gate (clean + PATCH + create).
- `poe check` (ruff) passes.

## Follow-up

- kippo-ui PR (monkut/kippo-ui) disables the date inputs on the project edit form when the project has a contract, so the 400 never surfaces to users.

## Update: slim registration (second commit set)

Project registration (admin `/add/` and API create) now collects **only** 顧客 / プロジェクト名 / 開始日 / フェーズ / カテゴリ (+ organization). Everything else — 担当PM, 完了予定日, 課題定義, 必要工数, and the contract — is added on a later edit as needed.

- `ADD_FIELDS`: organization, customer, name, start_date, phase, category.
- Required at registration (admin form + API): customer + start_date (name/organization are NOT NULL; phase/category carry defaults).
- The contract inline is no longer required nor rendered on `/add/` (supersedes kippo#40's 請求方法-at-registration rule).
- The under-contract phase gate now applies at registration too — with no contract inline on `/add/`, a new project can never start in 契約(稼働中); create → add contract → flip phase.
- `get_form` guards the `project_manager` initial default; the allocated_staff_days full-confidence requirement is skipped when the field is not rendered (enforced on the later edit).
