### PR TITLE
Surface MTG-calendar readonly fields at the top of the project admin

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1004,6 +1004,10 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
                     "category",
                     "project_manager",
                     "problem_definition",
+                    # computed readonly MTG-calendar displays (kippo#13) — surfaced at the top, below the
+                    # problem definition. Excluded on /add/ (only meaningful once the project exists).
+                    "meeting_calendar_url_field",
+                    "meeting_description_tag_field",
                 )
             },
         ),
@@ -1031,9 +1035,6 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
                     "docbase_tag",
                     "github_project_html_url",
                     "github_project_api_nodeid",
-                    # computed readonly MTG-calendar displays (kippo#13) — optional, secondary info
-                    "meeting_calendar_url_field",
-                    "meeting_description_tag_field",
                 ),
             },
         ),

--- a/kippo/projects/tests/test_admin_meeting_calendar.py
+++ b/kippo/projects/tests/test_admin_meeting_calendar.py
@@ -71,6 +71,22 @@ class MeetingCalendarAdminFieldTestCase(TestCase):
         assert "meeting_calendar_url_field" in excluded
         assert "meeting_description_tag_field" in excluded
 
+    def test_meeting_fields_in_top_section_after_problem_definition_on_change(self):
+        # The MTG-calendar readonly displays are surfaced at the top, directly below problem_definition,
+        # not in the collapsed Details section.
+        request = MockRequest()
+        request.user = self.user
+        fieldsets = self.admin.get_fieldsets(request, self.project)
+        label, opts = fieldsets[0]
+        top_fields = opts["fields"]
+        assert label is None
+        assert "meeting_calendar_url_field" in top_fields
+        assert "meeting_description_tag_field" in top_fields
+        assert top_fields.index("meeting_calendar_url_field") > top_fields.index("problem_definition")
+        details = next(opts["fields"] for lbl, opts in fieldsets if str(lbl) == "Details")
+        assert "meeting_calendar_url_field" not in details
+        assert "meeting_description_tag_field" not in details
+
 
 class AddCalendarLinksActionTestCase(TestCase):
     fixtures = DEFAULT_FIXTURES


### PR DESCRIPTION
## Summary

Move the two computed MTG-calendar readonly displays out of the collapsed **Details** section and into the top (unlabelled) fieldset, directly below `problem_definition`:

- `meeting_calendar_url_field` — **MTG カレンダー作成 URL** ("Create Project Meeting" link + コピー button)
- `meeting_description_tag_field` — **カレンダーの説明欄** (`[dsearch]…[/dsearch]` tag + コピー button)

Now the calendar link and description tag are visible at a glance on the change form without expanding Details.

## Behavior unchanged

Both stay in `readonly_fields` and remain excluded on `/add/` (they're only meaningful once the project exists), so they still don't render on the add form. `get_fieldsets` drops them from the top section on add via `get_exclude`.

## Test

Adds `test_meeting_fields_in_top_section_after_problem_definition_on_change`: asserts both fields live in the top (`None`-labelled) fieldset after `problem_definition` on the change form, and no longer appear in `Details`.

Full `projects.tests.test_admin` (133) + `test_admin_meeting_calendar` green; ruff clean.