### PR TITLE
Show customer name with project name in admin and __str__

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1775,7 +1775,7 @@ class KippoMilestoneAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     ordering = ("project", "target_date")
 
     def get_project_name(self, obj: KippoMilestone):
-        return obj.project.name
+        return obj.project.display_label
 
     get_project_name.short_description = _("Project")
 

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -882,7 +882,7 @@ class KippoProject(UserCreatedBaseModel):
     @property
     def display_label(self) -> str:
         """Project name prefixed with the customer name when a customer is set."""
-        return f"{self.customer.name}: {self.name}" if self.customer else self.name
+        return f"{self.customer.name} {self.name}" if self.customer else self.name
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}({self.display_label})"

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -879,8 +879,13 @@ class KippoProject(UserCreatedBaseModel):
         if phase_persisted:
             self._confidence_synced_phase = self.phase
 
+    @property
+    def display_label(self) -> str:
+        """Project name prefixed with the customer name when a customer is set."""
+        return f"{self.customer.name}: {self.name}" if self.customer else self.name
+
     def __str__(self) -> str:
-        return f"{self.__class__.__name__}({self.name})"
+        return f"{self.__class__.__name__}({self.display_label})"
 
 
 class ActiveKippoProjectManager(models.Manager):
@@ -981,7 +986,7 @@ class KippoProjectContract(UserCreatedBaseModel):
 
     def __str__(self) -> str:
         amount = f"¥{self.total_amount}" if self.total_amount is not None else "実績"
-        return f"KippoProjectContract({self.project.name} {self.billing_type}/{self.pricing_basis} {amount})"
+        return f"KippoProjectContract({self.project.display_label} {self.billing_type}/{self.pricing_basis} {amount})"
 
     @property
     def requires_estimate(self) -> bool:
@@ -1289,7 +1294,7 @@ class KippoProjectBillingEntry(UserCreatedBaseModel):
         constraints = (models.UniqueConstraint(fields=("contract", "billing_date"), name="unique_billingentry_contract_billing_date"),)
 
     def __str__(self) -> str:
-        return f"KippoProjectBillingEntry({self.contract.project.name} {self.billing_date} ¥{self.amount})"
+        return f"KippoProjectBillingEntry({self.contract.project.display_label} {self.billing_date} ¥{self.amount})"
 
     def save(self, *args, **kwargs):
         # keep the receipt fields consistent (mirrors KippoProject is_closed/closed_datetime).
@@ -1307,7 +1312,7 @@ class KippoProjectStatus(UserCreatedBaseModel):
     comment = models.TextField(help_text=_("Current Status"))
 
     def __str__(self) -> str:
-        return f"ProjectStatus({self.project.name} {self.created_datetime})"
+        return f"ProjectStatus({self.project.display_label} {self.created_datetime})"
 
 
 class KippoMilestone(UserCreatedBaseModel):
@@ -1855,7 +1860,7 @@ class KippoProjectUserStatisfactionResult(UserCreatedBaseModel):
         unique_together = ("project", "created_by")
 
     def __str__(self, *args, **kwargs) -> str:
-        return f"{self._meta.verbose_name} {self.project.name} {self.created_by.display_name}"
+        return f"{self._meta.verbose_name} {self.project.display_label} {self.created_by.display_name}"
 
 
 def get_current_month() -> datetime.date:
@@ -1875,7 +1880,7 @@ class KippoProjectUserMonthlyStatisfactionResult(UserCreatedBaseModel):
         unique_together = ("created_by", "project", "date")
 
     def __str__(self, *args, **kwargs) -> str:
-        return f"{self._meta.verbose_name} {self.project.name} ({self.date.strftime('%Y-%m')}) {self.created_by.display_name}"
+        return f"{self._meta.verbose_name} {self.project.display_label} ({self.date.strftime('%Y-%m')}) {self.created_by.display_name}"
 
 
 class ProjectAssignmentRate(UserCreatedBaseModel):
@@ -1891,7 +1896,7 @@ class ProjectAssignmentRate(UserCreatedBaseModel):
         unique_together = ("project", "role")
 
     def __str__(self) -> str:
-        return f"{self.project.name} - {self.role}: {self.rate_per_day}"
+        return f"{self.project.display_label} - {self.role}: {self.rate_per_day}"
 
 
 class ProjectMonthlyCost(TimestampedModel):
@@ -1904,4 +1909,4 @@ class ProjectMonthlyCost(TimestampedModel):
 
     def __str__(self) -> str:
         display_month = self.month.strftime("%Y-%m")
-        return f"{self.project.name}({self.project.id}) [{display_month}]"
+        return f"{self.project.display_label}({self.project.id}) [{display_month}]"

--- a/kippo/tasks/admin.py
+++ b/kippo/tasks/admin.py
@@ -25,7 +25,7 @@ class KippoTaskAdmin(OrganizationTaskQuerysetModelAdminMixin, UserCreatedBaseMod
     def get_kippoproject_name(self, obj: KippoTask | None = None) -> str:
         result = ""
         if obj and obj.project and obj.project.name:
-            result = obj.project.name
+            result = obj.project.display_label
         return result
 
     get_kippoproject_name.short_description = "KippoProject"


### PR DESCRIPTION
## Summary

Displays the project **customer name** alongside the project name in the Django admin and in model `__str__` output, so projects are identifiable by customer in dropdowns, changelists, history, and logs. Customer is omitted (name shown alone) when a project has no customer.

- New `KippoProject.display_label` property: `{customer.name}: {name}` when a customer is set, else `{name}`.
- `KippoProject.__str__` uses it — which also enriches every admin `list_display=("project", …)` column that renders the project FK (contract, monthly-assignment, monthly-cost, requirements admins).
- Applied to related `__str__` methods: contract, billing entry, status, satisfaction (×2), assignment rate, monthly cost.
- Explicit admin columns updated: `KippoMilestoneAdmin.get_project_name`, `KippoTaskAdmin.get_kippoproject_name`.

## Testing

- `uv run poe check` (ruff) ✅
- `projects.tests.test_models_billing` (73), `projects.tests.test_admin` + `tasks.tests` (150) — all pass ✅
- No existing test asserts the old `__str__` format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)