### PR TITLE
Make the full-confidence estimate requirement create-only

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -828,15 +828,20 @@ class KippoProjectAdminForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super().clean()
         category = cleaned_data.get("category")
-        # allocated_staff_days must be a positive estimate once a real, non-closed project is fully
-        # confident — confidence (確度) is derived from the submitted phase. Non-project categories
-        # (internal/overhead buckets) are exempt (kippo#41).
+        # allocated_staff_days must be a positive estimate when registering a real, non-closed project
+        # at full confidence — confidence (確度) is derived from the submitted phase. Non-project
+        # categories (internal/overhead buckets) are exempt (kippo#41). Create-only: editing an
+        # existing project must not be blocked by a missing estimate, so a later /change/ (e.g. adding
+        # a project-status comment) still saves even when allocated_staff_days is blank.
         phase = cleaned_data.get("phase")
         allocated_staff_days = cleaned_data.get("allocated_staff_days")
         is_non_project = getattr(category, "key", None) == NON_PROJECT_CATEGORY_VALUE
-        needs_estimate = not self.instance.is_closed and not is_non_project and PHASE_CONFIDENCE.get(phase) == FULL_CONFIDENCE
-        # the slim /add/ form does not render allocated_staff_days — the estimate requirement is
-        # enforced on the later edit (add_error on an absent field would raise)
+        needs_estimate = (
+            self.instance._state.adding and not self.instance.is_closed and not is_non_project and PHASE_CONFIDENCE.get(phase) == FULL_CONFIDENCE
+        )
+        # the slim /add/ form does not render allocated_staff_days, so the requirement can't apply
+        # there (add_error on an absent field would raise); the full add form (upsell close-wizard)
+        # does render it, so registration through that path is still validated.
         if "allocated_staff_days" not in self.fields:
             needs_estimate = False
         if needs_estimate and (allocated_staff_days is None or allocated_staff_days <= 0):

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -912,6 +912,27 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
         form = KippoProjectAdminForm(instance=existing, data=data)
         self.assertTrue(form.is_valid(), form.errors)
 
+    def test_edit_full_confidence_project_not_blocked_by_blank_allocated_staff_days(self):
+        # create-only rule (kippo#41): a full-confidence EXISTING project with a blank estimate must
+        # still validate on /change/ — otherwise a project-status (KippoProjectStatus) comment can't
+        # be added until the estimate is filled. The requirement stays enforced on /add/ (see
+        # test_full_confidence_requires_positive_allocated_staff_days).
+        existing = KippoProject.objects.create(
+            organization=self.organization,
+            name="existing-full-confidence-no-estimate",
+            category=_global_category("other"),
+            columnset=self.columnset,
+            phase="completed",  # confidence 100, not closed
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.assertFalse(existing.is_closed)
+        data = self._form_data(category="other")
+        data["phase"] = "completed"
+        del data["allocated_staff_days"]
+        form = KippoProjectAdminForm(instance=existing, data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+
     def test_edit_existing_project_not_blocked_by_registration_requirements(self):
         # editing an existing customer-less / PM-less project must still validate (create-only rule)
         existing = KippoProject.objects.create(
@@ -1953,6 +1974,53 @@ class GithubRepositoryInlineSaveTestCase(KippoProjectAdminFixtureTestCaseBase):
         self.assertEqual(post_response.status_code, HTTPStatus.FOUND, post_response.content[:500])
         repo = GithubRepository.objects.get(name="new-repo", project=self.project)
         self.assertEqual(repo.organization_id, self.project.organization_id)
+
+
+class StatusCommentOnChangeWithBlankEstimateTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """A full-confidence project with a blank allocated_staff_days must still accept a new
+    KippoProjectStatus comment on /change/. The estimate requirement is create-only (kippo#41), so
+    adding a status comment on an existing project is not blocked by a missing estimate.
+    """
+
+    def test_change_view_post_adds_status_comment_when_estimate_blank(self):
+        from projects.admin import KippoProjectStatusAdminInline
+
+        project = KippoProject.objects.create(
+            organization=self.organization,
+            name="full-confidence-blank-estimate",
+            category=_global_category("other"),
+            columnset=self.columnset,
+            start_date=self.current_date,
+            phase="completed",  # confidence 100, not closed
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.assertFalse(project.is_closed)
+        self.assertIsNone(project.allocated_staff_days)
+
+        url = reverse("admin:projects_activekippoproject_change", args=[project.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        # Two inlines share the KippoProjectStatus model, so the editable one's prefix is
+        # disambiguated at runtime — resolve it from the rendered formsets rather than hardcoding.
+        status_prefix = next(
+            ifs.formset.prefix for ifs in response.context["inline_admin_formsets"] if isinstance(ifs.opts, KippoProjectStatusAdminInline)
+        )
+        comment = "status update while estimate is blank"
+        form_data = _extract_admin_form_post_data(response, project)
+        form_data.update(
+            {
+                f"{status_prefix}-TOTAL_FORMS": "1",
+                f"{status_prefix}-INITIAL_FORMS": "0",
+                f"{status_prefix}-0-comment": comment,
+                f"{status_prefix}-0-id": "",
+                f"{status_prefix}-0-project": str(project.id),
+            }
+        )
+        post_response = self.client.post(url, data=form_data, follow=False)
+        self.assertEqual(post_response.status_code, HTTPStatus.FOUND, post_response.content[:1000])
+        self.assertTrue(KippoProjectStatus.objects.filter(project=project, comment=comment).exists())
 
 
 def _extract_admin_form_post_data(get_response: HttpResponse, project: KippoProject) -> dict:


### PR DESCRIPTION
## Problem

On the KippoProject **/change/** admin page, you could not add a **KippoProjectStatus** (project status / コメント) entry when the project had no `allocated_staff_days` estimate.

Status comments are only addable on the change page (via `KippoProjectStatusAdminInline`). Saving that page runs `KippoProjectAdminForm.clean`, which required a positive `allocated_staff_days` once the project reached full confidence (phase 契約(稼働中) / 完了). That check had **no add-vs-edit guard**, so it fired on edits too — a full-confidence project with a blank estimate could not be saved, blocking the comment until the estimate was filled.

## Fix

Gate the estimate requirement on `self.instance._state.adding` so it applies at **registration only** — matching the "create-only rule" the existing kippo#40/#41 tests already describe (the test at `test_edit_existing_project_not_blocked_by_new_required_fields` only passed because it used a non-full-confidence phase, so it never caught the edit-time block).

Behaviour after the change:

| Path | `allocated_staff_days` requirement |
|---|---|
| Slim `/add/` | not rendered → not enforced (unchanged) |
| Full `/add/` (upsell close-wizard) | rendered + adding → **enforced** (create requirement maintained) |
| `/change/` (edit) | **not enforced** → status comments can be added |

## Tests

- Form-level: editing a full-confidence project with a blank estimate is now valid.
- End-to-end: an admin change-view POST that adds a status-comment inline on such a project succeeds (302) and persists the comment.
- Full `projects.tests.test_admin` (135 tests) passes; `poe check` clean.

Refs kiconiaworks/kippo