### PR TITLE
Scope project-category admin to the user's organizations

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -15,6 +15,7 @@ from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
 from commons.admin import AllowIsStaffAdminMixin, PrettyJSONWidget, UserCreatedBaseModelAdmin
 from commons.definitions import SATURDAY
 from commons.functions import get_current_month_date_range
+from commons.viewsets import organization_ids_for_user
 from commons.widgets import MonthYearWidget
 from customers.models import KippoCustomer
 from django import forms
@@ -950,12 +951,13 @@ def _format_estimated_completion(result: "ForecastResult") -> str:
 
 @admin.register(KippoProjectOrganizationCategory)
 class KippoProjectOrganizationCategoryAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
-    """Staff manage org-scoped categories; the global (organization=null) template is superuser-only.
+    """Staff manage their own organizations' categories; the global (organization=null) template is superuser-only.
 
-    Mirrors the API rule (``IsSuperuserOrOrgMemberForCategory``, kippo#48): a non-superuser staff
-    user may add/edit/delete org-scoped rows, but only a superuser may create or modify a global
-    template row. Non-superusers do not see globals in the changelist at all, so they cannot change,
-    delete, or bulk-delete them (kippo#49).
+    Mirrors the API rule (``IsSuperuserOrOrgMemberForCategory``, kippo#48): a non-superuser staff user
+    may add/edit/delete rows only for organizations they are a member of (``organization_ids_for_user``);
+    only a superuser may create or modify a global template row or another organization's rows.
+    Non-superusers see only their own organizations' categories in the changelist — never the global
+    template, never another organization's rows — so they cannot change, delete, or bulk-delete them (kippo#49).
     """
 
     list_display = ("key", "label", "organization", "sort_order", "is_active", "is_default")
@@ -966,24 +968,40 @@ class KippoProjectOrganizationCategoryAdmin(AllowIsStaffAdminMixin, UserCreatedB
     def get_queryset(self, request: DjangoRequest):
         queryset = super().get_queryset(request)
         if not request.user.is_superuser:
-            # hide global template rows from non-superusers -> they cannot change/delete/bulk-delete them
-            queryset = queryset.filter(organization__isnull=False)
+            # scope to the user's organizations -> also excludes global (organization=null) template rows,
+            # so non-superusers cannot see/change/delete/bulk-delete them or other orgs' rows
+            queryset = queryset.filter(organization__in=organization_ids_for_user(request.user))
         return queryset
 
+    def _manageable_by(self, request: DjangoRequest, obj: models.Model | None) -> bool:
+        """Non-superusers may only manage rows for organizations they belong to (globals excluded)."""
+        if request.user.is_superuser or obj is None:
+            return True
+        return obj.organization_id in organization_ids_for_user(request.user)
+
     def has_change_permission(self, request: DjangoRequest, obj: models.Model | None = None):
-        if obj is not None and obj.organization_id is None and not request.user.is_superuser:
+        if not self._manageable_by(request, obj):
             return False
         return super().has_change_permission(request, obj)
 
     def has_delete_permission(self, request: DjangoRequest, obj: models.Model | None = None):
-        if obj is not None and obj.organization_id is None and not request.user.is_superuser:
+        if not self._manageable_by(request, obj):
             return False
         return super().has_delete_permission(request, obj)
 
+    def formfield_for_foreignkey(self, db_field: models.ForeignKey, request: DjangoRequest, **kwargs):
+        # limit the organization picker to the user's organizations (superusers keep the full list)
+        if db_field.name == "organization" and not request.user.is_superuser:
+            kwargs["queryset"] = KippoOrganization.objects.filter(pk__in=organization_ids_for_user(request.user))
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
     def save_model(self, request: DjangoRequest, obj: KippoProjectOrganizationCategory, form: forms.ModelForm, change: bool) -> None:
-        # has_add_permission cannot see the object; block creating/turning a row into a global template here.
-        if obj.organization_id is None and not request.user.is_superuser:
-            raise PermissionDenied(_("Only a superuser may create or edit a global (template) category."))
+        # has_add_permission cannot see the object; block creating/moving a row into a global template or an
+        # organization the user does not belong to here.
+        if not self._manageable_by(request, obj):
+            raise PermissionDenied(
+                _("You may only create or edit categories for your own organizations; global (template) categories are superuser-only.")
+            )
         super().save_model(request, obj, form, change)
 
 

--- a/kippo/projects/tests/test_admin_projectcategory.py
+++ b/kippo/projects/tests/test_admin_projectcategory.py
@@ -4,7 +4,7 @@ Staff manage org-scoped categories; the global (organization=null) template is s
 mirroring the API rule (IsSuperuserOrOrgMemberForCategory).
 """
 
-from accounts.models import KippoUser
+from accounts.models import KippoOrganization, KippoUser
 from commons.tests import DEFAULT_FIXTURES, setup_basic_project
 from django.contrib import admin
 from django.core.exceptions import PermissionDenied
@@ -21,13 +21,19 @@ class KippoProjectOrganizationCategoryAdminTestCase(TestCase):
     def setUp(self):
         created = setup_basic_project()
         self.organization = created["KippoOrganization"]
-        self.staff_user = created["KippoUser"]  # is_staff=True, is_superuser=False
+        self.staff_user = created["KippoUser"]  # is_staff=True, is_superuser=False, member of self.organization
         self.assertTrue(self.staff_user.is_staff)
         self.assertFalse(self.staff_user.is_superuser)
         self.superuser = KippoUser.objects.create(username="cat-admin-su", email="su@example.com", is_staff=True, is_superuser=True)
 
+        # a second organization the staff_user is NOT a member of, with its own seeded categories
+        self.other_organization = KippoOrganization.objects.create(
+            name="other-org", github_organization_name="other-org", day_workhours=8, created_by=self.superuser, updated_by=self.superuser
+        )
+
         self.global_category = KippoProjectOrganizationCategory.objects.get(organization__isnull=True, key="other")
         self.org_category = KippoProjectOrganizationCategory.objects.get(organization=self.organization, key="other")
+        self.other_org_category = KippoProjectOrganizationCategory.objects.get(organization=self.other_organization, key="other")
 
         self.admin = KippoProjectOrganizationCategoryAdmin(KippoProjectOrganizationCategory, admin.site)
         self.factory = RequestFactory()
@@ -37,10 +43,13 @@ class KippoProjectOrganizationCategoryAdminTestCase(TestCase):
         request.user = user
         return request
 
-    def test_non_superuser_queryset_excludes_globals(self):
+    def test_non_superuser_queryset_excludes_globals_and_other_orgs(self):
         rows = self.admin.get_queryset(self._request(self.staff_user))
         self.assertTrue(rows.exists())
         self.assertFalse(rows.filter(organization__isnull=True).exists())
+        # only the user's own organization's rows are visible
+        self.assertFalse(rows.exclude(organization=self.organization).exists())
+        self.assertFalse(rows.filter(organization=self.other_organization).exists())
 
     def test_superuser_queryset_includes_globals(self):
         rows = self.admin.get_queryset(self._request(self.superuser))
@@ -55,6 +64,17 @@ class KippoProjectOrganizationCategoryAdminTestCase(TestCase):
         request = self._request(self.staff_user)
         self.assertTrue(self.admin.has_change_permission(request, self.org_category))
         self.assertTrue(self.admin.has_delete_permission(request, self.org_category))
+
+    def test_non_superuser_cannot_change_or_delete_other_org_row(self):
+        request = self._request(self.staff_user)
+        self.assertFalse(self.admin.has_change_permission(request, self.other_org_category))
+        self.assertFalse(self.admin.has_delete_permission(request, self.other_org_category))
+
+    def test_non_superuser_save_model_rejects_other_org_row(self):
+        request = self._request(self.staff_user)
+        new_row = KippoProjectOrganizationCategory(organization=self.other_organization, key="staff-cross-org", label="Cross Org")
+        with self.assertRaises(PermissionDenied):
+            self.admin.save_model(request, new_row, form=None, change=False)
 
     def test_superuser_can_change_global(self):
         request = self._request(self.superuser)


### PR DESCRIPTION
## Summary

`KippoProjectOrganizationCategoryAdmin` only excluded the global (`organization=null`) template rows for non-superusers — a staff user could still **view, change, and delete every other organization's** project categories. This aligns the admin with the API rule (`IsSuperuserOrOrgMemberForCategory`): non-superusers now see and manage only rows for organizations they are a member of (`organization_ids_for_user`).

## Changes

- `get_queryset` filters to the user's organizations (which also drops the global template rows).
- `has_change_permission` / `has_delete_permission` block both globals and other orgs' rows via a shared `_manageable_by` helper.
- `formfield_for_foreignkey` limits the organization picker to the user's orgs (poka-yoke, mirrors the serializer's `validate_organization`).
- `save_model` rejects saving a row into a global template or a non-member organization.

Superusers retain full access (all orgs + the global template).

## Tests

`projects/tests/test_admin_projectcategory.py` gains a second organization the staff user is **not** a member of, and asserts the queryset excludes other orgs' rows and that change/delete/save are all rejected cross-org. All 9 tests pass; `ruff check` clean.

Refs kiconiaworks/kippo#48, kiconiaworks/kippo#49