### PR TITLE
Render 契約 inline directly below Dates & Estimates on the project admin

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1050,11 +1050,11 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         # Milestones not used atm, commenting out.
         # KippoMilestoneReadOnlyInline,
         # KippoMilestoneAdminInline,
-        # 契約 first: it sits directly below the "Dates & Estimates" fieldset (its period is the
-        # source of truth for the project's start/target dates — see get_exclude / _sync_project_period).
-        KippoProjectContractInline,
         ProjectAssignmentRateInline,
         ProjectMonthlyAssignmentInline,
+        # 契約 is rendered directly below the "Dates & Estimates" fieldset by the change_form template
+        # (Django emits all fieldsets before any inline, so this list order can't place it there).
+        KippoProjectContractInline,
         GithubRepositoryProjectInline,
         ProjectWeeklyEffortReadOnlyInine,
         ProjectWeeklyEffortAdminInline,

--- a/kippo/projects/templates/admin/projects/kippoproject/change_form.html
+++ b/kippo/projects/templates/admin/projects/kippoproject/change_form.html
@@ -110,3 +110,29 @@
 })();
 </script>
 {% endblock %}
+
+{# Render the 契約 (contract) inline directly below the "Dates & Estimates" fieldset. Django renders
+   ALL fieldsets before ANY inline, so the inlines list order alone cannot place an inline between two
+   fieldsets — we pull the contract inline out of the default inline loop and emit it here instead.
+   Match by the inline's verbose_name (KippoProjectContract.Meta.verbose_name = 契約); if the verbose_name
+   ever changes, both blocks fall back to Django's default (contract renders at the top of the inline
+   block), so the worst case is the old position, never a broken form.
+   Invariant: the contract inline only appears on the change form, where the "Dates & Estimates" fieldset
+   is always present (allocated_staff_days is never excluded). If that ever changes, the anchor below must
+   change too, or the contract inline — skipped in the inline loop — would render nowhere. #}
+{% block field_sets %}
+{% for fieldset in adminform %}
+  {% include "admin/includes/fieldset.html" with heading_level=2 prefix="fieldset" id_prefix=0 id_suffix=forloop.counter0 %}
+  {% if fieldset.name == "Dates & Estimates" %}
+    {% for inline_admin_formset in inline_admin_formsets %}
+      {% if inline_admin_formset.opts.verbose_name == "契約" %}{% include inline_admin_formset.opts.template %}{% endif %}
+    {% endfor %}
+  {% endif %}
+{% endfor %}
+{% endblock %}
+
+{% block inline_field_sets %}
+{% for inline_admin_formset in inline_admin_formsets %}
+  {% if inline_admin_formset.opts.verbose_name != "契約" %}{% include inline_admin_formset.opts.template %}{% endif %}
+{% endfor %}
+{% endblock %}

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -346,10 +346,34 @@ class ProjectsAdminViewTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertTemplateUsed(response, "admin/change_list.html")
 
-        # self.client.force_login(self.client_user)
-        # response = self.client.get(url)
-        # self.assertEqual(response.status_code, HTTPStatus.OK)
-        # self.assertTemplateUsed(response, "admin/change_list.html")
+    def test_contract_inline_renders_directly_after_dates_and_estimates(self):
+        # The change_form template pulls the 契約 inline out of the default inline block and emits it
+        # directly below the "Dates & Estimates" fieldset. Assert the rendered order:
+        #   Dates & Estimates (allocated_staff_days) < 契約 (billing_type) < Details (document_folder_url).
+        # Field names are used as markers because they are prefix-independent and absent from the <head>.
+        KippoProjectContract.objects.create(
+            project=self.project1,
+            billing_type="monthly",
+            pricing_basis="fixed",
+            total_amount=300000,
+            start_date=self.current_date,
+            end_date=self.current_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        url = reverse("admin:projects_kippoproject_change", args=[self.project1.id])
+        self.client.force_login(self.superuser_no_org)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.content.decode()
+        dates_idx = content.index("allocated_staff_days")
+        contract_idx = content.index("billing_type")
+        details_idx = content.index("document_folder_url")
+        self.assertLess(dates_idx, contract_idx, "契約 inline should render after the Dates & Estimates fieldset")
+        self.assertLess(contract_idx, details_idx, "契約 inline should render before the Details fieldset")
+        # A contract exists, so the project's own start/target inputs are hidden (contract is the source of truth).
+        self.assertNotIn('name="start_date"', content)
+        self.assertNotIn('name="target_date"', content)
 
 
 class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):


### PR DESCRIPTION
## Summary

Follow-up to #359. That PR reordered the `inlines` list to put `KippoProjectContractInline` first, but **Django renders all fieldsets before any inline** — so the 契約 section still appeared below the collapsed `Details` / `Extra` fieldsets rather than "just after Dates & Estimates" as requested.

This PR renders the 契約 inline in the correct position via the change-form template:

- Override the `field_sets` block to emit the 契約 inline immediately after the **Dates & Estimates** fieldset.
- Override `inline_field_sets` to skip 契約 in the default inline loop (so it isn't rendered twice).
- The inline is matched by its `verbose_name` (`KippoProjectContract.Meta.verbose_name` = 契約). If that ever changes, both blocks fall back to Django's default position — never a broken form.
- Revert the now-moot list reorder from #359 (placement is template-driven now).

Rendered order on the change form is now:

```
(main fields)
Dates & Estimates
契約            ← contract inline
Details        (collapsed)
Extra          (collapsed)
ProjectAssignmentRate … (remaining inlines)
```

## Why the template, not the inlines list

Inlines always render after the fieldset block, so list order alone can't place an inline between two fieldsets. Pulling the one inline out of the default loop and emitting it after a named fieldset is the standard approach. nested_admin initializes it in place (no post-load DOM move), so the nested billing-entry inline keeps working.

## Test

Adds `test_contract_inline_renders_directly_after_dates_and_estimates`: creates a contract, GETs the change form, and asserts the render order `allocated_staff_days` < `billing_type` < `document_folder_url` (prefix-independent markers absent from the page `<head>`). Also asserts the project's own `start_date` / `target_date` inputs are hidden once a contract exists (contract period is the source of truth).

Local: `projects.tests.test_admin` ProjectsAdminViewTestCase / IsStaffOrganizationKippoProjectAdminTestCase / CloseProjectActionTestCase / meeting_calendar — all green; ruff clean.