### PR TITLE
Scope project admin category select and relocate the 契約 phase gate

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -91,6 +91,11 @@ if TYPE_CHECKING:
 
 CLOSE_PROJECT_NO_UPSELL_VALUE = "__no_upsell__"
 
+# Shown on the contract inline (not the phase field) when a project is moved into 契約(稼働中) without a
+# contract that carries both period dates. The message is attached to the inline formset so Django
+# renders that 契約 component in its error state (highlighted), instead of a message on the phase field.
+CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG = _("A contract with both a start date and an end date is required to set the phase to 契約(稼働中).")
+
 # GET/POST param carrying the admin URL to return to after a project add/change. Set by callers
 # that send the user into the project add form from elsewhere (e.g. the customer admin's
 # "プロジェクトを追加" button) so the save redirects back to where they came from.
@@ -202,6 +207,51 @@ class KippoProjectBillingEntryInline(AllowIsStaffAdminMixin, nested_admin.Nested
         return f"¥{contract.effort_actual_amount(obj.billing_date):,}"
 
 
+def _validate_under_contract_gate(formset: BaseFormSet) -> None:
+    """Raise on the contract inline when its project is being moved into 契約(稼働中) without a contract
+    that carries both period dates.
+
+    Validated against the contract submitted in the SAME request (the inline forms) — not just the
+    persisted contract — so filling the inline and flipping the phase in one save is allowed. The error
+    is attached to the formset (non-form error) so Django highlights this 契約 component; the matching
+    model-level gate is deferred on the admin change form (see ``KippoProject.clean``).
+    """
+    if any(formset.errors):  # per-row field errors already flag the inline; don't stack another error
+        return
+    project = formset.instance
+    if project is None or not project._is_entering_under_contract():
+        return
+
+    def _effective_period_complete(form: Form) -> bool:
+        """Whether the contract this form persists ends up with BOTH period dates after save.
+
+        A form flagged for deletion removes the contract (no period). For a NEW contract a blank date is
+        backfilled from the project (KippoProjectContract.save, creation only), so a blank period counts
+        as complete when the project supplies both dates; on an edit a blank date is honored as-is.
+        """
+        cleaned = getattr(form, "cleaned_data", None)
+        if not cleaned or formset._should_delete_form(form):
+            return False
+        start = cleaned.get("start_date")
+        end = cleaned.get("end_date")
+        if form.instance._state.adding:  # new contract -> a blank period backfills from the project on save
+            start = start or project.start_date
+            end = end or project.target_date
+        return bool(start and end)
+
+    # The inline is a OneToOne (max_num=1); its submitted rows ARE the post-save contract state — so a
+    # same-request delete or period-clear is judged on the effective result, not the stale DB row. Only
+    # when no contract row is submitted at all do we fall back to the persisted contract.
+    contract_forms = [form for form in formset.forms if getattr(form, "cleaned_data", None)]
+    if contract_forms:
+        gate_satisfied = any(_effective_period_complete(form) for form in contract_forms)
+    else:
+        existing = project.get_contract()
+        gate_satisfied = bool(existing and existing.has_complete_period())
+    if not gate_satisfied:
+        raise ValidationError(CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG)
+
+
 class KippoProjectContractInline(LockWhenProjectClosedInlineMixin, AllowIsStaffAdminMixin, nested_admin.NestedStackedInline):
     model = KippoProjectContract
     extra = 1
@@ -214,18 +264,24 @@ class KippoProjectContractInline(LockWhenProjectClosedInlineMixin, AllowIsStaffA
         """Pre-fill the new contract row's period with the project's dates so the admin user
         sees the defaults before saving (the model still backfills them on save if cleared).
         An untouched pre-filled row is skipped by the formset, so it never creates a contract.
+
+        Also enforces the 契約(稼働中) phase gate here (see ``clean``) so the requirement is surfaced on
+        this contract component rather than on the parent's phase field.
         """
         formset = super().get_formset(request, obj, **kwargs)
-        if obj is None or not (obj.start_date or obj.target_date):
-            return formset
-        period_initial = [{"start_date": obj.start_date, "end_date": obj.target_date}]
+        period_initial = [{"start_date": obj.start_date, "end_date": obj.target_date}] if obj and (obj.start_date or obj.target_date) else None
 
-        class PeriodPrefilledFormSet(formset):
+        class KippoProjectContractInlineFormSet(formset):
             def __init__(self, *args, **inner_kwargs) -> None:
-                inner_kwargs.setdefault("initial", period_initial)
+                if period_initial is not None:
+                    inner_kwargs.setdefault("initial", period_initial)
                 super().__init__(*args, **inner_kwargs)
 
-        return PeriodPrefilledFormSet
+            def clean(self) -> None:
+                super().clean()
+                _validate_under_contract_gate(self)
+
+        return KippoProjectContractInlineFormSet
 
 
 class KippoMilestoneReadOnlyInline(AllowIsStaffAdminMixin, admin.TabularInline):
@@ -824,6 +880,12 @@ class KippoProjectAdminForm(forms.ModelForm):
             for field in self.REQUIRED_AT_REGISTRATION:
                 if field in self.fields:
                     self.fields[field].required = True
+        else:
+            # On the change form the 契約(稼働中) gate is enforced on the contract inline (validated against
+            # the contract submitted in the same request), so defer the model-level phase gate to avoid a
+            # duplicate message on the phase field and to allow supplying the contract in the same save.
+            # The contract inline is hidden on /add/, so the model gate still applies there.
+            self.instance._admin_defers_contract_gate = True
 
     def clean(self):
         cleaned_data = super().clean()
@@ -932,6 +994,10 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
     """
 
     form = KippoProjectAdminForm
+    # Changelist override adds inline CSS widening the 顧客(customer) and フェーズ(phase) columns so each
+    # renders on a single line. Set explicitly (not auto-discovered) so the ActiveKippoProject proxy admin
+    # uses the same template too. (App static/ dirs are gitignored here, so an external CSS file can't ship.)
+    change_list_template = "admin/projects/kippoproject/change_list.html"
     # Inlines hidden on /add/ (only meaningful once a project exists). Exposed as a class
     # attribute so tests and subclasses can reference the same source of truth.
     HIDDEN_ON_ADD_INLINES = (
@@ -1348,10 +1414,12 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
 
     @admin.display(description=_("GITHUBプロジェクト"))
     def show_github_project_html_url(self, obj: KippoProject) -> str:
-        url = ""
-        if obj.github_project_html_url:
-            url = format_html('<a href="{url}">{url}</a>', url=obj.github_project_html_url)
-        return url
+        if not obj.github_project_html_url:
+            return ""
+        # Display only the last path component (text after the final "/"), e.g. the project number,
+        # while still linking to the full URL.
+        label = obj.github_project_html_url.rstrip("/").rsplit("/", 1)[-1]
+        return format_html('<a href="{url}">{label}</a>', url=obj.github_project_html_url, label=label)
 
     def save_formset(self, request: DjangoRequest, form: Form, formset: BaseFormSet, change: bool) -> None:
         instances = formset.save(commit=False)
@@ -1412,6 +1480,19 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         # customer: scope queryset to the project's organization (on change) or the user's orgs (on add).
         self._scope_customer_queryset(form, obj, user_memberships)
 
+        # category: scope to the project's organization (on change) or the user's orgs (on add) so the
+        # select never lists other organizations' categories.
+        self._scope_category_queryset(form, obj, user_memberships)
+
+        # On /add/ the model default is a GLOBAL template row, which the org-scoped queryset above drops;
+        # pre-select the initial organization's OWN default category so the required field renders selected
+        # and validates without the user opening the dropdown. A ?category= GET prefill (upsell wizard)
+        # still wins via the form's initial data.
+        if obj is None and user_initial_organization and "category" in form.base_fields:
+            default_category = KippoProjectOrganizationCategory.get_default_for_organization(user_initial_organization.id)
+            if default_category:
+                form.base_fields["category"].initial = default_category.pk
+
         # Arriving from the customer admin's "プロジェクトを追加" button (?customer=<pk>): the customer is
         # already chosen, so hide the field. The value is still prefilled (get_changeform_initial_data)
         # and POSTed; the scoped queryset validates it server-side.
@@ -1431,6 +1512,23 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
             form.base_fields["customer"].queryset = KippoCustomer.objects.filter(organization=obj.organization)
         else:
             form.base_fields["customer"].queryset = KippoCustomer.objects.filter(organization__in=user_memberships)
+
+    @staticmethod
+    def _scope_category_queryset(form: Form, obj: KippoProject | None, user_memberships: models.QuerySet) -> None:
+        """Scope the category select to the project's organization (or the user's orgs on /add/).
+
+        Narrows the queryset already built by formfield_for_foreignkey (which drops upsell categories
+        on the plain add form) so that exclusion is preserved. On the change form the currently-selected
+        category is always kept selectable — even a legacy global (organization=null) row — so an edit
+        can never silently drop it.
+        """
+        if "category" not in form.base_fields:
+            return
+        queryset = form.base_fields["category"].queryset
+        if obj is not None and obj.organization_id:
+            form.base_fields["category"].queryset = queryset.filter(models.Q(organization=obj.organization) | models.Q(pk=obj.category_id))
+        else:
+            form.base_fields["category"].queryset = queryset.filter(organization__in=user_memberships)
 
     @staticmethod
     def _apply_upsell_source_widgets(form: Form, user_memberships: models.QuerySet) -> None:

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -482,7 +482,11 @@ class KippoProject(UserCreatedBaseModel):
         # and only then can the phase move to under-contract — at which point the contract period
         # drives the project dates. Gated on the TRANSITION into the phase only, so rows already
         # persisted in 契約(稼働中) (legacy projects predating contracts) stay editable/saveable.
-        if self._is_entering_under_contract():
+        # The admin change form defers this gate to the contract inline (``_admin_defers_contract_gate``):
+        # it is surfaced on the 契約 component and validated against the contract submitted in the SAME
+        # request, so filling the inline and flipping the phase in one save works. Every other caller
+        # (API model validation, direct full_clean, shell) still enforces it here.
+        if self._is_entering_under_contract() and not getattr(self, "_admin_defers_contract_gate", False):
             contract = self.get_contract()
             if not (contract and contract.has_complete_period()):
                 raise ValidationError({"phase": UNDER_CONTRACT_REQUIRES_CONTRACT_MSG})

--- a/kippo/projects/templates/admin/projects/kippoproject/change_list.html
+++ b/kippo/projects/templates/admin/projects/kippoproject/change_list.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_list.html" %}
+{% block extrahead %}{{ block.super }}
+{# Keep the 顧客(customer) and フェーズ(phase) columns on a single line so their values are not wrapped
+   across rows. Inline here rather than a static file because this app's static/ dirs are gitignored. #}
+<style>
+  #result_list th.column-get_customer_name,
+  #result_list td.field-get_customer_name,
+  #result_list th.column-phase,
+  #result_list td.field-phase {
+    white-space: nowrap;
+  }
+</style>
+{% endblock %}

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -18,6 +18,7 @@ from django import forms
 from django.contrib import admin
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME, AdminForm
 from django.db import connection
+from django.forms.models import BaseInlineFormSet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.test import RequestFactory, SimpleTestCase
 from django.test.utils import CaptureQueriesContext
@@ -25,6 +26,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from projects.admin import (
+    CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG,
     ActiveKippoProjectAdmin,
     KippoMilestoneAdmin,
     KippoProjectAdmin,
@@ -36,9 +38,11 @@ from projects.admin import (
     _next_upsell_project_name,
     _start_of_next_month,
 )
+from projects.definitions import DEFAULT_BILLING_TYPE, DEFAULT_PRICING_BASIS
 from projects.filters import PhaseMultiSelectListFilter
 from projects.models import (
     DEFAULT_ACTIVE_PROJECT_PHASES,
+    PHASE_UNDER_CONTRACT,
     VALID_PROJECT_PHASES,
     ActiveKippoProject,
     KippoMilestone,
@@ -239,6 +243,121 @@ class IsStaffOrganizationKippoProjectAdminTestCase(IsStaffModelAdminTestCaseBase
         formset.save()
         self.assertIsNone(getattr(self.project1, "contract", None))
 
+    def _contract_gate_formset(self, project: KippoProject, form_data: dict | None) -> BaseInlineFormSet:
+        """Build the contract inline formset (no period prefill) bound to ``project`` as its parent."""
+        inline = KippoProjectContractInline(parent_model=KippoProject, admin_site=self.site)
+        formset_class = inline.get_formset(request=self.super_user_request, obj=None)  # obj=None -> no period prefill
+        prefix = "contract"
+        data = {
+            f"{prefix}-TOTAL_FORMS": "1",
+            f"{prefix}-INITIAL_FORMS": "0",
+            f"{prefix}-MIN_NUM_FORMS": "0",
+            f"{prefix}-MAX_NUM_FORMS": "1",
+        }
+        # a browser always posts the billing_type / pricing_basis selects at their rendered defaults even
+        # when the operator enters nothing else; mirror that so an otherwise-empty row is treated as
+        # unchanged (creates no contract) rather than raising required-field errors.
+        row = {"billing_type": DEFAULT_BILLING_TYPE, "pricing_basis": DEFAULT_PRICING_BASIS}
+        if form_data:
+            row.update(form_data)
+        data.update({f"{prefix}-0-{field}": value for field, value in row.items()})
+        return formset_class(data=data, instance=project, prefix=prefix)
+
+    def _entering_under_contract_project(self) -> KippoProject:
+        project = KippoProject.objects.get(pk=self.project1.pk)  # snapshot persisted phase (proposing-low)
+        project.phase = PHASE_UNDER_CONTRACT  # transition -> entering
+        self.assertTrue(project._is_entering_under_contract())
+        return project
+
+    def test_under_contract_gate_flags_inline_not_phase_when_contract_missing(self):
+        # entering 契約(稼働中) with an empty contract inline: the requirement is surfaced on the contract
+        # component (formset non-form error, so Django highlights it), NOT on the phase field, and blocks the save.
+        project = self._entering_under_contract_project()
+        formset = self._contract_gate_formset(project, form_data=None)
+        self.assertFalse(formset.is_valid())
+        self.assertTrue(formset.non_form_errors())
+        self.assertIn(str(CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG), formset.non_form_errors())
+
+    def test_under_contract_gate_passes_when_contract_period_submitted_same_request(self):
+        # supplying a complete contract period in the SAME request satisfies the gate (the fix: previously
+        # the model-level check queried the DB and rejected the contract-and-phase-in-one-save flow).
+        project = self._entering_under_contract_project()
+        formset = self._contract_gate_formset(
+            project,
+            form_data={
+                "billing_type": DEFAULT_BILLING_TYPE,
+                "pricing_basis": DEFAULT_PRICING_BASIS,
+                "total_amount": "500000",
+                "start_date": "2026-01-01",
+                "end_date": "2026-06-30",
+            },
+        )
+        self.assertTrue(formset.is_valid(), formset.non_form_errors() or formset.errors)
+
+    def test_under_contract_gate_ignores_non_entering_edit(self):
+        # a normal edit that does not transition into 契約(稼働中) is not gated, even with an empty inline
+        project = KippoProject.objects.get(pk=self.project1.pk)  # phase stays proposing-low
+        self.assertFalse(project._is_entering_under_contract())
+        formset = self._contract_gate_formset(project, form_data=None)
+        self.assertTrue(formset.is_valid(), formset.non_form_errors())
+
+    def test_under_contract_gate_passes_when_new_contract_period_backfills(self):
+        # a NEW contract row left blank still satisfies the gate: KippoProjectContract.save() backfills the
+        # period from the project's start_date / target_date on creation, so the saved contract is complete.
+        project = KippoProject.objects.get(pk=self.project1.pk)
+        project.start_date = date(2026, 1, 1)
+        project.target_date = date(2026, 6, 30)
+        project.save()
+        entering = KippoProject.objects.get(pk=project.pk)
+        entering.phase = PHASE_UNDER_CONTRACT
+        formset = self._contract_gate_formset(entering, form_data={"total_amount": "500000", "start_date": "", "end_date": ""})
+        self.assertTrue(formset.is_valid(), formset.non_form_errors() or formset.errors)
+
+    def test_under_contract_gate_blocks_when_contract_deleted_same_request(self):
+        # entering 契約(稼働中) while DELETING the only contract in the same save must be blocked — the gate
+        # judges the post-save state, not the still-persisted DB row.
+        project = KippoProject.objects.get(pk=self.project1.pk)
+        project.start_date = date(2026, 1, 1)
+        project.target_date = date(2026, 6, 30)
+        project.save()
+        contract = KippoProjectContract.objects.create(project=project, total_amount=100000)  # period backfills
+        self.assertTrue(contract.has_complete_period())
+        entering = KippoProject.objects.get(pk=project.pk)
+        entering.phase = PHASE_UNDER_CONTRACT
+        inline = KippoProjectContractInline(parent_model=KippoProject, admin_site=self.site)
+        formset_class = inline.get_formset(request=self.super_user_request, obj=entering)
+        prefix = "contract"
+        data = {
+            f"{prefix}-TOTAL_FORMS": "1",
+            f"{prefix}-INITIAL_FORMS": "1",
+            f"{prefix}-MIN_NUM_FORMS": "0",
+            f"{prefix}-MAX_NUM_FORMS": "1",
+            f"{prefix}-0-id": str(contract.pk),
+            f"{prefix}-0-billing_type": contract.billing_type,
+            f"{prefix}-0-pricing_basis": contract.pricing_basis,
+            f"{prefix}-0-total_amount": str(contract.total_amount),
+            f"{prefix}-0-start_date": contract.start_date.isoformat(),
+            f"{prefix}-0-end_date": contract.end_date.isoformat(),
+            f"{prefix}-0-DELETE": "on",
+        }
+        formset = formset_class(data=data, instance=entering, prefix=prefix)
+        self.assertFalse(formset.is_valid())
+        self.assertIn(str(CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG), formset.non_form_errors())
+
+    def test_show_github_project_html_url_displays_last_path_component(self):
+        # the changelist GITHUBプロジェクト cell links to the full URL but shows only the trailing component
+        admin_instance = KippoProjectAdmin(KippoProject, self.site)
+        self.project1.github_project_html_url = "https://github.com/orgs/acme/projects/42"
+        html = admin_instance.show_github_project_html_url(self.project1)
+        self.assertIn('href="https://github.com/orgs/acme/projects/42"', html)
+        self.assertIn(">42<", html)
+        self.assertNotIn(">https://github.com", html)
+
+    def test_show_github_project_html_url_blank_when_unset(self):
+        admin_instance = KippoProjectAdmin(KippoProject, self.site)
+        self.project1.github_project_html_url = ""
+        self.assertEqual(admin_instance.show_github_project_html_url(self.project1), "")
+
 
 class IsStaffOrganizationKippoMilestoneAdminTestCase(IsStaffModelAdminTestCaseBase):
     fixtures = DEFAULT_FIXTURES
@@ -411,6 +530,15 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         )
         self.changelist_url = reverse("admin:projects_kippoproject_changelist")
         self.client.force_login(self.superuser_no_org)
+
+    def test_changelist_includes_single_line_column_style(self):
+        # the changelist template widens the 顧客(customer) + フェーズ(phase) columns to a single line
+        response = self.client.get(self.changelist_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.content.decode()
+        self.assertIn("td.field-get_customer_name", content)
+        self.assertIn("td.field-phase", content)
+        self.assertIn("white-space: nowrap", content)
 
     def test_multiple_projects_selected_rejected(self):
         response = self.client.post(
@@ -683,6 +811,42 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         keys = set(response.context["adminform"].form.fields["category"].queryset.values_list("key", flat=True))
         self.assertFalse(keys.isdisjoint(UPSELL_CATEGORY_VALUES), "wizard add must keep upsell categories available")
+
+    def test_add_form_category_scoped_to_user_organizations(self):
+        # the category select must list only the user's organizations' categories, never another org's
+        other_org_category = KippoProjectOrganizationCategory.objects.filter(organization=self.other_organization).first()
+        self.assertIsNotNone(other_org_category, "fixture should have seeded the other org's categories")
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        queryset = response.context["adminform"].form.fields["category"].queryset
+        org_ids = set(queryset.values_list("organization_id", flat=True))
+        self.assertEqual(org_ids, {self.organization.id}, f"category select leaked non-member org categories: {org_ids}")
+        self.assertNotIn(other_org_category.pk, set(queryset.values_list("pk", flat=True)))
+
+    def test_add_form_preselects_org_default_category(self):
+        # the model default is a GLOBAL row the org-scoped queryset drops; the add form must still
+        # pre-select the org's OWN default category (and keep it selectable) so a plain registration
+        # validates without opening the カテゴリ dropdown.
+        default_category = KippoProjectOrganizationCategory.get_default_for_organization(self.organization.id)
+        self.assertIsNotNone(default_category)
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        field = response.context["adminform"].form.fields["category"]
+        self.assertEqual(str(field.initial), str(default_category.pk))
+        self.assertIn(default_category.pk, set(field.queryset.values_list("pk", flat=True)))
+
+    def test_change_form_category_scoped_to_project_organization(self):
+        # editing a project must only offer that project's organization's categories
+        other_org_category = KippoProjectOrganizationCategory.objects.filter(organization=self.other_organization).first()
+        url = reverse("admin:projects_kippoproject_change", args=[self.project1.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        queryset = response.context["adminform"].form.fields["category"].queryset
+        org_ids = set(queryset.values_list("organization_id", flat=True))
+        self.assertEqual(org_ids, {self.organization.id}, f"category select leaked non-project org categories: {org_ids}")
+        self.assertNotIn(other_org_category.pk, set(queryset.values_list("pk", flat=True)))
 
     def test_upsell_redirect_hides_parent_project_and_organization(self):
         # close-action upsell redirect: parent_project and organization must render as hidden inputs

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -904,6 +904,13 @@ class KippoProjectUnderContractPhaseGateTestCase(TestCase):
             project.clean()
         self.assertIn("phase", context.exception.message_dict)
 
+    def test_clean_defers_gate_when_admin_flag_set(self):
+        # the admin change form relocates this gate to the contract inline (validated against the contract
+        # submitted in the same request); when it sets the defer flag, model.clean() must not raise here.
+        self.project.phase = PHASE_UNDER_CONTRACT
+        self.project._admin_defers_contract_gate = True
+        self.project.clean()  # does not raise despite having no contract
+
     def test_clean_allows_legacy_under_contract_row_without_contract(self):
         # a row already persisted in 契約(稼働中) with no contract (legacy data predating contracts) is
         # NOT re-gated: the gate fires only on the TRANSITION into the phase, so the row stays editable


### PR DESCRIPTION
## Summary

Four related fixes to the `KippoProject` admin (all in `KippoProjectBaseAdmin`, shared by the all-projects and active-projects admins).

### 1. Category select is organization-scoped
The category `<select>` previously listed **every** organization's categories. It's now scoped to the project's organization on the change form (the currently-selected value is always kept selectable, even a legacy global row) and to the acting user's organizations on the add form. Because the model default is a global (`organization=null`) template row that the scoping drops, the add form now pre-selects the organization's **own** default category so a plain registration still validates without opening the dropdown.

### 2. 契約(稼働中) phase gate surfaced on the contract inline
Entering the 契約(稼働中) phase without a contract used to raise a wordy error on the **phase** field, and — because the model gate queried the DB — it also blocked the natural "add the contract and flip the phase in one save" flow. On the change form the requirement is now surfaced on the **contract inline** (rendered in Django's error state), validated against the contract submitted in the **same request**:

- a same-request **delete** or **period-clear** is judged on the post-save state (no longer masked by the stale DB row),
- a **new** contract left blank counts as complete via `KippoProjectContract.save()`'s create-time period backfill.

The model-level gate (`KippoProject.clean`) is unchanged for every non-admin caller (API model validation, `full_clean`, shell); the admin change form simply defers to the inline.

### 3. Changelist: customer + phase on a single line
A `change_list` template override adds inline CSS keeping the 顧客(customer) and フェーズ(phase) columns on one line. (Implemented as a template, not a static file, because this app's `static/` dirs are gitignored.)

### 4. GitHub project link shows only the trailing path component
The changelist GITHUBプロジェクト cell now displays only the text after the final `/` (e.g. the project number) while still linking to the full URL.

## Tests
- Model: gate defers when the admin flag is set (existing gate tests unchanged).
- Admin: contract-inline gate (flags inline not phase / passes with same-request period / create-time backfill / blocks same-request delete / ignores non-entering edit); category scoping on add and change; add-form default pre-selection; changelist single-line style; GitHub link rendering.
- `projects.tests.test_admin`, `test_models`, and `test_api_rest` pass (`--debug-mode`).

Refs kiconiaworks/kippo