### PR TITLE
Make customer compliance 反社チェック verified action-only

### DIFF
--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -11,7 +11,7 @@ from django.contrib.admin.utils import unquote
 from django.contrib.admin.views.main import ChangeList
 from django.db import models
 from django.db.models import Prefetch
-from django.forms import BaseFormSet, Form
+from django.forms import Form
 from django.http import request as DjangoRequest  # noqa: N812
 from django.urls import reverse
 from django.utils import timezone
@@ -171,10 +171,11 @@ class KippoCustomerComplianceCheckInline(AllowIsStaffAdminMixin, admin.StackedIn
     max_num = 1
     can_delete = False
     fields = ("completion_notice", "verified", "verified_datetime", "verified_by", "notes")
-    # verified_datetime / verified_by are auto-managed (stamped when verified is ticked, cleared when
-    # unticked) — shown read-only so typed values can't be silently discarded. completion_notice is a
-    # read-only reminder rendered when the check is not yet completed.
-    readonly_fields = ("completion_notice", "verified_datetime", "verified_by")
+    # verified is set only via the changelist actions (反社チェック完了 / 取消), never hand-toggled here, so
+    # it and its auto-stamped verified_datetime / verified_by are read-only; the actions own who/when.
+    # completion_notice is a read-only reminder rendered when the check is not yet completed. notes stays
+    # editable.
+    readonly_fields = ("completion_notice", "verified", "verified_datetime", "verified_by")
 
     def has_add_permission(self, request: DjangoRequest, obj: models.Model | None = None) -> bool:
         return False  # one is auto-created per customer via the post_save signal
@@ -195,7 +196,7 @@ class KippoCustomerComplianceCheckInline(AllowIsStaffAdminMixin, admin.StackedIn
 class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
     list_display = ("name", "get_active_project_count", "get_compliance_verified", "updated_datetime")
     list_display_links = ("name",)
-    actions = ("mark_compliance_check_completed",)
+    actions = ("mark_compliance_check_completed", "mark_compliance_check_unverified")
     # organization is added conditionally in get_list_filter (only for multi-org members).
     list_filter = (CustomerEndingProjectsFilter,)
     search_fields = ("name", "email")
@@ -212,21 +213,6 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         # applies this admin's get_ordering(). Ordering by the annotation name would raise FieldError
         # there, and the `ordering` attribute would be rejected by admin check E033.
         return (ACTIVE_PROJECT_COUNT.desc(), "name")
-
-    def save_formset(self, request: DjangoRequest, form: Form, formset: BaseFormSet, change: bool):
-        # Specializes the base created_by/updated_by stamping to also record the compliance check's
-        # verified_by — the acting admin who marked it verified (save() clears it when un-verified).
-        instances = formset.save(commit=False)
-        for obj in formset.deleted_objects:
-            obj.delete()
-        for instance in instances:
-            if instance.id is None:
-                instance.created_by = request.user
-            instance.updated_by = request.user
-            if isinstance(instance, KippoCustomerComplianceCheck) and instance.verified and not instance.verified_by:
-                instance.verified_by = request.user
-            instance.save()
-        formset.save_m2m()
 
     def get_list_display(self, request: DjangoRequest) -> tuple:
         # Show the organization column only for superusers who belong to more than one organization;
@@ -378,6 +364,21 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
             compliance_check.save()
             completed += 1
         self.message_user(request, _("反社チェックを完了にしました: %(count)d 件") % {"count": completed})
+
+    @admin.action(description=_("反社チェック取消（ComplianceCheck Unverified）"))
+    def mark_compliance_check_unverified(self, request: DjangoRequest, queryset: models.QuerySet) -> None:
+        # Reverse a completed 反社チェック: model.save() clears verified_datetime and verified_by when
+        # verified is unset. Not-yet-verified checks are skipped so the count reflects real reversals.
+        reverted = 0
+        for customer in queryset:
+            compliance_check = getattr(customer, "compliance_check", None)
+            if compliance_check is None or not compliance_check.verified:
+                continue
+            compliance_check.verified = False
+            compliance_check.updated_by = request.user
+            compliance_check.save()
+            reverted += 1
+        self.message_user(request, _("反社チェックを取消しました: %(count)d 件") % {"count": reverted})
 
     def change_view(self, request: DjangoRequest, object_id: str, form_url: str = "", extra_context: dict | None = None):
         # Surface an "プロジェクトを追加" button under the projects inline that sends the user to the

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -136,20 +136,24 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertEqual(inline.get_contract_total(project), "実績")
         self.assertEqual(inline.get_contract_type(project), "月額 / 実績")
 
-    def test_compliance_check_inline_registered_and_editable(self):
+    def test_compliance_check_inline_registered_and_read_only(self):
         from customers.admin import KippoCustomerComplianceCheckInline
 
         self.assertIn(KippoCustomerComplianceCheckInline, KippoCustomerAdmin.inlines)
         # the 反社チェック record is auto-created per customer (signal); the inline edits it (no add)
         inline = KippoCustomerComplianceCheckInline(KippoCustomer, self.site)
         self.assertFalse(inline.has_add_permission(self.staff_user_request))
-        self.assertIn("verified_datetime", inline.readonly_fields)  # auto-managed
+        # verified is set only via the changelist actions, so it and its stamps are read-only
+        self.assertIn("verified", inline.readonly_fields)
+        self.assertIn("verified_datetime", inline.readonly_fields)
         self.assertIn("verified_by", inline.readonly_fields)
-        # change view renders the compliance inline form for the auto-created record
+        # change view renders the inline form (notes stays editable) but not an editable verified input
         url = reverse("admin:customers_kippocustomer_change", args=[self.customer.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertIn("compliance_check-0-verified", response.content.decode())
+        content = response.content.decode()
+        self.assertIn("compliance_check-0-notes", content)  # inline rendered; notes editable
+        self.assertNotIn('name="compliance_check-0-verified"', content)  # verified is not a form input
 
     def test_compliance_inline_shows_not_completed_notice_when_unverified(self):
         # The 反社チェック inline (add/change UI) shows the reminder while the check is not completed.
@@ -175,35 +179,18 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         content = self.client.get(url).content.decode()
         # the record is created on view, so the inline form and its completion notice now render
         self.assertTrue(KippoCustomerComplianceCheck.objects.filter(customer=self.customer).exists())
-        self.assertIn("compliance_check-0-verified", content)
+        self.assertIn("compliance_check-0-notes", content)  # inline form rendered
         self.assertIn("反社チェックが未完了です", content)
 
-    def test_compliance_inline_save_stamps_verified_by_and_datetime(self):
+    def test_compliance_inline_verified_not_an_editable_form_field(self):
+        # verified is read-only in the inline: the form has no editable 'verified' field, so it cannot
+        # be hand-toggled from the customer page — the changelist actions are the only way to set it.
         from customers.admin import KippoCustomerComplianceCheckInline
 
-        check = self.customer.compliance_check
-        self.assertFalse(check.verified)
-        admin_obj = KippoCustomerAdmin(KippoCustomer, self.site)
         inline = KippoCustomerComplianceCheckInline(KippoCustomer, self.site)
         formset_class = inline.get_formset(request=self.super_user_request, obj=self.customer)
-        prefix = "compliance_check"
-        data = {
-            f"{prefix}-TOTAL_FORMS": "1",
-            f"{prefix}-INITIAL_FORMS": "1",
-            f"{prefix}-MIN_NUM_FORMS": "0",
-            f"{prefix}-MAX_NUM_FORMS": "1",
-            f"{prefix}-0-id": str(check.id),
-            f"{prefix}-0-verified": "on",
-            f"{prefix}-0-notes": "",
-        }
-        formset = formset_class(data=data, instance=self.customer, prefix=prefix)
-        self.assertTrue(formset.is_valid(), formset.errors)
-        admin_obj.save_formset(self.super_user_request, form=None, formset=formset, change=True)
-
-        check.refresh_from_db()
-        self.assertTrue(check.verified)
-        self.assertEqual(check.verified_by, self.super_user_request.user)  # acting admin stamped
-        self.assertIsNotNone(check.verified_datetime)
+        self.assertNotIn("verified", formset_class.form.base_fields)
+        self.assertIn("notes", formset_class.form.base_fields)  # notes stays editable
 
     def test_change_view_lists_related_project_with_admin_link(self):
         project = self._make_customer_project("acme-alpha", self.customer, date(2026, 6, 1))
@@ -312,6 +299,26 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         # already-completed check is left untouched (original verifier/datetime preserved)
         self.assertEqual(check.verified_by, self.github_manager)
         self.assertEqual(check.verified_datetime, original_datetime)
+
+    def test_compliance_check_unverified_action_clears_verified_fields(self):
+        from django.utils import timezone
+
+        check = self.customer.compliance_check
+        check.verified = True
+        check.verified_datetime = timezone.now()
+        check.verified_by = self.github_manager
+        check.save()
+        url = reverse("admin:customers_kippocustomer_changelist")
+        response = self.client.post(
+            url,
+            {"action": "mark_compliance_check_unverified", "_selected_action": [str(self.customer.pk)]},
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        check.refresh_from_db()
+        # reversal clears verified and its stamps (model.save() nulls datetime/by when unverified)
+        self.assertFalse(check.verified)
+        self.assertIsNone(check.verified_datetime)
+        self.assertIsNone(check.verified_by)
 
     def test_active_project_count_zero_renders_plain(self):
         modeladmin = KippoCustomerAdmin(KippoCustomer, self.site)


### PR DESCRIPTION
## Problem

On the customer admin, the 反社チェック (compliance check) inline exposed a hand-editable `verified` checkbox, while the inline's own status notice told admins to complete the check via the **「反社チェック完了」changelist action** — two competing paths to set the same boolean. The on-page guidance and the actual control disagreed.

## Change

- **`verified` is now read-only in the inline** (`KippoCustomerComplianceCheckInline`), so the changelist action is the only way to set it. `notes` stays editable.
- **Dropped the `save_formset` override**: its only extra job was stamping `verified_by` for the manual checkbox path. With that path gone, the base `save_formset` (created_by/updated_by) suffices, and the action owns `verified_by` — this also removes a mis-attribution risk (a notes-editor could otherwise be stamped as the verifier).
- **Added a 「反社チェック取消」(unverify) action** so a completed check can still be reversed — the previous manual checkbox was the only un-verify path. `KippoCustomerComplianceCheck.save()` already clears `verified_datetime`/`verified_by` when `verified` is unset.

The status notice text ("…「反社チェック完了」アクションで更新してください") is now accurate — the action is the sole entry point.

## Testing

- `uv run poe check` (ruff) — clean
- `customers.tests.test_admin` — 45 passed, including: verified in `readonly_fields`, verified is not an editable form field, inline still renders (notes editable), completed action, and the new unverify action clears verified/datetime/verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)