### PR TITLE
Move 契約 inline directly below Dates & Estimates on the project admin

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1050,9 +1050,11 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         # Milestones not used atm, commenting out.
         # KippoMilestoneReadOnlyInline,
         # KippoMilestoneAdminInline,
+        # 契約 first: it sits directly below the "Dates & Estimates" fieldset (its period is the
+        # source of truth for the project's start/target dates — see get_exclude / _sync_project_period).
+        KippoProjectContractInline,
         ProjectAssignmentRateInline,
         ProjectMonthlyAssignmentInline,
-        KippoProjectContractInline,
         GithubRepositoryProjectInline,
         ProjectWeeklyEffortReadOnlyInine,
         ProjectWeeklyEffortAdminInline,


### PR DESCRIPTION
## Summary

Reorders `KippoProjectBaseAdmin.inlines` so `KippoProjectContractInline` renders first in the inline block, placing the **契約 (contract)** section immediately below the **Dates & Estimates** fieldset on the project change form.

The contract's period is the single source of truth for the project's `start_date` / `target_date` (mirrored via `KippoProjectContract._sync_project_period`, and the project's own date fields are hidden once a contract exists — see `KippoProjectAdmin.get_exclude`). Grouping the two sections together makes that relationship visible in the UI.

## Details

- Pure ordering change to the change-form inline block.
- `HIDDEN_ON_ADD_INLINES` filters by membership (order-independent), and `KippoProjectContractInline` stays hidden on `/add/` — so add-form behavior is unchanged.
- No caller depends on a positional index into `inlines`.

Note: Django renders all fieldsets before the inline block, so the collapsed `Details` / `Extra` fieldsets still sit above the inline region; the contract inline is now the first thing in that region.

## Confirmation (from review of the change)

When a contract exists, the project's `start_date` / `target_date` are **hidden** (excluded from the form via `get_exclude`), not readonly — leaving `Dates & Estimates` with `allocated_staff_days` + `estimated_completion_date`.