### PR TITLE
Resolve project category against the org's own categories

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db.models import Sum
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -280,6 +281,27 @@ class KippoProjectBillingEntrySerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "contract", "received_datetime", "received_by", "created_datetime", "updated_datetime"]
 
 
+@extend_schema_field(OpenApiTypes.STR)
+class ProjectCategoryKeyField(serializers.Field):
+    """Read/write the KippoProject.category as its KEY string.
+
+    Read → the FK's key. Write → passes the raw key string through unresolved; the FK is resolved
+    against the project's own organization in ``KippoProjectSerializer.validate`` (kippo#49
+    copy-on-create — each org owns its category set, so a key can't be resolved against the global
+    template alone).
+    """
+
+    default_error_messages = {"invalid": _("A category key must be a string.")}
+
+    def to_representation(self, value: "KippoProjectOrganizationCategory | None") -> "str | None":
+        return value.key if value else None
+
+    def to_internal_value(self, data: object) -> str:
+        if not isinstance(data, str):
+            self.fail("invalid")
+        return data
+
+
 class KippoProjectSerializer(serializers.ModelSerializer):
     """Serializer for KippoProject model."""
 
@@ -296,11 +318,10 @@ class KippoProjectSerializer(serializers.ModelSerializer):
     # A set value is preserved by KippoProject.save() until phase changes; changing phase in the same
     # update re-derives confidence from the new phase and ignores any confidence sent (kippo#36 / T09).
     confidence = serializers.IntegerField(min_value=0, max_value=100, required=False)
-    # category is a FK to KippoProjectOrganizationCategory; expose it as the category key string for
-    # API backward-compatibility. Writes resolve against the global default categories (kippo#30 / T08, T20).
-    category = serializers.SlugRelatedField(
-        slug_field="key",
-        queryset=KippoProjectOrganizationCategory.objects.filter(organization__isnull=True),
+    # category is a FK to KippoProjectOrganizationCategory; expose/accept it as the category key
+    # string for API backward-compatibility. Writes resolve against the project's OWN organization's
+    # categories in validate() (kippo#49 copy-on-create), falling back to the global template.
+    category = ProjectCategoryKeyField(
         required=False,
         help_text="Project category key (e.g. 'ai-development', 'other', 'non-project').",
     )
@@ -437,6 +458,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         """
         attrs = super().validate(attrs)
         organization = attrs.get("organization") or getattr(self.instance, "organization", None)
+        self._resolve_category(attrs, organization)
         columnset = attrs.get("columnset")
         # Re-parenting (organization changes) without a new columnset must re-check the
         # project's *existing* columnset against the new org — otherwise a stale cross-org
@@ -473,6 +495,27 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         self._validate_contract_synced_dates(attrs)
         self._validate_under_contract_phase(attrs)
         return attrs
+
+    def _resolve_category(self, attrs: dict, organization: "KippoOrganization | None") -> None:
+        """Resolve the incoming category KEY string to the project's org category FK (kippo#49).
+
+        Prefer the project organization's OWN category with that key (copy-on-create means each org
+        owns its set, including org-custom keys like 'sunx'); fall back to the global template row so
+        a pre-copy org / global-only key still resolves (KippoProject.save() then remaps a resolved
+        global to the org's copy — a project never references a global). An unresolvable key is a 400,
+        not a 500. Omitted category (not in attrs) leaves the model default untouched.
+        """
+        category_key = attrs.get("category")
+        if not isinstance(category_key, str):
+            return
+        category = None
+        if organization is not None:
+            category = KippoProjectOrganizationCategory.objects.filter(organization=organization, key=category_key).first()
+        if category is None:
+            category = KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, key=category_key).first()
+        if category is None:
+            raise serializers.ValidationError({"category": _("Unknown category key '%(key)s' for this organization.") % {"key": category_key}})
+        attrs["category"] = category
 
     def _validate_contract_synced_dates(self, attrs: dict) -> None:
         """Once a contract has a period, that period is the single source of truth — the project's

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -2,6 +2,7 @@
 
 import datetime
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 from unittest import mock
 
 from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
@@ -23,6 +24,9 @@ from ..models import (
     ProjectColumnSet,
     ProjectWeeklyEffort,
 )
+
+if TYPE_CHECKING:
+    from customers.models import KippoCustomer
 
 
 def _registration_fields(organization: KippoOrganization, project_manager: KippoUser) -> dict:
@@ -1122,6 +1126,93 @@ class PermissionsTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
         created = KippoProject.objects.get(name="Slim Registration Project")
         self.assertIsNone(created.project_manager)
+
+    def _create_project_customer(self, name: str = "cat-test-customer") -> "KippoCustomer":
+        from customers.models import KippoCustomer
+
+        return KippoCustomer.objects.create(
+            organization=self.organization,
+            name=name,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+    def test_create_resolves_org_specific_category_key(self):
+        """A category key that exists only as the org's OWN category (kippo#49 copy-on-create) resolves
+        to that org row — org-custom keys are no longer rejected as non-global (kippo#40 category picker).
+        """
+        org_category = KippoProjectOrganizationCategory.objects.create(
+            organization=self.organization,
+            key="sunx",
+            label="SUNX",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        customer = self._create_project_customer()
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Org Category Project",
+            "organization": str(self.organization.id),
+            "columnset": self.project.columnset.id,
+            "customer": str(customer.id),
+            "start_date": "2026-08-01",
+            "category": "sunx",
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
+        self.assertEqual(response.json()["category"], "sunx")
+        created = KippoProject.objects.get(name="Org Category Project")
+        self.assertEqual(created.category_id, org_category.id)
+
+    def test_create_global_only_key_resolves_and_remaps_to_org_category(self):
+        """A global-template key with no org copy is not rejected (kippo#49): the serializer resolves it
+        to the global, then KippoProject.save() remaps it to the org's copy — a project never references
+        a global. Asserts no 400 and that the persisted category belongs to the org.
+        """
+        # global-only key with no org copy — the seeded org owns copies of the default keys, so a fresh
+        # global-only key is needed to exercise the fallback branch.
+        KippoProjectOrganizationCategory.objects.create(
+            organization=None,
+            key="global-only-key",
+            label="Global Only",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.assertFalse(KippoProjectOrganizationCategory.objects.filter(organization=self.organization, key="global-only-key").exists())
+        customer = self._create_project_customer("global-cat-customer")
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Global Category Project",
+            "organization": str(self.organization.id),
+            "columnset": self.project.columnset.id,
+            "customer": str(customer.id),
+            "start_date": "2026-08-01",
+            "category": "global-only-key",
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
+        created = KippoProject.objects.get(name="Global Category Project")
+        # save() remaps the resolved global to an org-owned category (never a global template row).
+        self.assertEqual(created.category.organization_id, self.organization.id)
+
+    def test_create_unknown_category_key_returns_400(self):
+        """An unresolvable category key is a 400 (not a 500), scoped to the project's organization."""
+        customer = self._create_project_customer("bad-cat-customer")
+        self.client.force_authenticate(user=self.user)
+        url = f"{settings.URL_PREFIX}/api/projects/"
+        data = {
+            "name": "Bad Category Project",
+            "organization": str(self.organization.id),
+            "columnset": self.project.columnset.id,
+            "customer": str(customer.id),
+            "start_date": "2026-08-01",
+            "category": "does-not-exist",
+        }
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+        self.assertIn("category", response.json())
 
     def test_edit_existing_project_not_blocked_by_registration_requirements(self):
         """The required-field validation is create-only; editing a contract-less / customer-less


### PR DESCRIPTION
## Problem

The kippo-ui **新規プロジェクト作成** (New Project) category dropdown shows no categories (`(カテゴリがありません)`).

Root cause is a read/write mismatch introduced by copy-on-create (kippo#49):

- The category list endpoint (`/api/project-categories/?organization=<uuid>`) returns each org's **own** category copies and no longer surfaces the global template (`organization=null`) to members. (Verified live: an org returns 8 org-owned categories, zero globals.)
- But the `KippoProject` write-path serializer resolved the `category` key against **globals only** (`organization__isnull=True`).

An org that diverged from the global seed (org-custom keys like `sunx`, `info`, `employee-referral`) therefore could not assign those categories to a project — the serializer 400'd on them.

## Fix

- Replace the globals-only `SlugRelatedField` for `category` with a `ProjectCategoryKeyField` that defers resolution.
- `KippoProjectSerializer.validate` resolves the category KEY against the **project organization's own** categories first, falling back to the global template. `KippoProject.save()` already remaps a resolved global to the org's copy, so a project never references a global.
- Unknown keys surface a clean `400` (not a 500).
- OpenAPI type for `category` stays `string` — the generated kippo-ui client is unchanged.

## Tests

- Added: org-specific key resolves to the org row; global-only key resolves and remaps to an org category; unknown key → 400.
- `projects.tests.test_api_rest` + `test_projectcategory_viewset` (134 tests) pass; `poe check` clean.

The companion kippo-ui change (show the org's own categories in the picker) ships separately against monkut/kippo-ui.

Refs kiconiaworks/kippo