### PR TITLE
Changelist name column single-line + clearer 契約(稼働中) gate message

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -92,9 +92,13 @@ if TYPE_CHECKING:
 CLOSE_PROJECT_NO_UPSELL_VALUE = "__no_upsell__"
 
 # Shown on the contract inline (not the phase field) when a project is moved into 契約(稼働中) without a
-# contract that carries both period dates. The message is attached to the inline formset so Django
-# renders that 契約 component in its error state (highlighted), instead of a message on the phase field.
-CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG = _("A contract with both a start date and an end date is required to set the phase to 契約(稼働中).")
+# SAVED contract. The 契約 period is pre-filled from the project dates, so the misleading part is that the
+# dates look present — the real gap is that the row was not saved as a contract (a 契約金額 is needed to
+# create one). Attached to the inline formset so Django renders that 契約 component in its error state.
+CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG = _(
+    "A saved 契約 is required to set the phase to 契約(稼働中): enter the 契約金額 (and confirm the "
+    "start/end dates) so the contract is created — the pre-filled dates alone do not save a contract."
+)
 
 # GET/POST param carrying the admin URL to return to after a project add/change. Set by callers
 # that send the user into the project add form from elsewhere (e.g. the customer admin's

--- a/kippo/projects/templates/admin/projects/kippoproject/change_list.html
+++ b/kippo/projects/templates/admin/projects/kippoproject/change_list.html
@@ -1,8 +1,11 @@
 {% extends "admin/change_list.html" %}
 {% block extrahead %}{{ block.super }}
-{# Keep the 顧客(customer) and フェーズ(phase) columns on a single line so their values are not wrapped
-   across rows. Inline here rather than a static file because this app's static/ dirs are gitignored. #}
+{# Keep the プロジェクト名(name), 顧客(customer) and フェーズ(phase) columns on a single line so their
+   values are not wrapped across rows. Inline here rather than a static file because this app's static/
+   dirs are gitignored. #}
 <style>
+  #result_list th.column-name,
+  #result_list td.field-name,
   #result_list th.column-get_customer_name,
   #result_list td.field-get_customer_name,
   #result_list th.column-phase,

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -532,10 +532,11 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.client.force_login(self.superuser_no_org)
 
     def test_changelist_includes_single_line_column_style(self):
-        # the changelist template widens the 顧客(customer) + フェーズ(phase) columns to a single line
+        # the changelist template widens the プロジェクト名(name) + 顧客(customer) + フェーズ(phase) columns to a single line
         response = self.client.get(self.changelist_url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.content.decode()
+        self.assertIn("td.field-name", content)
         self.assertIn("td.field-get_customer_name", content)
         self.assertIn("td.field-phase", content)
         self.assertIn("white-space: nowrap", content)

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1,5 +1,6 @@
 import datetime
 from datetime import date
+from html.parser import HTMLParser
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 from unittest import TestCase
@@ -2472,3 +2473,127 @@ class ActiveProjectPhaseFilterTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(str(choices[0]["display"]), "全て")
         self.assertTrue(choices[0]["selected"])
         self.assertFalse(any(choice["selected"] for choice in choices[1:]))
+
+
+class _AdminFormFieldParser(HTMLParser):
+    """Extract name->value for every submittable input/select/textarea in a rendered admin form,
+    reproducing what a browser would POST (so an untouched change form round-trips faithfully).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.data: dict[str, str] = {}
+        self._select_name: str | None = None
+        self._select_value: str | None = None
+        self._select_first: str | None = None
+        self._textarea_name: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        a = dict(attrs)
+        if tag == "input":
+            name = a.get("name")
+            itype = (a.get("type") or "text").lower()
+            if not name or itype in ("submit", "button", "image", "file"):
+                return
+            if itype in ("checkbox", "radio"):
+                if "checked" in a:
+                    self.data[name] = a.get("value", "on")
+            else:
+                self.data[name] = a.get("value", "")
+        elif tag == "select":
+            self._select_name = a.get("name")
+            self._select_value = None
+            self._select_first = None
+        elif tag == "option" and self._select_name:
+            value = a.get("value", "")
+            if self._select_first is None:
+                self._select_first = value
+            if "selected" in a:
+                self._select_value = value
+        elif tag == "textarea":
+            self._textarea_name = a.get("name")
+            if self._textarea_name:
+                self.data[self._textarea_name] = ""
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "select" and self._select_name:
+            chosen = self._select_value if self._select_value is not None else (self._select_first or "")
+            self.data[self._select_name] = chosen
+            self._select_name = None
+        elif tag == "textarea":
+            self._textarea_name = None
+
+    def handle_data(self, data: str) -> None:
+        if self._textarea_name:
+            self.data[self._textarea_name] = self.data.get(self._textarea_name, "") + data
+
+
+class KippoProjectAdminUnderContractChangeViewTestCase(IsStaffModelAdminTestCaseBase):
+    """Full change-view POST: flipping the phase to 契約(稼働中) with the default (pre-filled) contract
+    must save (the contract is created from its defaults) rather than raising the phase gate.
+    """
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        super().setUp()
+        columnset = ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK)
+        OrganizationMembership.objects.get_or_create(
+            user=self.superuser_no_org,
+            organization=self.organization,
+            defaults={"created_by": self.github_manager, "updated_by": self.github_manager},
+        )
+        self.project = KippoProject.objects.create(
+            organization=self.organization,
+            name="under-contract-target",
+            category=_global_category("other"),
+            columnset=columnset,
+            start_date=datetime.date(2026, 1, 1),
+            target_date=datetime.date(2026, 6, 30),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.client.force_login(self.superuser_no_org)
+        self.change_url = reverse("admin:projects_kippoproject_change", args=[self.project.id])
+
+    def _rendered_post_data(self) -> dict:
+        response = self.client.get(self.change_url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        parser = _AdminFormFieldParser()
+        parser.feed(response.content.decode())
+        return parser.data
+
+    def test_change_phase_to_under_contract_with_default_contract_saves(self):
+        data = self._rendered_post_data()
+        # sanity: the contract inline is pre-filled with the project's dates
+        self.assertEqual(data.get("contract-0-start_date"), "2026-01-01")
+        self.assertEqual(data.get("contract-0-end_date"), "2026-06-30")
+        data["phase"] = PHASE_UNDER_CONTRACT
+        data["contract-0-total_amount"] = "1000000"  # fixed pricing requires an amount; keep the default dates
+        response = self.client.post(self.change_url, data)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND, self._formset_errors(response))
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.phase, PHASE_UNDER_CONTRACT)
+        self.assertIsNotNone(self.project.get_contract())
+
+    def test_change_phase_to_under_contract_with_empty_contract_shows_actionable_message(self):
+        # the pre-filled dates alone do not save a contract (no 契約金額 -> the row is skipped): the phase
+        # change is blocked with an ACCURATE message on the contract inline, not the misleading dates one.
+        data = self._rendered_post_data()
+        data["phase"] = PHASE_UNDER_CONTRACT  # leave the contract row at its pre-filled defaults (no amount)
+        response = self.client.post(self.change_url, data)
+        self.assertEqual(response.status_code, HTTPStatus.OK)  # re-rendered, not saved
+        self.assertIn(str(CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG), self._formset_errors(response))
+        self.project.refresh_from_db()
+        self.assertNotEqual(self.project.phase, PHASE_UNDER_CONTRACT)
+        self.assertIsNone(self.project.get_contract())
+
+    @staticmethod
+    def _formset_errors(response: HttpResponse) -> str:
+        """Collect inline formset errors from a re-rendered (non-redirect) change response, for assert messages."""
+        parts = []
+        for inline in response.context.get("inline_admin_formsets", []) if response.context else []:
+            nonform = inline.formset.non_form_errors()
+            if nonform:
+                parts.append(f"{inline.formset.prefix}: {nonform.as_text()}")
+        return " | ".join(parts)


### PR DESCRIPTION
Two small `KippoProject` admin fixes.

## 1. Keep the project name changelist column on a single line
Extends the changelist no-wrap style (added in #367 for 顧客(customer) and フェーズ(phase)) to the プロジェクト名(name) column, in the shared `admin/projects/kippoproject/change_list.html` override so both the all-projects and active-projects admins pick it up.

## 2. Clearer 契約(稼働中) phase-gate message for an unsaved default contract
The 契約 inline pre-fills its period from the project dates, so an untouched row *shows* complete dates but is skipped by the formset — no contract is saved. The gate then blocked the phase change with a misleading "both a start date and an end date is required" (the dates are present; the real gap is that no contract was saved — a 契約金額 is required to create one). The message now says so. The gate and `has_complete_period()` are unchanged, and no contract is auto-created.

### Tests
- `test_changelist_includes_single_line_column_style` updated to assert the `field-name` column.
- New `KippoProjectAdminUnderContractChangeViewTestCase` (full admin change-view POST): default dates + 契約金額 saves; an untouched default row is blocked with the accurate message and creates no contract.

Refs kiconiaworks/kippo