### PR TITLE
Copy-on-create org project categories (kippo#49)

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -20,7 +20,7 @@ from customers.models import KippoCustomer
 from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import models
 from django.db.models import Case, JSONField, Model, OuterRef, Prefetch, QuerySet, Subquery, Sum, Value, When
 from django.forms import BaseFormSet, Form
@@ -881,10 +881,41 @@ def _format_estimated_completion(result: "ForecastResult") -> str:
 
 @admin.register(KippoProjectOrganizationCategory)
 class KippoProjectOrganizationCategoryAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
+    """Staff manage org-scoped categories; the global (organization=null) template is superuser-only.
+
+    Mirrors the API rule (``IsSuperuserOrOrgMemberForCategory``, kippo#48): a non-superuser staff
+    user may add/edit/delete org-scoped rows, but only a superuser may create or modify a global
+    template row. Non-superusers do not see globals in the changelist at all, so they cannot change,
+    delete, or bulk-delete them (kippo#49).
+    """
+
     list_display = ("key", "label", "organization", "sort_order", "is_active")
     list_filter = ("is_active", "organization")
     search_fields = ("key", "label", "organization__name")
     ordering = ("organization", "sort_order", "key")
+
+    def get_queryset(self, request: DjangoRequest):
+        queryset = super().get_queryset(request)
+        if not request.user.is_superuser:
+            # hide global template rows from non-superusers -> they cannot change/delete/bulk-delete them
+            queryset = queryset.filter(organization__isnull=False)
+        return queryset
+
+    def has_change_permission(self, request: DjangoRequest, obj: models.Model | None = None):
+        if obj is not None and obj.organization_id is None and not request.user.is_superuser:
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_delete_permission(self, request: DjangoRequest, obj: models.Model | None = None):
+        if obj is not None and obj.organization_id is None and not request.user.is_superuser:
+            return False
+        return super().has_delete_permission(request, obj)
+
+    def save_model(self, request: DjangoRequest, obj: KippoProjectOrganizationCategory, form: forms.ModelForm, change: bool) -> None:
+        # has_add_permission cannot see the object; block creating/turning a row into a global template here.
+        if obj.organization_id is None and not request.user.is_superuser:
+            raise PermissionDenied(_("Only a superuser may create or edit a global (template) category."))
+        super().save_model(request, obj, form, change)
 
 
 class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmin, UserCreatedBaseModelAdmin):

--- a/kippo/projects/migrations/0048_seed_org_categories_and_remap_projects.py
+++ b/kippo/projects/migrations/0048_seed_org_categories_and_remap_projects.py
@@ -1,0 +1,81 @@
+"""Copy-on-create org categories backfill (kippo#49).
+
+For every existing organization:
+  1. copy the active global (organization=null) default categories into org-scoped rows
+     (idempotent by key), and
+  2. remap each of the org's projects from the global category it references to the org's
+     copy of the same key.
+
+Globals are retained as the seed template (not deleted), so no PROTECT delete occurs. The
+reverse repoints projects back to the global of the same key and removes the seeded org rows
+that are no longer referenced.
+"""
+
+from django.db import migrations
+
+
+def seed_and_remap(apps, schema_editor):
+    Category = apps.get_model("projects", "KippoProjectOrganizationCategory")  # noqa: N806
+    Organization = apps.get_model("accounts", "KippoOrganization")  # noqa: N806
+    Project = apps.get_model("projects", "KippoProject")  # noqa: N806
+
+    global_defaults = list(Category.objects.filter(organization__isnull=True, is_active=True))
+
+    for organization in Organization.objects.all():
+        existing_keys = set(Category.objects.filter(organization=organization).values_list("key", flat=True))
+        actor_id = getattr(organization, "created_by_id", None)
+        Category.objects.bulk_create(
+            [
+                Category(
+                    organization=organization,
+                    key=default.key,
+                    label=default.label,
+                    sort_order=default.sort_order,
+                    is_active=default.is_active,
+                    created_by_id=actor_id,
+                    updated_by_id=actor_id,
+                )
+                for default in global_defaults
+                if default.key not in existing_keys
+            ]
+        )
+        org_by_key = {c.key: c for c in Category.objects.filter(organization=organization)}
+
+        # Remap the org's projects that still reference a global category to the org's copy of the same key.
+        for project in Project.objects.filter(organization=organization).select_related("category"):
+            category = project.category
+            if category is None or category.organization_id is not None:
+                continue  # already org-scoped
+            target = org_by_key.get(category.key) or org_by_key.get("other")
+            if target is not None and target.pk != category.pk:
+                project.category = target
+                project.save(update_fields=["category"])
+
+
+def unremap(apps, schema_editor):
+    Category = apps.get_model("projects", "KippoProjectOrganizationCategory")  # noqa: N806
+    Project = apps.get_model("projects", "KippoProject")  # noqa: N806
+
+    globals_by_key = {c.key: c for c in Category.objects.filter(organization__isnull=True)}
+
+    # Repoint projects back to the matching global, then drop the seeded (now-unreferenced) org rows.
+    for project in Project.objects.select_related("category").all():
+        category = project.category
+        if category is None or category.organization_id is None:
+            continue
+        target = globals_by_key.get(category.key)
+        if target is not None and target.pk != category.pk:
+            project.category = target
+            project.save(update_fields=["category"])
+
+    Category.objects.filter(organization__isnull=False).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("projects", "0047_kippoprojectcontract_estimated_monthly_amount_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_and_remap, unremap),
+    ]

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -226,48 +226,72 @@ class KippoProjectOrganizationCategory(UserCreatedBaseModel):
         constraints = (
             models.UniqueConstraint(fields=("organization", "key"), name="uniq_org_category_key"),
             models.UniqueConstraint(fields=("key",), condition=models.Q(organization__isnull=True), name="uniq_global_category_key"),
-            # ラベル: unique within an organization (org↔org overlap is allowed, e.g. org1=label1 + org2=label1),
-            # and unique among the global defaults. The global↔org disjointness (a global label may not also be
-            # used by an organization, and vice versa) cannot be expressed as a UniqueConstraint — it is enforced
-            # in clean().
+            # ラベル: unique within an organization (and among the global defaults). Under copy-on-create
+            # (kippo#49) an org OWNS its copy of the defaults, so an org label equal to a global label is
+            # expected (globals are only the seed template, never shown alongside org rows) — there is no
+            # cross-scope disjointness rule.
             models.UniqueConstraint(fields=("organization", "label"), name="uniq_org_category_label"),
             models.UniqueConstraint(fields=("label",), condition=models.Q(organization__isnull=True), name="uniq_global_category_label"),
         )
-
-    def clean(self):
-        super().clean()
-        # A label is shared between only one scope: a global label and an organization label must not
-        # collide (org↔org overlap stays allowed). The UniqueConstraints above cover within-org and
-        # among-global uniqueness; this is the cross-scope half they cannot express.
-        if not self.label:
-            return
-        if self.organization_id is None:
-            # global default: no organization may already use this label
-            clashes = KippoProjectOrganizationCategory.objects.filter(label=self.label, organization__isnull=False).exclude(pk=self.pk)
-            if clashes.exists():
-                raise ValidationError({"label": _("このラベルは組織カテゴリで使用されているため、グローバルでは使用できません。")})
-        else:
-            # organization-scoped: no global default may use this label
-            clashes = KippoProjectOrganizationCategory.objects.filter(label=self.label, organization__isnull=True).exclude(pk=self.pk)
-            if clashes.exists():
-                raise ValidationError({"label": _("このラベルはグローバルカテゴリで使用されているため、組織では使用できません。")})
 
     def __str__(self) -> str:
         return self.label
 
     @classmethod
     def get_for_organization(cls, organization: KippoOrganization | None) -> QuerySet:
-        """Active categories available to an organization: its own rows plus the global defaults."""
-        return cls.objects.filter(is_active=True).filter(models.Q(organization=organization) | models.Q(organization__isnull=True))
+        """Active categories owned by an organization (org-scoped rows only).
+
+        Under copy-on-create (kippo#49) each org owns its own copy of the default set; the global
+        (organization=null) rows are only the seed template and are no longer inherited/shown here.
+        """
+        return cls.objects.filter(is_active=True, organization=organization)
+
+    @classmethod
+    def seed_for_organization(cls, organization: KippoOrganization, created_by: KippoUser | None = None) -> int:
+        """Copy the active global default categories into org-scoped rows for ``organization``.
+
+        Idempotent: a key already present for the org is skipped, so re-running never duplicates.
+        Returns the number of rows created.
+        """
+        existing_keys = set(cls.objects.filter(organization=organization).values_list("key", flat=True))
+        actor = created_by or getattr(organization, "created_by", None)
+        to_create = [
+            cls(
+                organization=organization,
+                key=default.key,
+                label=default.label,
+                sort_order=default.sort_order,
+                is_active=default.is_active,
+                created_by=actor,
+                updated_by=actor,
+            )
+            for default in cls.objects.filter(organization__isnull=True, is_active=True)
+            if default.key not in existing_keys
+        ]
+        cls.objects.bulk_create(to_create)
+        return len(to_create)
 
 
 def get_default_project_category():
-    """PK of the global (organization=null) fallback category, for KippoProject.category's default."""
+    """PK of the global (organization=null) template default, used as ``KippoProject.category``'s
+    field default at instantiation. On create, ``KippoProject.save()`` swaps this for the project's
+    own organization's copy of the same key (kippo#49).
+    """
     return (
         KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, key=DEFAULT_PROJECT_CATEGORY_VALUE)
         .values_list("pk", flat=True)
         .first()
     )
+
+
+@receiver(models.signals.post_save, sender=KippoOrganization)
+def seed_organization_project_categories(sender: type[KippoOrganization], instance: KippoOrganization, created: bool, raw: bool = False, **kwargs):  # noqa: ARG001, FBT001, FBT002
+    """On organization creation, copy the global default categories into org-scoped rows (kippo#49).
+
+    Skipped during fixture loading (``raw=True``) so loaddata controls the exact rows.
+    """
+    if created and not raw:
+        KippoProjectOrganizationCategory.seed_for_organization(instance)
 
 
 class KippoProject(UserCreatedBaseModel):
@@ -828,6 +852,19 @@ class KippoProject(UserCreatedBaseModel):
         if self._state.adding:  # created
             # perform initial creation tasks
             self.slug = slugify(self.name, allow_unicode=True)
+
+            # copy-on-create (kippo#49): a project references its ORG's category copy, never a global
+            # template row. If the category resolves to a global (e.g. the field default), swap it for
+            # the org's copy of the same key (fallback: the org's 'other').
+            if self.category_id and self.organization_id and self.category.organization_id is None:
+                org_category = (
+                    KippoProjectOrganizationCategory.objects.filter(organization_id=self.organization_id, key=self.category.key).first()
+                    or KippoProjectOrganizationCategory.objects.filter(
+                        organization_id=self.organization_id, key=DEFAULT_PROJECT_CATEGORY_VALUE
+                    ).first()
+                )
+                if org_category:
+                    self.category = org_category
 
         # Slack's slash-command payload sends "channel_name" without a leading "#",
         # so the slash-command project lookup ("...subcommands/projectstatus.py") does

--- a/kippo/projects/tests/test_admin_projectcategory.py
+++ b/kippo/projects/tests/test_admin_projectcategory.py
@@ -1,0 +1,74 @@
+"""KippoProjectOrganizationCategoryAdmin permission scoping (kippo#49, option B).
+
+Staff manage org-scoped categories; the global (organization=null) template is superuser-only —
+mirroring the API rule (IsSuperuserOrOrgMemberForCategory).
+"""
+
+from accounts.models import KippoUser
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.contrib import admin
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest
+from django.test import RequestFactory, TestCase
+
+from projects.admin import KippoProjectOrganizationCategoryAdmin
+from projects.models import KippoProjectOrganizationCategory
+
+
+class KippoProjectOrganizationCategoryAdminTestCase(TestCase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.staff_user = created["KippoUser"]  # is_staff=True, is_superuser=False
+        self.assertTrue(self.staff_user.is_staff)
+        self.assertFalse(self.staff_user.is_superuser)
+        self.superuser = KippoUser.objects.create(username="cat-admin-su", email="su@example.com", is_staff=True, is_superuser=True)
+
+        self.global_category = KippoProjectOrganizationCategory.objects.get(organization__isnull=True, key="other")
+        self.org_category = KippoProjectOrganizationCategory.objects.get(organization=self.organization, key="other")
+
+        self.admin = KippoProjectOrganizationCategoryAdmin(KippoProjectOrganizationCategory, admin.site)
+        self.factory = RequestFactory()
+
+    def _request(self, user: KippoUser) -> HttpRequest:
+        request = self.factory.get("/")
+        request.user = user
+        return request
+
+    def test_non_superuser_queryset_excludes_globals(self):
+        rows = self.admin.get_queryset(self._request(self.staff_user))
+        self.assertTrue(rows.exists())
+        self.assertFalse(rows.filter(organization__isnull=True).exists())
+
+    def test_superuser_queryset_includes_globals(self):
+        rows = self.admin.get_queryset(self._request(self.superuser))
+        self.assertTrue(rows.filter(organization__isnull=True).exists())
+
+    def test_non_superuser_cannot_change_or_delete_global(self):
+        request = self._request(self.staff_user)
+        self.assertFalse(self.admin.has_change_permission(request, self.global_category))
+        self.assertFalse(self.admin.has_delete_permission(request, self.global_category))
+
+    def test_non_superuser_can_change_and_delete_org_row(self):
+        request = self._request(self.staff_user)
+        self.assertTrue(self.admin.has_change_permission(request, self.org_category))
+        self.assertTrue(self.admin.has_delete_permission(request, self.org_category))
+
+    def test_superuser_can_change_global(self):
+        request = self._request(self.superuser)
+        self.assertTrue(self.admin.has_change_permission(request, self.global_category))
+        self.assertTrue(self.admin.has_delete_permission(request, self.global_category))
+
+    def test_non_superuser_save_model_rejects_creating_a_global(self):
+        request = self._request(self.staff_user)
+        new_global = KippoProjectOrganizationCategory(organization=None, key="staff-global", label="Staff Global")
+        with self.assertRaises(PermissionDenied):
+            self.admin.save_model(request, new_global, form=None, change=False)
+
+    def test_superuser_save_model_allows_creating_a_global(self):
+        request = self._request(self.superuser)
+        new_global = KippoProjectOrganizationCategory(organization=None, key="su-global", label="SU Global")
+        self.admin.save_model(request, new_global, form=None, change=False)
+        self.assertTrue(KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, key="su-global").exists())

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -667,14 +667,23 @@ class KippoProjectOrganizationCategoryTestCase(TestCase):
         self.user = created["KippoUser"]
         self.project = created["KippoProject"]
 
-    def test_get_for_organization_includes_globals_and_org_specific(self):
+    def test_get_for_organization_returns_only_org_rows_not_globals(self):
+        # copy-on-create (kippo#49): the org owns its copy of the defaults; globals are not inherited.
         KippoProjectOrganizationCategory.objects.create(
             organization=self.organization, key="org-special", label="Org Special", sort_order=5, created_by=self.user, updated_by=self.user
         )
-        keys = set(KippoProjectOrganizationCategory.get_for_organization(self.organization).values_list("key", flat=True))
+        global_only = KippoProjectOrganizationCategory.objects.create(
+            organization=None, key="global-only", label="Global Only", sort_order=99, created_by=self.user, updated_by=self.user
+        )
+        qs = KippoProjectOrganizationCategory.get_for_organization(self.organization)
+        keys = set(qs.values_list("key", flat=True))
         self.assertIn("org-special", keys)
+        # org's seeded copies of the defaults are present (own rows)...
         self.assertIn(DEFAULT_PROJECT_CATEGORY_VALUE, keys)
         self.assertIn(NON_PROJECT_CATEGORY_VALUE, keys)
+        # ...but every returned row is org-scoped, and a global-only row is excluded.
+        self.assertTrue(all(row.organization_id == self.organization.id for row in qs))
+        self.assertNotIn(global_only.key, keys)
 
     def test_get_for_organization_excludes_inactive(self):
         KippoProjectOrganizationCategory.objects.create(
@@ -687,9 +696,52 @@ class KippoProjectOrganizationCategoryTestCase(TestCase):
         # setup_basic_project creates projects without an explicit category — they take the model default.
         self.assertEqual(self.project.category.key, DEFAULT_PROJECT_CATEGORY_VALUE)
 
+    # --- copy-on-create (kippo#49) ---
+    def test_new_organization_seeds_category_copies(self):
+        org = KippoOrganization.objects.create(
+            name="seed-test-org", github_organization_name="seedtestorg", created_by=self.user, updated_by=self.user
+        )
+        global_keys = set(KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, is_active=True).values_list("key", flat=True))
+        org_keys = set(KippoProjectOrganizationCategory.objects.filter(organization=org).values_list("key", flat=True))
+        self.assertTrue(global_keys)
+        self.assertEqual(global_keys, org_keys)
+
+    def test_seed_for_organization_is_idempotent(self):
+        before = KippoProjectOrganizationCategory.objects.filter(organization=self.organization).count()
+        created = KippoProjectOrganizationCategory.seed_for_organization(self.organization)
+        after = KippoProjectOrganizationCategory.objects.filter(organization=self.organization).count()
+        self.assertEqual(created, 0)
+        self.assertEqual(before, after)
+
+    def test_new_project_category_is_org_scoped_copy_not_global(self):
+        # the model default resolves to a global template row; save() must repoint it to the org's copy.
+        self.assertEqual(self.project.category.organization_id, self.organization.id)
+        self.assertEqual(self.project.category.key, DEFAULT_PROJECT_CATEGORY_VALUE)
+
+    def test_backfill_migration_remaps_project_off_global(self):
+        import importlib
+
+        from django.apps import apps as real_apps
+
+        migration = importlib.import_module("projects.migrations.0048_seed_org_categories_and_remap_projects")
+        global_other = KippoProjectOrganizationCategory.objects.get(organization__isnull=True, key=DEFAULT_PROJECT_CATEGORY_VALUE)
+        # simulate a legacy project still pointing at the global template (bypass save() remap via update)
+        KippoProject.objects.filter(pk=self.project.pk).update(category=global_other)
+
+        migration.seed_and_remap(real_apps, None)
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.category.organization_id, self.organization.id)
+        self.assertEqual(self.project.category.key, DEFAULT_PROJECT_CATEGORY_VALUE)
+
 
 class KippoProjectCategoryLabelUniquenessTestCase(TestCase):
-    """ラベル uniqueness: global↔org labels must not repeat; org↔org labels may overlap."""
+    """ラベル uniqueness: unique within one org and among globals; org↔org and org↔global labels may overlap.
+
+    Under copy-on-create (kippo#49) an org owns its copy of the defaults, so an org label equal to a
+    global label is expected (globals are the seed template, never shown alongside org rows) — there
+    is no cross-scope disjointness rule.
+    """
 
     fixtures = DEFAULT_FIXTURES
 
@@ -716,21 +768,15 @@ class KippoProjectCategoryLabelUniquenessTestCase(TestCase):
         labels = KippoProjectOrganizationCategory.objects.filter(label="共有ラベル").count()
         self.assertEqual(labels, 2)
 
-    def test_global_label_cannot_be_reused_by_an_organization(self):
-        # NG: global=label1 already exists → org1=label1 is rejected by clean()
-        self._make(None, key="g1", label="グローバル限定")
+    def test_organization_may_reuse_a_global_label(self):
+        # copy-on-create (kippo#49): an org label equal to a global label is allowed (no cross-scope rule).
+        self._make(None, key="g1", label="グローバルと同じ")
         category = KippoProjectOrganizationCategory(
-            organization=self.org1, key="g1-org", label="グローバル限定", created_by=self.user, updated_by=self.user
+            organization=self.org1, key="g1-org", label="グローバルと同じ", created_by=self.user, updated_by=self.user
         )
-        with self.assertRaises(ValidationError):
-            category.full_clean()
-
-    def test_organization_label_cannot_be_reused_globally(self):
-        # NG (symmetric): org label already exists → adding the same global label is rejected by clean()
-        self._make(self.org1, key="o1", label="組織限定")
-        category = KippoProjectOrganizationCategory(organization=None, key="o1-global", label="組織限定", created_by=self.user, updated_by=self.user)
-        with self.assertRaises(ValidationError):
-            category.full_clean()
+        category.full_clean()  # must not raise
+        category.save()
+        self.assertEqual(KippoProjectOrganizationCategory.objects.filter(label="グローバルと同じ").count(), 2)
 
     def test_duplicate_global_label_rejected(self):
         self._make(None, key="g1", label="重複グローバル")

--- a/kippo/projects/tests/test_projectcategory_viewset.py
+++ b/kippo/projects/tests/test_projectcategory_viewset.py
@@ -247,8 +247,9 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_member_cannot_update_global_category(self):
+        # global template rows are outside a member's queryset (copy-on-create) -> 404, not leaked as 403
         response = self.client.patch(self._detail_url(self.global_category), {"label": "Hijack Global"}, format="json")
-        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     # --- delete ---
     def test_member_can_delete_unused_own_org_category(self):
@@ -266,8 +267,9 @@ class ProjectCategoryWriteViewSetTestCase(TestCase):
         self.assertTrue(KippoProjectOrganizationCategory.objects.filter(pk=self.own_category.pk).exists())
 
     def test_member_cannot_delete_global_category(self):
+        # global template rows are outside a member's queryset (copy-on-create) -> 404
         response = self.client.delete(self._detail_url(self.global_category))
-        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     # --- inactive visibility (soft-delete / reactivation) ---
     def test_default_list_hides_inactive_but_include_inactive_shows_it(self):

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -6,7 +6,7 @@ from typing import Any
 from accounts.models import KippoUser
 from commons.viewsets import OrganizationFilterMixin, organization_ids_for_user
 from django.conf import settings
-from django.db.models import Exists, OuterRef, Prefetch, Q, QuerySet, Sum
+from django.db.models import Exists, OuterRef, Prefetch, QuerySet, Sum
 from django.db.models.deletion import ProtectedError
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -63,18 +63,19 @@ class KippoProjectOrganizationCategoryViewSet(viewsets.ModelViewSet):
     Backs the kippo-ui project create/edit form category picker (read) and the org category
     management screen (write).
 
-    **Organization Scoping:**
-    - Regular users see global default categories plus the categories of organizations they belong to.
-    - Superusers see all active categories.
+    **Organization Scoping (copy-on-create, kippo#49):**
+    - Regular users see only the categories owned by organizations they belong to. Global
+      (organization=null) rows are the seed template and are NOT listed for members.
+    - Superusers see all categories (including the global template).
 
     **Filtering:**
-    - organization: UUID filter — narrows to that organization's categories (intersected with the
-      user's memberships) while still including the global defaults.
+    - organization: UUID filter — narrows to that organization's own categories (intersected with
+      the user's memberships).
 
     **Permissions:**
     - Read (GET): Authenticated users (organization-scoped for regular users).
     - Write (POST/PUT/PATCH/DELETE) on an org-scoped category: superuser or any member of that
-      organization. Global defaults are superuser-only. See ``IsSuperuserOrOrgMemberForCategory``.
+      organization. Global template rows are superuser-only. See ``IsSuperuserOrOrgMemberForCategory``.
     """
 
     serializer_class = KippoProjectOrganizationCategorySerializer
@@ -83,7 +84,9 @@ class KippoProjectOrganizationCategoryViewSet(viewsets.ModelViewSet):
 
     @extend_schema(
         parameters=[
-            OpenApiParameter(name="organization", description="Filter by organization UUID (globals always included)", required=False, type=str),
+            OpenApiParameter(
+                name="organization", description="Filter by organization UUID (that organization's own categories)", required=False, type=str
+            ),
             OpenApiParameter(
                 name="include_inactive",
                 description="Include inactive (is_active=false) categories in the list (management view). Default false.",
@@ -114,11 +117,13 @@ class KippoProjectOrganizationCategoryViewSet(viewsets.ModelViewSet):
             )
 
     def get_queryset(self):
-        """Globals + the user's organization categories; superusers see all such categories.
+        """The user's organizations' own categories; superusers see all (including the global template).
 
-        Inactive rows are hidden from the default list (the picker only wants active categories),
-        but are always included for detail actions (retrieve/update/destroy) and for the list when
-        ``include_inactive=true`` — so a member can see and reactivate a category they deactivated.
+        Under copy-on-create (kippo#49) globals are not inherited/listed for members — each org owns
+        its copy of the default set. Inactive rows are hidden from the default list (the picker only
+        wants active categories) but included for detail actions (retrieve/update/destroy) and for
+        the list when ``include_inactive=true`` — so a member can see and reactivate a category they
+        deactivated.
         """
         queryset = super().get_queryset()
         include_inactive = self.action != "list" or self.request.query_params.get("include_inactive", "").lower() in ("true", "1")
@@ -129,13 +134,13 @@ class KippoProjectOrganizationCategoryViewSet(viewsets.ModelViewSet):
 
         if user.is_superuser:
             if organization:
-                queryset = queryset.filter(Q(organization__isnull=True) | Q(organization=organization))
+                queryset = queryset.filter(organization=organization)
             return queryset
 
         user_organizations = organization_ids_for_user(user)
         if organization and organization in {str(org_id) for org_id in user_organizations}:
-            return queryset.filter(Q(organization__isnull=True) | Q(organization=organization))
-        return queryset.filter(Q(organization__isnull=True) | Q(organization__in=user_organizations))
+            return queryset.filter(organization=organization)
+        return queryset.filter(organization__in=user_organizations)
 
 
 class KippoProjectViewSet(OrganizationFilterMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary

Moves project categories from **live inheritance** (every org sees the shared globals, owns nothing) to **per-org ownership**: when a `KippoOrganization` is created it gets its own copy of the global default set and edits that copy independently (via the #48 member-CRUD API). Globals (`organization=null`) become a **seed template**, no longer shown live in any org's picker.

Implements kiconiaworks/kippo#49. Builds on #30 / #43 / #48 (#354).

## Changes

- **Seed on creation** — `post_save` receiver on `KippoOrganization` copies active globals into org-scoped rows (`KippoProjectOrganizationCategory.seed_for_organization`, idempotent; skipped on `raw` fixture loads).
- **Scope to own rows** — `get_for_organization()` and the category viewset return only the org's own rows; globals are excluded for members (superusers still see the template for management).
- **Drop the cross-scope label rule** — an org label equal to a global label is now expected (it's the copy), so the `clean()` global↔org disjointness check is removed. DB uniqueness (within-org, among-globals) is retained.
- **Org-aware default** — `KippoProject.save()` repoints a global-template category to the project org's copy of the same key on create, preserving `other` (default) and `non-project` (T10) semantics per-org.
- **Backfill migration `0048`** — for every existing org: seed copies of the active globals, then remap the org's projects from the global category to the org copy of the **same key** (1:1, no data loss; reversible; globals retained so no `PROTECT` delete).

## Tests

`projects.tests.test_models` + `test_projectcategory_viewset`: seeding on org creation, `seed_for_organization` idempotency, own-row scoping (globals excluded), org-scoped default remap, migration remap-off-global, and updated label-uniqueness (an org **may** reuse a global label; within-org/among-global duplicates still rejected). Full `projects`+`accounts` suite green apart from the 12 pre-existing S3/AWS-credential baseline errors (CSV/download/weeklyeffort-admin).

## Deploy note

Ships a data migration (`0048`) that backfills every org's category copies and remaps existing projects. Reversible.

## Follow-up

kiconiaworks/kippo#50 — curate the KiconiaWorks category set once this deploys (now an API/data task since the org owns its copy).

Refs kiconiaworks/kippo#49