### PR TITLE
Org-member management (CRUD) of project categories (kippo#48)

### DIFF
--- a/kippo/commons/viewsets.py
+++ b/kippo/commons/viewsets.py
@@ -33,23 +33,6 @@ def organization_ids_for_user(user: Any) -> set:  # noqa: ANN401
     return cached
 
 
-def pm_organization_ids_for_user(user: Any) -> set:  # noqa: ANN401
-    """Return the organization PKs where the user is a project manager (``is_project_manager=True``).
-
-    Same request-scoped memoization contract as :func:`organization_ids_for_user`; used to gate
-    org-admin actions (e.g. project-category management, kippo#48) to an org's PMs.
-    """
-    if not (user and user.is_authenticated):
-        return set()
-    if not hasattr(user, "organizationmembership_set"):
-        return set()
-    cached = getattr(user, "_pm_organization_ids_cache", None)
-    if cached is None:
-        cached = set(user.organizationmembership_set.filter(is_project_manager=True).values_list("organization", flat=True))
-        user._pm_organization_ids_cache = cached
-    return cached
-
-
 class OrganizationFilterMixin:
     """Filter a viewset queryset to the request user's organization memberships.
 

--- a/kippo/commons/viewsets.py
+++ b/kippo/commons/viewsets.py
@@ -33,6 +33,23 @@ def organization_ids_for_user(user: Any) -> set:  # noqa: ANN401
     return cached
 
 
+def pm_organization_ids_for_user(user: Any) -> set:  # noqa: ANN401
+    """Return the organization PKs where the user is a project manager (``is_project_manager=True``).
+
+    Same request-scoped memoization contract as :func:`organization_ids_for_user`; used to gate
+    org-admin actions (e.g. project-category management, kippo#48) to an org's PMs.
+    """
+    if not (user and user.is_authenticated):
+        return set()
+    if not hasattr(user, "organizationmembership_set"):
+        return set()
+    cached = getattr(user, "_pm_organization_ids_cache", None)
+    if cached is None:
+        cached = set(user.organizationmembership_set.filter(is_project_manager=True).values_list("organization", flat=True))
+        user._pm_organization_ids_cache = cached
+    return cached
+
+
 class OrganizationFilterMixin:
     """Filter a viewset queryset to the request user's organization memberships.
 

--- a/kippo/projects/permissions.py
+++ b/kippo/projects/permissions.py
@@ -2,10 +2,52 @@
 
 from typing import Any
 
-from commons.viewsets import organization_ids_for_user
+from commons.viewsets import organization_ids_for_user, pm_organization_ids_for_user
 from rest_framework import permissions
 from rest_framework.request import Request
 from rest_framework.views import APIView
+
+
+class IsSuperuserOrOrgPMForCategory(permissions.BasePermission):
+    """Org-scoped write permission for KippoProjectOrganizationCategory (kippo#48).
+
+    - Read (GET/HEAD/OPTIONS): authenticated; queryset-level filtering scopes results to the
+      user's orgs plus the global defaults.
+    - Write on an org-scoped category (create/update/delete): superuser, OR a project manager
+      (``OrganizationMembership.is_project_manager``) of that category's organization.
+    - Write on a global (``organization=null``) default: superuser only. An org PM may add
+      org-scoped categories alongside the globals but may not edit or delete a global default.
+    """
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        if user.is_superuser:
+            return True
+        if request.method == "POST":
+            # A missing/blank organization means a global default -> superuser only (already returned above).
+            target_org = request.data.get("organization") if hasattr(request, "data") else None
+            if not target_org:
+                return False
+            return str(target_org) in {str(oid) for oid in pm_organization_ids_for_user(user)}
+        # PUT/PATCH/DELETE: object-level check enforces org-PM membership.
+        return request.method in ("PUT", "PATCH", "DELETE")
+
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:  # noqa: ANN401
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        if user.is_superuser:
+            return True
+        # global default: superuser only
+        if obj.organization_id is None:
+            return False
+        return obj.organization_id in pm_organization_ids_for_user(user)
 
 
 class IsSuperuserOrOwnOrgReadUpdateCreate(permissions.BasePermission):

--- a/kippo/projects/permissions.py
+++ b/kippo/projects/permissions.py
@@ -2,20 +2,20 @@
 
 from typing import Any
 
-from commons.viewsets import organization_ids_for_user, pm_organization_ids_for_user
+from commons.viewsets import organization_ids_for_user
 from rest_framework import permissions
 from rest_framework.request import Request
 from rest_framework.views import APIView
 
 
-class IsSuperuserOrOrgPMForCategory(permissions.BasePermission):
+class IsSuperuserOrOrgMemberForCategory(permissions.BasePermission):
     """Org-scoped write permission for KippoProjectOrganizationCategory (kippo#48).
 
     - Read (GET/HEAD/OPTIONS): authenticated; queryset-level filtering scopes results to the
       user's orgs plus the global defaults.
-    - Write on an org-scoped category (create/update/delete): superuser, OR a project manager
-      (``OrganizationMembership.is_project_manager``) of that category's organization.
-    - Write on a global (``organization=null``) default: superuser only. An org PM may add
+    - Write on an org-scoped category (create/update/delete): superuser, OR any member
+      (``OrganizationMembership``) of that category's organization.
+    - Write on a global (``organization=null``) default: superuser only. An org member may add
       org-scoped categories alongside the globals but may not edit or delete a global default.
     """
 
@@ -32,8 +32,8 @@ class IsSuperuserOrOrgPMForCategory(permissions.BasePermission):
             target_org = request.data.get("organization") if hasattr(request, "data") else None
             if not target_org:
                 return False
-            return str(target_org) in {str(oid) for oid in pm_organization_ids_for_user(user)}
-        # PUT/PATCH/DELETE: object-level check enforces org-PM membership.
+            return str(target_org) in {str(oid) for oid in organization_ids_for_user(user)}
+        # PUT/PATCH/DELETE: object-level check enforces org membership.
         return request.method in ("PUT", "PATCH", "DELETE")
 
     def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:  # noqa: ANN401
@@ -47,7 +47,7 @@ class IsSuperuserOrOrgPMForCategory(permissions.BasePermission):
         # global default: superuser only
         if obj.organization_id is None:
             return False
-        return obj.organization_id in pm_organization_ids_for_user(user)
+        return obj.organization_id in organization_ids_for_user(user)
 
 
 class IsSuperuserOrOwnOrgReadUpdateCreate(permissions.BasePermission):

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from accounts.models import KippoOrganization, KippoUser
 from commons.fields import CommaSeparatedField
-from commons.viewsets import pm_organization_ids_for_user
+from commons.viewsets import organization_ids_for_user
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Sum
@@ -173,11 +173,11 @@ class ProjectAssignmentRateSerializer(serializers.ModelSerializer):
 class KippoProjectOrganizationCategorySerializer(serializers.ModelSerializer):
     """Read/write serializer for KippoProjectOrganizationCategory.
 
-    Backs both the project category picker (read, kippo#43) and org-PM category management
-    (write, kippo#48). Write access is gated by ``IsSuperuserOrOrgPMForCategory``; this serializer
-    additionally (a) runs the model's cross-scope/uniqueness validation so duplicates surface as
-    400s (never a DB IntegrityError 500) and (b) rejects an ``organization`` the requester does not
-    manage as a PM (defence-in-depth alongside the permission class).
+    Backs both the project category picker (read, kippo#43) and org category management
+    (write, kippo#48). Write access is gated by ``IsSuperuserOrOrgMemberForCategory``; this
+    serializer additionally (a) runs the model's cross-scope/uniqueness validation so duplicates
+    surface as 400s (never a DB IntegrityError 500) and (b) rejects an ``organization`` the
+    requester is not a member of (defence-in-depth alongside the permission class).
     """
 
     class Meta:
@@ -190,11 +190,11 @@ class KippoProjectOrganizationCategorySerializer(serializers.ModelSerializer):
         user = getattr(request, "user", None)
         if user is None or user.is_superuser:
             return value
-        # Non-superusers may only create/keep categories under an org they PM. A null org (global
-        # default) is superuser-only and already blocked by the permission class.
-        pm_org_ids = pm_organization_ids_for_user(user)
-        if value is None or value.pk not in pm_org_ids:
-            raise serializers.ValidationError(_("You may only manage categories for an organization you are a project manager of."))
+        # Non-superusers may only create/keep categories under an org they belong to. A null org
+        # (global default) is superuser-only and already blocked by the permission class.
+        member_org_ids = organization_ids_for_user(user)
+        if value is None or value.pk not in member_org_ids:
+            raise serializers.ValidationError(_("You may only manage categories for an organization you are a member of."))
         return value
 
     def validate(self, attrs: dict) -> dict:

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -3,7 +3,9 @@ from typing import TYPE_CHECKING
 
 from accounts.models import KippoOrganization, KippoUser
 from commons.fields import CommaSeparatedField
+from commons.viewsets import pm_organization_ids_for_user
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Sum
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -169,12 +171,51 @@ class ProjectAssignmentRateSerializer(serializers.ModelSerializer):
 
 
 class KippoProjectOrganizationCategorySerializer(serializers.ModelSerializer):
-    """Read-only serializer for KippoProjectOrganizationCategory (project category picker)."""
+    """Read/write serializer for KippoProjectOrganizationCategory.
+
+    Backs both the project category picker (read, kippo#43) and org-PM category management
+    (write, kippo#48). Write access is gated by ``IsSuperuserOrOrgPMForCategory``; this serializer
+    additionally (a) runs the model's cross-scope/uniqueness validation so duplicates surface as
+    400s (never a DB IntegrityError 500) and (b) rejects an ``organization`` the requester does not
+    manage as a PM (defence-in-depth alongside the permission class).
+    """
 
     class Meta:
         model = KippoProjectOrganizationCategory
         fields = ["id", "key", "label", "organization", "sort_order", "is_active"]
-        read_only_fields = fields
+        read_only_fields = ["id"]
+
+    def validate_organization(self, value: KippoOrganization | None) -> KippoOrganization | None:
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        if user is None or user.is_superuser:
+            return value
+        # Non-superusers may only create/keep categories under an org they PM. A null org (global
+        # default) is superuser-only and already blocked by the permission class.
+        pm_org_ids = pm_organization_ids_for_user(user)
+        if value is None or value.pk not in pm_org_ids:
+            raise serializers.ValidationError(_("You may only manage categories for an organization you are a project manager of."))
+        return value
+
+    def validate(self, attrs: dict) -> dict:
+        # Merge incoming attrs over the existing instance (partial updates) and run the model's
+        # own validation: field checks, clean() (cross-scope label rule) and the unique constraints.
+        merged = {}
+        if self.instance is not None:
+            merged = {field: getattr(self.instance, field) for field in ("organization", "key", "label", "sort_order", "is_active")}
+        merged.update(attrs)
+        candidate = KippoProjectOrganizationCategory(**merged)
+        if self.instance is not None:
+            # Reflect the existing row so validate_unique/validate_constraints exclude self
+            # (otherwise the update trips the (organization, key)/(organization, label)/pk constraints).
+            candidate.pk = self.instance.pk
+            candidate._state.adding = False
+            candidate._state.db = self.instance._state.db
+        try:
+            candidate.full_clean(exclude=("created_by", "updated_by", "closed_datetime"))
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.message_dict if hasattr(exc, "message_dict") else exc.messages) from exc
+        return attrs
 
 
 class KippoProjectContractSerializer(serializers.ModelSerializer):

--- a/kippo/projects/tests/test_projectcategory_viewset.py
+++ b/kippo/projects/tests/test_projectcategory_viewset.py
@@ -127,15 +127,14 @@ class ProjectCategoryViewSetTestCase(TestCase):
 
 
 class ProjectCategoryWriteViewSetTestCase(TestCase):
-    """Org-PM management (create/update/delete) of project categories — kippo#48."""
+    """Org-member management (create/update/delete) of project categories — kippo#48."""
 
     fixtures = DEFAULT_FIXTURES
 
     def setUp(self):
         self.created = setup_basic_project()
         self.organization = self.created["KippoOrganization"]
-        self.user = self.created["KippoUser"]
-        self.membership = self.created["OrganizationMembership"]
+        self.user = self.created["KippoUser"]  # a member (is_developer) of self.organization
         self.github_manager = KippoUser.objects.get(username="github-manager")
 
         self.other_org = KippoOrganization.objects.create(
@@ -169,13 +168,9 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
     def _detail_url(self, category: KippoProjectOrganizationCategory) -> str:
         return f"{self.url}{category.id}/"
 
-    def _make_pm(self) -> None:
-        self.membership.is_project_manager = True
-        self.membership.save()
-
     # --- create ---
-    def test_pm_can_create_own_org_category(self):
-        self._make_pm()
+    def test_member_can_create_own_org_category(self):
+        # self.user is a member (is_developer) of self.organization — no PM role required.
         response = self.client.post(
             self.url,
             {"organization": str(self.organization.id), "key": "new-cat", "label": "New Category", "sort_order": 5},
@@ -187,16 +182,18 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         self.assertEqual(created.created_by, self.user)
         self.assertEqual(created.updated_by, self.user)
 
-    def test_non_pm_member_cannot_create(self):
-        response = self.client.post(
+    def test_non_member_cannot_create(self):
+        outsider = KippoUser.objects.create(username="cat-outsider", email="outsider@example.com")
+        client = APIClient()
+        client.force_authenticate(user=outsider)
+        response = client.post(
             self.url,
             {"organization": str(self.organization.id), "key": "nope", "label": "Nope"},
             format="json",
         )
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
-    def test_pm_cannot_create_for_other_org(self):
-        self._make_pm()
+    def test_member_cannot_create_for_other_org(self):
         response = self.client.post(
             self.url,
             {"organization": str(self.other_org.id), "key": "cross-org", "label": "Cross Org"},
@@ -204,11 +201,10 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
-    def test_pm_cannot_create_global_category(self):
-        self._make_pm()
+    def test_member_cannot_create_global_category(self):
         response = self.client.post(
             self.url,
-            {"key": "pm-global", "label": "PM Global"},
+            {"key": "member-global", "label": "Member Global"},
             format="json",
         )
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
@@ -222,7 +218,6 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         self.assertTrue(KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, key="su-global").exists())
 
     def test_duplicate_org_key_rejected_with_400_not_500(self):
-        self._make_pm()
         response = self.client.post(
             self.url,
             {"organization": str(self.organization.id), "key": "own-active", "label": "Dup Key"},
@@ -231,7 +226,6 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
 
     def test_cross_scope_label_collision_rejected(self):
-        self._make_pm()
         response = self.client.post(
             self.url,
             {"organization": str(self.organization.id), "key": "shadow-global", "label": self.global_category.label},
@@ -240,34 +234,29 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
 
     # --- update ---
-    def test_pm_can_update_own_org_category(self):
-        self._make_pm()
+    def test_member_can_update_own_org_category(self):
         response = self.client.patch(self._detail_url(self.own_category), {"label": "Renamed"}, format="json")
         self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
         self.own_category.refresh_from_db()
         self.assertEqual(self.own_category.label, "Renamed")
         self.assertEqual(self.own_category.updated_by, self.user)
 
-    def test_pm_cannot_update_other_org_category(self):
-        self._make_pm()
+    def test_member_cannot_update_other_org_category(self):
         response = self.client.patch(self._detail_url(self.other_category), {"label": "Hijack"}, format="json")
         # other_org category is outside the user's queryset -> 404 (not leaked as 403)
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
-    def test_pm_cannot_update_global_category(self):
-        self._make_pm()
+    def test_member_cannot_update_global_category(self):
         response = self.client.patch(self._detail_url(self.global_category), {"label": "Hijack Global"}, format="json")
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
     # --- delete ---
-    def test_pm_can_delete_unused_own_org_category(self):
-        self._make_pm()
+    def test_member_can_delete_unused_own_org_category(self):
         response = self.client.delete(self._detail_url(self.own_category))
         self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertFalse(KippoProjectOrganizationCategory.objects.filter(pk=self.own_category.pk).exists())
 
     def test_delete_in_use_category_returns_409(self):
-        self._make_pm()
         # Attach the category to an existing (fully-formed) project so the delete hits PROTECT.
         project = self.created["KippoProject"]
         project.category = self.own_category
@@ -276,14 +265,12 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.CONFLICT, response.content)
         self.assertTrue(KippoProjectOrganizationCategory.objects.filter(pk=self.own_category.pk).exists())
 
-    def test_pm_cannot_delete_global_category(self):
-        self._make_pm()
+    def test_member_cannot_delete_global_category(self):
         response = self.client.delete(self._detail_url(self.global_category))
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
     # --- inactive visibility (soft-delete / reactivation) ---
     def test_default_list_hides_inactive_but_include_inactive_shows_it(self):
-        self._make_pm()
         inactive = KippoProjectOrganizationCategory.objects.create(
             organization=self.organization,
             key="own-inactive",
@@ -297,8 +284,7 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         with_inactive_keys = {row["key"] for row in self.client.get(self.url, {"include_inactive": "true"}).json()["results"]}
         self.assertIn(inactive.key, with_inactive_keys)
 
-    def test_pm_can_reactivate_inactive_category(self):
-        self._make_pm()
+    def test_member_can_reactivate_inactive_category(self):
         inactive = KippoProjectOrganizationCategory.objects.create(
             organization=self.organization,
             key="reactivate-me",

--- a/kippo/projects/tests/test_projectcategory_viewset.py
+++ b/kippo/projects/tests/test_projectcategory_viewset.py
@@ -124,3 +124,191 @@ class ProjectCategoryViewSetTestCase(TestCase):
         self.assertIn("own-active", keys)
         self.assertIn("other-active", keys)
         self.assertNotIn("own-inactive", keys)
+
+
+class ProjectCategoryWriteViewSetTestCase(TestCase):
+    """Org-PM management (create/update/delete) of project categories — kippo#48."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        self.created = setup_basic_project()
+        self.organization = self.created["KippoOrganization"]
+        self.user = self.created["KippoUser"]
+        self.membership = self.created["OrganizationMembership"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        self.other_org = KippoOrganization.objects.create(
+            name="other-org-for-category-write-test",
+            github_organization_name="otherorg-category-write",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.own_category = KippoProjectOrganizationCategory.objects.create(
+            organization=self.organization,
+            key="own-active",
+            label="Own Active",
+            sort_order=10,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_category = KippoProjectOrganizationCategory.objects.create(
+            organization=self.other_org,
+            key="other-active",
+            label="Other Active",
+            sort_order=10,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.global_category = KippoProjectOrganizationCategory.objects.get(organization__isnull=True, key="other")
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.url = f"{settings.URL_PREFIX}/api/project-categories/"
+
+    def _detail_url(self, category: KippoProjectOrganizationCategory) -> str:
+        return f"{self.url}{category.id}/"
+
+    def _make_pm(self) -> None:
+        self.membership.is_project_manager = True
+        self.membership.save()
+
+    # --- create ---
+    def test_pm_can_create_own_org_category(self):
+        self._make_pm()
+        response = self.client.post(
+            self.url,
+            {"organization": str(self.organization.id), "key": "new-cat", "label": "New Category", "sort_order": 5},
+            format="json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
+        created = KippoProjectOrganizationCategory.objects.get(organization=self.organization, key="new-cat")
+        # audit user recorded
+        self.assertEqual(created.created_by, self.user)
+        self.assertEqual(created.updated_by, self.user)
+
+    def test_non_pm_member_cannot_create(self):
+        response = self.client.post(
+            self.url,
+            {"organization": str(self.organization.id), "key": "nope", "label": "Nope"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_pm_cannot_create_for_other_org(self):
+        self._make_pm()
+        response = self.client.post(
+            self.url,
+            {"organization": str(self.other_org.id), "key": "cross-org", "label": "Cross Org"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_pm_cannot_create_global_category(self):
+        self._make_pm()
+        response = self.client.post(
+            self.url,
+            {"key": "pm-global", "label": "PM Global"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_superuser_can_create_global_category(self):
+        superuser = KippoUser.objects.create(username="cat-write-su", email="su2@example.com", is_superuser=True, is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        response = client.post(self.url, {"key": "su-global", "label": "SU Global"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
+        self.assertTrue(KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, key="su-global").exists())
+
+    def test_duplicate_org_key_rejected_with_400_not_500(self):
+        self._make_pm()
+        response = self.client.post(
+            self.url,
+            {"organization": str(self.organization.id), "key": "own-active", "label": "Dup Key"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    def test_cross_scope_label_collision_rejected(self):
+        self._make_pm()
+        response = self.client.post(
+            self.url,
+            {"organization": str(self.organization.id), "key": "shadow-global", "label": self.global_category.label},
+            format="json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+    # --- update ---
+    def test_pm_can_update_own_org_category(self):
+        self._make_pm()
+        response = self.client.patch(self._detail_url(self.own_category), {"label": "Renamed"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        self.own_category.refresh_from_db()
+        self.assertEqual(self.own_category.label, "Renamed")
+        self.assertEqual(self.own_category.updated_by, self.user)
+
+    def test_pm_cannot_update_other_org_category(self):
+        self._make_pm()
+        response = self.client.patch(self._detail_url(self.other_category), {"label": "Hijack"}, format="json")
+        # other_org category is outside the user's queryset -> 404 (not leaked as 403)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_pm_cannot_update_global_category(self):
+        self._make_pm()
+        response = self.client.patch(self._detail_url(self.global_category), {"label": "Hijack Global"}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    # --- delete ---
+    def test_pm_can_delete_unused_own_org_category(self):
+        self._make_pm()
+        response = self.client.delete(self._detail_url(self.own_category))
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+        self.assertFalse(KippoProjectOrganizationCategory.objects.filter(pk=self.own_category.pk).exists())
+
+    def test_delete_in_use_category_returns_409(self):
+        self._make_pm()
+        # Attach the category to an existing (fully-formed) project so the delete hits PROTECT.
+        project = self.created["KippoProject"]
+        project.category = self.own_category
+        project.save()
+        response = self.client.delete(self._detail_url(self.own_category))
+        self.assertEqual(response.status_code, HTTPStatus.CONFLICT, response.content)
+        self.assertTrue(KippoProjectOrganizationCategory.objects.filter(pk=self.own_category.pk).exists())
+
+    def test_pm_cannot_delete_global_category(self):
+        self._make_pm()
+        response = self.client.delete(self._detail_url(self.global_category))
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    # --- inactive visibility (soft-delete / reactivation) ---
+    def test_default_list_hides_inactive_but_include_inactive_shows_it(self):
+        self._make_pm()
+        inactive = KippoProjectOrganizationCategory.objects.create(
+            organization=self.organization,
+            key="own-inactive",
+            label="Own Inactive",
+            is_active=False,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        default_keys = {row["key"] for row in self.client.get(self.url).json()["results"]}
+        self.assertNotIn(inactive.key, default_keys)
+        with_inactive_keys = {row["key"] for row in self.client.get(self.url, {"include_inactive": "true"}).json()["results"]}
+        self.assertIn(inactive.key, with_inactive_keys)
+
+    def test_pm_can_reactivate_inactive_category(self):
+        self._make_pm()
+        inactive = KippoProjectOrganizationCategory.objects.create(
+            organization=self.organization,
+            key="reactivate-me",
+            label="Reactivate Me",
+            is_active=False,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        # detail actions must reach inactive rows even though the default list hides them
+        response = self.client.patch(self._detail_url(inactive), {"is_active": True}, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        inactive.refresh_from_db()
+        self.assertTrue(inactive.is_active)

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -7,9 +7,11 @@ from accounts.models import KippoUser
 from commons.viewsets import OrganizationFilterMixin, organization_ids_for_user
 from django.conf import settings
 from django.db.models import Exists, OuterRef, Prefetch, Q, QuerySet, Sum
+from django.db.models.deletion import ProtectedError
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
+from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, inline_serializer
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
@@ -34,7 +36,7 @@ from .models import (
     ProjectWeeklyEffort,
     ProjectWeeklyEffortUnlock,
 )
-from .permissions import IsSuperuserOrOwnOrgReadUpdateCreate, IsSuperuserOrReadUpdateCreateOwn
+from .permissions import IsSuperuserOrOrgPMForCategory, IsSuperuserOrOwnOrgReadUpdateCreate, IsSuperuserOrReadUpdateCreateOwn
 from .serializers import (
     KippoProjectBillingEntrySerializer,
     KippoProjectContractSerializer,
@@ -54,11 +56,12 @@ from .services.forecast import ProjectAssignmentForecastManager
 from .services.suggest import ProjectAssignmentSuggestionManager
 
 
-class KippoProjectOrganizationCategoryViewSet(viewsets.ReadOnlyModelViewSet):
+class KippoProjectOrganizationCategoryViewSet(viewsets.ModelViewSet):
     """
-    Read-only list of selectable project categories (kippo#43).
+    Selectable project categories (kippo#43 read; kippo#48 org-PM management).
 
-    Backs the kippo-ui project create/edit form category picker.
+    Backs the kippo-ui project create/edit form category picker (read) and the org category
+    management screen (write).
 
     **Organization Scoping:**
     - Regular users see global default categories plus the categories of organizations they belong to.
@@ -70,23 +73,57 @@ class KippoProjectOrganizationCategoryViewSet(viewsets.ReadOnlyModelViewSet):
 
     **Permissions:**
     - Read (GET): Authenticated users (organization-scoped for regular users).
+    - Write (POST/PUT/PATCH/DELETE) on an org-scoped category: superuser or a project manager of
+      that organization. Global defaults are superuser-only. See ``IsSuperuserOrOrgPMForCategory``.
     """
 
     serializer_class = KippoProjectOrganizationCategorySerializer
-    permission_classes = [IsAuthenticated]
-    queryset = KippoProjectOrganizationCategory.objects.filter(is_active=True).order_by("sort_order", "label")
+    permission_classes = [IsSuperuserOrOrgPMForCategory]
+    queryset = KippoProjectOrganizationCategory.objects.all().order_by("sort_order", "label")
 
     @extend_schema(
         parameters=[
             OpenApiParameter(name="organization", description="Filter by organization UUID (globals always included)", required=False, type=str),
+            OpenApiParameter(
+                name="include_inactive",
+                description="Include inactive (is_active=false) categories in the list (management view). Default false.",
+                required=False,
+                type=bool,
+            ),
         ]
     )
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
         return super().list(request, *args, **kwargs)
 
+    def perform_create(self, serializer: KippoProjectOrganizationCategorySerializer) -> None:
+        serializer.save(created_by=self.request.user, updated_by=self.request.user)
+
+    def perform_update(self, serializer: KippoProjectOrganizationCategorySerializer) -> None:
+        serializer.save(updated_by=self.request.user)
+
+    def destroy(self, request: Request, *args: Any, **kwargs: Any) -> Response:  # noqa: ANN401
+        # category is referenced by KippoProject.category (on_delete=PROTECT); a hard delete of an
+        # in-use category would raise ProtectedError -> 500. Surface a 409 with guidance to
+        # deactivate (is_active=False) instead.
+        try:
+            return super().destroy(request, *args, **kwargs)
+        except ProtectedError:
+            return Response(
+                {"detail": _("This category is assigned to one or more projects and cannot be deleted. Set it inactive (is_active=false) instead.")},
+                status=HTTPStatus.CONFLICT.value,
+            )
+
     def get_queryset(self):
-        """Globals + the user's organization categories; superusers see all active categories."""
+        """Globals + the user's organization categories; superusers see all such categories.
+
+        Inactive rows are hidden from the default list (the picker only wants active categories),
+        but are always included for detail actions (retrieve/update/destroy) and for the list when
+        ``include_inactive=true`` — so a PM can see and reactivate a category they deactivated.
+        """
         queryset = super().get_queryset()
+        include_inactive = self.action != "list" or self.request.query_params.get("include_inactive", "").lower() in ("true", "1")
+        if not include_inactive:
+            queryset = queryset.filter(is_active=True)
         user = self.request.user
         organization = self.request.query_params.get("organization", None)
 

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -36,7 +36,7 @@ from .models import (
     ProjectWeeklyEffort,
     ProjectWeeklyEffortUnlock,
 )
-from .permissions import IsSuperuserOrOrgPMForCategory, IsSuperuserOrOwnOrgReadUpdateCreate, IsSuperuserOrReadUpdateCreateOwn
+from .permissions import IsSuperuserOrOrgMemberForCategory, IsSuperuserOrOwnOrgReadUpdateCreate, IsSuperuserOrReadUpdateCreateOwn
 from .serializers import (
     KippoProjectBillingEntrySerializer,
     KippoProjectContractSerializer,
@@ -73,12 +73,12 @@ class KippoProjectOrganizationCategoryViewSet(viewsets.ModelViewSet):
 
     **Permissions:**
     - Read (GET): Authenticated users (organization-scoped for regular users).
-    - Write (POST/PUT/PATCH/DELETE) on an org-scoped category: superuser or a project manager of
-      that organization. Global defaults are superuser-only. See ``IsSuperuserOrOrgPMForCategory``.
+    - Write (POST/PUT/PATCH/DELETE) on an org-scoped category: superuser or any member of that
+      organization. Global defaults are superuser-only. See ``IsSuperuserOrOrgMemberForCategory``.
     """
 
     serializer_class = KippoProjectOrganizationCategorySerializer
-    permission_classes = [IsSuperuserOrOrgPMForCategory]
+    permission_classes = [IsSuperuserOrOrgMemberForCategory]
     queryset = KippoProjectOrganizationCategory.objects.all().order_by("sort_order", "label")
 
     @extend_schema(
@@ -118,7 +118,7 @@ class KippoProjectOrganizationCategoryViewSet(viewsets.ModelViewSet):
 
         Inactive rows are hidden from the default list (the picker only wants active categories),
         but are always included for detail actions (retrieve/update/destroy) and for the list when
-        ``include_inactive=true`` — so a PM can see and reactivate a category they deactivated.
+        ``include_inactive=true`` — so a member can see and reactivate a category they deactivated.
         """
         queryset = super().get_queryset()
         include_inactive = self.action != "list" or self.request.query_params.get("include_inactive", "").lower() in ("true", "1")


### PR DESCRIPTION
## Summary

`KippoProjectOrganizationCategory` (added in #30) only had a **read-only** API (#43) backing the project create/edit category picker. This lets an **organization's members** manage their org's categories, defaulting to the global set but customizable per org — the piece requested in kiconiaworks/kippo#48.

## Changes

- **Viewset** `KippoProjectOrganizationCategoryViewSet` → full `ModelViewSet` gated by new `IsSuperuserOrOrgMemberForCategory`:
  - Any **member** (`OrganizationMembership`) of an org may create / edit / delete that org's categories.
  - Global (`organization=null`) defaults remain **superuser-only** — a member may add org-scoped categories alongside them but cannot edit/delete a global.
- **Writable serializer** runs the model's `clean()` + unique-constraint validation, so cross-scope label collisions and duplicate `(organization, key)` surface as **400s** (never a DB `IntegrityError` 500), and rejects an `organization` the requester is not a member of.
- **DELETE of an in-use category** (`KippoProject.category` is `on_delete=PROTECT`) returns **409** with guidance to deactivate (`is_active=false`) instead of a 500.
- **Inactive rows** are hidden from the default picker list but reachable via detail actions and `?include_inactive=true`, so a member can see/reactivate a category they deactivated.

## Tests

`projects.tests.test_projectcategory_viewset` — 22 tests (read + write): member CRUD on own org; non-member blocked (403 on write); cross-org and global writes blocked; duplicate-key/cross-scope-label → 400; delete-in-use → 409; unused delete → 204; inactive hide/`include_inactive`/reactivation. Full `projects.tests.test_api_rest` (104) green; OpenAPI schema generates with 0 errors.

## Authorization

Write access is by **organization membership** (any `OrganizationMembership` for the target org), not restricted to `is_project_manager`. No new field/migration.

## Follow-up

kippo-ui category-management screen (blocked until this ships in a `monkut/kippo` release so the generated client picks up the write ops).

Refs kiconiaworks/kippo#48