### PR TITLE
Expose estimated_monthly_amount on the contract API

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -14,7 +14,9 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from .definitions import (
+    BILLING_TYPE_MONTHLY,
     FULL_CONFIDENCE_PERCENTAGE,
+    PRICING_BASIS_EFFORT,
     PRICING_BASIS_FIXED,
     SURVEY_EFFORT_THRESHOLD_PERCENTAGE,
     WEEKLY_EFFORT_CLOSED_MESSAGE,
@@ -233,6 +235,7 @@ class KippoProjectContractSerializer(serializers.ModelSerializer):
             "billing_type",
             "pricing_basis",
             "total_amount",
+            "estimated_monthly_amount",
             "start_date",
             "end_date",
             "note",
@@ -247,14 +250,21 @@ class KippoProjectContractSerializer(serializers.ModelSerializer):
         # same invariants as the admin (a fixed-price contract without total_amount otherwise breaks
         # billing generation: total_amount // len(months)). For PATCH, fall back to the stored values.
         instance = self.instance
+        billing_type = attrs.get("billing_type", getattr(instance, "billing_type", None))
         pricing_basis = attrs.get("pricing_basis", getattr(instance, "pricing_basis", None))
         total_amount = attrs.get("total_amount", getattr(instance, "total_amount", None))
+        estimated_monthly_amount = attrs.get("estimated_monthly_amount", getattr(instance, "estimated_monthly_amount", None))
         start_date = attrs.get("start_date", getattr(instance, "start_date", None))
         end_date = attrs.get("end_date", getattr(instance, "end_date", None))
         if start_date and end_date and start_date > end_date:
             raise serializers.ValidationError({"end_date": _("Contract start_date is after end_date")})
         if pricing_basis == PRICING_BASIS_FIXED and total_amount is None:
             raise serializers.ValidationError({"total_amount": _("Total amount is required for fixed-price contracts.")})
+        # 仮月額 (kippo#46) only drives effort + monthly billing — reject it elsewhere as a likely mistake.
+        if estimated_monthly_amount is not None and not (pricing_basis == PRICING_BASIS_EFFORT and billing_type == BILLING_TYPE_MONTHLY):
+            raise serializers.ValidationError(
+                {"estimated_monthly_amount": _("Estimated monthly amount (仮月額) only applies to effort + monthly contracts.")}
+            )
         return attrs
 
 

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -1845,6 +1845,35 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         )
         self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
 
+    def test_estimated_monthly_amount_round_trips_for_effort_monthly(self):
+        """仮月額 (kippo#46) is settable/readable on the contract endpoint for effort + monthly terms."""
+        url = f"{self.base}/{self.project.id}/contract/"
+        resp = self.client.post(
+            url,
+            {"billing_type": "monthly", "pricing_basis": "effort", "estimated_monthly_amount": "500000", "end_date": "2026-09-30"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, HTTPStatus.CREATED, resp.content)
+        self.assertEqual(resp.json()["estimated_monthly_amount"], "500000")
+        self.assertEqual(self.project.contract.estimated_monthly_amount, 500000)
+
+    def test_estimated_monthly_amount_rejected_off_effort_monthly(self):
+        """Mirror KippoProjectContract.clean(): 仮月額 anywhere but effort + monthly → 400."""
+        url = f"{self.base}/{self.project.id}/contract/"
+        resp = self.client.post(
+            url,
+            {
+                "billing_type": "delivery",
+                "pricing_basis": "fixed",
+                "total_amount": "1",
+                "estimated_monthly_amount": "500000",
+                "end_date": "2026-09-30",
+            },
+            format="json",
+        )
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("estimated_monthly_amount", resp.json())
+
     def test_duplicate_billing_entry_rejected_cleanly(self):
         # effort/no-effort -> empty ledger on creation, so the first POST below is the only entry
         KippoProjectContract.objects.create(


### PR DESCRIPTION
## Summary

`KippoProjectContractSerializer` omitted **`estimated_monthly_amount`** (仮月額, kippo#46) — the one field the admin's `KippoProjectContractInline` edits that the REST API did not expose. As a result the kippo-ui project-edit contract section (which mirrors that inline) cannot set or read it.

- Add `estimated_monthly_amount` to `KippoProjectContractSerializer.Meta.fields`.
- Mirror `KippoProjectContract.clean()` in `validate()`: 仮月額 is only valid on **effort + monthly** contracts and is rejected (400) elsewhere — matching the model invariant so the API can't persist a value the billing logic would silently ignore.

## Tests

Added to `ContractAndBillingEntryAPITestCase`:
- `test_estimated_monthly_amount_round_trips_for_effort_monthly` — settable/readable on effort+monthly.
- `test_estimated_monthly_amount_rejected_off_effort_monthly` — 400 elsewhere.

`projects.tests.test_api_rest.ContractAndBillingEntryAPITestCase` — 13/13 pass; `ruff check` clean.

## Downstream

Once released, kippo-ui will pick this up via `pnpm update:api` and add the 仮月額 input to the project-edit contract section (only shown for 実績+月額 terms).

Refs kiconiaworks/kippo#46