### PR TITLE
Retire upsell project categories for a single 継続 category; rename 仮月額 → 月額

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -47,9 +47,9 @@ from tasks.periodic.tasks import collect_github_project_issues
 
 from .definitions import (
     BILLING_TYPE_MONTHLY,
+    CONTINUATION_CATEGORY_VALUE,
     NON_PROJECT_CATEGORY_VALUE,
     PRICING_BASIS_EFFORT,
-    UPSELL_CATEGORY_VALUES,
     WEEKLY_EFFORT_CLOSED_MESSAGE,
     ProjectProgressStatus,
     ProjectRoles,
@@ -91,7 +91,7 @@ from .models import (
 if TYPE_CHECKING:
     from .services.forecast import ForecastResult
 
-CLOSE_PROJECT_NO_UPSELL_VALUE = "__no_upsell__"
+CLOSE_PROJECT_NO_CONTINUATION_VALUE = "__no_continuation__"
 
 # Shown on the contract inline (not the phase field) when a project is moved into 契約(稼働中) but the 契約
 # inline is empty. The period is pre-filled from the project, so the actionable gap for the user is the
@@ -110,11 +110,11 @@ RETURN_TO_PARAM = "_return_to"
 # stay in sync instead of repeating the literal tuple.
 PROJECT_CLOSURE_FIELDS = ("close_comment", "survey_issued")
 
-# GET marker the close-action upsell wizard adds to the /add/ URL (kippo#41). When present, the admin
-# keeps the full sectioned add form (so the prefilled parent_project + inherited fields render and
-# save) and the upsell categories stay selectable, instead of the flat required-only plain add.
-UPSELL_SOURCE_PARAM = "_upsell_source"
-UPSELL_SOURCE_VALUE = "close"
+# GET marker the close-action continuation wizard adds to the /add/ URL (kippo#41). When present, the
+# admin keeps the full sectioned add form (so the prefilled parent_project + inherited fields render and
+# save) and the continuation category stays selectable, instead of the flat required-only plain add.
+CONTINUATION_SOURCE_PARAM = "_continuation_source"
+CONTINUATION_SOURCE_VALUE = "close"
 
 # confidence (%, derived from phase via PHASE_CONFIDENCE) at which a non-closed project must carry a
 # positive allocated_staff_days estimate (kippo#41).
@@ -660,17 +660,15 @@ collect_project_github_repositories_action.short_description = _("Collect Projec
 
 class CloseProjectActionForm(forms.Form):
     CATEGORY_CHOICES = (
-        ("upsell-improvement", _("(Upsell) 追加改善・拡張")),
-        ("upsell-new-proposal", _("(Upsell) 新規提案")),
-        ("upsell-new-department", _("(Upsell) 別部署紹介")),
-        (CLOSE_PROJECT_NO_UPSELL_VALUE, _("upsellなし")),
+        (CONTINUATION_CATEGORY_VALUE, _("継続")),
+        (CLOSE_PROJECT_NO_CONTINUATION_VALUE, _("継続なし")),
     )
 
     category = forms.ChoiceField(
         label=_("Category"),
         widget=forms.Select,
         choices=CATEGORY_CHOICES,
-        initial=CLOSE_PROJECT_NO_UPSELL_VALUE,
+        initial=CLOSE_PROJECT_NO_CONTINUATION_VALUE,
     )
     close_comment = forms.CharField(
         label=_("Close Comment"),
@@ -682,12 +680,12 @@ class CloseProjectActionForm(forms.Form):
         cleaned_data = super().clean()
         category = cleaned_data.get("category")
         close_comment = cleaned_data.get("close_comment", "").strip()
-        if category == CLOSE_PROJECT_NO_UPSELL_VALUE and not close_comment:
-            raise ValidationError({"close_comment": _("Close Comment is required when upsellなし is selected.")})
+        if category == CLOSE_PROJECT_NO_CONTINUATION_VALUE and not close_comment:
+            raise ValidationError({"close_comment": _("Close Comment is required when 継続なし is selected.")})
         return cleaned_data
 
 
-def _next_upsell_project_name(name: str) -> str:
+def _next_continuation_project_name(name: str) -> str:
     match = re.match(r"(.*) Phase (\d+)$", name)
     if match:
         return f"{match.group(1)} Phase {int(match.group(2)) + 1}"
@@ -698,18 +696,18 @@ def _start_of_next_month(today: datetime.date) -> datetime.date:
     return (today.replace(day=1) + datetime.timedelta(days=32)).replace(day=1)
 
 
-def _build_upsell_prefill_params(project: KippoProject, selected_category: str) -> dict[str, str]:
+def _build_continuation_prefill_params(project: KippoProject, selected_category: str) -> dict[str, str]:
     today = timezone.now().date()
     # category is now a FK — the add-form prefill needs the global category's PK, not its key string.
-    upsell_category_pk = (
+    continuation_category_pk = (
         KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, key=selected_category).values_list("pk", flat=True).first()
     )
     params = {
-        "category": str(upsell_category_pk) if upsell_category_pk else "",
+        "category": str(continuation_category_pk) if continuation_category_pk else "",
         "parent_project": str(project.id),
         "organization": str(project.organization_id),
-        UPSELL_SOURCE_PARAM: UPSELL_SOURCE_VALUE,
-        "name": _next_upsell_project_name(project.name),
+        CONTINUATION_SOURCE_PARAM: CONTINUATION_SOURCE_VALUE,
+        "name": _next_continuation_project_name(project.name),
         "start_date": _start_of_next_month(today).isoformat(),
         "slack_channel_name": project.slack_channel_name,
         "slack_notification_channel_name": project.slack_notification_channel_name,
@@ -724,7 +722,7 @@ def _build_upsell_prefill_params(project: KippoProject, selected_category: str) 
 
 
 def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoRequest, queryset: models.QuerySet):
-    """Close a KippoProject with an optional upsell follow-up project."""
+    """Close a KippoProject with an optional 継続 (continuation) follow-up project."""
     if queryset.count() != 1:
         modeladmin.message_user(request, _("Select exactly one project to close."), level=messages.ERROR)
         return None
@@ -752,8 +750,8 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
 
             modeladmin.message_user(request, _("Project '%s' closed.") % project.name, level=messages.INFO)
 
-            if selected_category in UPSELL_CATEGORY_VALUES:
-                params = urllib.parse.urlencode(_build_upsell_prefill_params(project, selected_category))
+            if selected_category == CONTINUATION_CATEGORY_VALUE:
+                params = urllib.parse.urlencode(_build_continuation_prefill_params(project, selected_category))
                 return HttpResponseRedirect(f"{settings.URL_PREFIX}/admin/projects/kippoproject/add/?{params}")
             return HttpResponseRedirect(f"{settings.URL_PREFIX}/admin/projects/kippoproject/")
     else:
@@ -766,7 +764,7 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
         "form": form,
         "action": "close_kippoproject_action",
         "opts": modeladmin.model._meta,
-        "no_upsell_value": CLOSE_PROJECT_NO_UPSELL_VALUE,
+        "no_continuation_value": CLOSE_PROJECT_NO_CONTINUATION_VALUE,
     }
     return TemplateResponse(request, "admin/projects/close_project_action.html", context)
 
@@ -906,7 +904,7 @@ class KippoProjectAdminForm(forms.ModelForm):
             self.instance._state.adding and not self.instance.is_closed and not is_non_project and PHASE_CONFIDENCE.get(phase) == FULL_CONFIDENCE
         )
         # the slim /add/ form does not render allocated_staff_days, so the requirement can't apply
-        # there (add_error on an absent field would raise); the full add form (upsell close-wizard)
+        # there (add_error on an absent field would raise); the full add form (continuation close-wizard)
         # does render it, so registration through that path is still validated.
         if "allocated_staff_days" not in self.fields:
             needs_estimate = False
@@ -918,12 +916,12 @@ class KippoProjectAdminForm(forms.ModelForm):
         organization = cleaned_data.get("organization")
         submitted_parent_project = cleaned_data.get("parent_project")
         # parent_project is readonly on the change form, so it won't appear in cleaned_data there
-        # — fall back to the persisted instance value so existing upsell projects keep validating.
+        # — fall back to the persisted instance value so existing continuation projects keep validating.
         parent_project = submitted_parent_project or getattr(self.instance, "parent_project", None)
-        if getattr(category, "key", None) in UPSELL_CATEGORY_VALUES and not parent_project:
+        if getattr(category, "key", None) == CONTINUATION_CATEGORY_VALUE and not parent_project:
             self.add_error(
                 "parent_project",
-                _("アップセルカテゴリを選択した場合は親プロジェクトが必須です。"),
+                _("継続カテゴリを選択した場合は親プロジェクトが必須です。"),
             )
         # On /add/, parent_project must belong to the same organization as the new project.
         # (On /change/, parent_project is readonly so it isn't in submitted data — skip this check.)
@@ -1036,7 +1034,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
     )
     # /add/ form (kippo#41, slimmed for the contract-driven flow): flat, no sections — registration
     # collects only these fields; everything else (contract, PM, estimates, …) is added on a later
-    # edit. The upsell close-wizard add (?_upsell_source=close) instead gets the full sectioned form
+    # edit. The continuation close-wizard add (?_continuation_source=close) instead gets the full sectioned form
     # (see get_fieldsets) so its prefilled optional fields (parent_project, slack, …) render and save.
     ADD_FIELDS = (
         "organization",
@@ -1195,23 +1193,23 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         return tuple(excluded)
 
     @staticmethod
-    def _is_upsell_add(request: DjangoRequest, obj: KippoProject | None) -> bool:
-        """True on the upsell close-wizard /add/ (kippo#41): it keeps the full sectioned form so the
+    def _is_continuation_add(request: DjangoRequest, obj: KippoProject | None) -> bool:
+        """True on the continuation close-wizard /add/ (kippo#41): it keeps the full sectioned form so the
         prefilled parent_project + inherited fields render and save, unlike the flat plain add.
         """
-        return obj is None and request.GET.get(UPSELL_SOURCE_PARAM) == UPSELL_SOURCE_VALUE
+        return obj is None and request.GET.get(CONTINUATION_SOURCE_PARAM) == CONTINUATION_SOURCE_VALUE
 
     def get_fieldsets(self, request: DjangoRequest, obj: KippoProject | None = None):
         excluded: set[str] = set(self.get_exclude(request, obj) or ())
         # estimated_completion_date is a computed readonly field, only surfaced for open projects on edit
         if obj is None or obj.is_closed:
             excluded.add("estimated_completion_date")
-        # /add/ (kippo#41): flat, required-only, in spec order — EXCEPT the upsell close-wizard add,
+        # /add/ (kippo#41): flat, required-only, in spec order — EXCEPT the continuation close-wizard add,
         # which prefills optional fields (parent_project, slack, …) that must render to be saved, so it
         # gets the full sectioned form below.
-        if obj is None and not self._is_upsell_add(request, obj):
+        if obj is None and not self._is_continuation_add(request, obj):
             return [(None, {"fields": tuple(f for f in self.ADD_FIELDS if f not in excluded)})]
-        # Change form (and upsell-wizard add): the full sectioned layout minus excluded fields. Build a
+        # Change form (and continuation-wizard add): the full sectioned layout minus excluded fields. Build a
         # fresh list (never mutate the class attribute); drop now-empty sections; expand collapsed
         # sections on the add path so prefilled fields are visible.
         rebuilt = []
@@ -1245,14 +1243,14 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         # Limit the category select to active categories (global defaults + any organization's custom categories).
         if db_field.name == "category":
             queryset = KippoProjectOrganizationCategory.objects.filter(is_active=True)
-            # On the plain /add/ form (kippo#41) upsell categories are hidden: they require a
-            # parent_project, which only the upsell close-wizard add exposes. Manual upsell creation
-            # goes through the close wizard (?_upsell_source=close), where they remain available.
+            # On the plain /add/ form (kippo#41) the 継続 category is hidden: it requires a
+            # parent_project, which only the close-wizard continuation add exposes. Manual continuation
+            # creation goes through the close wizard (?_continuation_source=close), where it stays available.
             # Detect the add view via the resolved url_name (…_add) rather than a path substring.
             url_name = getattr(request.resolver_match, "url_name", "") or ""
-            is_plain_add = url_name.endswith("_add") and request.GET.get(UPSELL_SOURCE_PARAM) != UPSELL_SOURCE_VALUE
+            is_plain_add = url_name.endswith("_add") and request.GET.get(CONTINUATION_SOURCE_PARAM) != CONTINUATION_SOURCE_VALUE
             if is_plain_add:
-                queryset = queryset.exclude(key__in=UPSELL_CATEGORY_VALUES)
+                queryset = queryset.exclude(key=CONTINUATION_CATEGORY_VALUE)
             kwargs["queryset"] = queryset
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
@@ -1495,8 +1493,8 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
             form.base_fields[fieldname].widget.can_delete_related = False
 
         # parent_project: readonly on the change form (handled in get_readonly_fields). On /add/ it only
-        # appears via the upsell close-wizard (kippo#41), where _apply_upsell_source_widgets scopes its
-        # queryset; required when category is an upsell value — enforced by KippoProjectAdminForm.clean().
+        # appears via the continuation close-wizard (kippo#41), where _apply_continuation_source_widgets scopes
+        # its queryset; required when category is 継続 — enforced by KippoProjectAdminForm.clean().
 
         # customer: scope queryset to the project's organization (on change) or the user's orgs (on add).
         self._scope_customer_queryset(form, obj, user_memberships)
@@ -1507,7 +1505,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
 
         # On /add/ the model default is a GLOBAL template row, which the org-scoped queryset above drops;
         # pre-select the initial organization's OWN default category so the required field renders selected
-        # and validates without the user opening the dropdown. A ?category= GET prefill (upsell wizard)
+        # and validates without the user opening the dropdown. A ?category= GET prefill (continuation wizard)
         # still wins via the form's initial data.
         if obj is None and user_initial_organization and "category" in form.base_fields:
             default_category = KippoProjectOrganizationCategory.get_default_for_organization(user_initial_organization.id)
@@ -1520,8 +1518,8 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         if obj is None and request.GET.get("customer") and "customer" in form.base_fields:
             form.base_fields["customer"].widget = forms.HiddenInput()
 
-        if self._is_upsell_add(request, obj):
-            self._apply_upsell_source_widgets(form, user_memberships)
+        if self._is_continuation_add(request, obj):
+            self._apply_continuation_source_widgets(form, user_memberships)
         return form
 
     @staticmethod
@@ -1538,7 +1536,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
     def _scope_category_queryset(form: Form, obj: KippoProject | None, user_memberships: models.QuerySet) -> None:
         """Scope the category select to the project's organization (or the user's orgs on /add/).
 
-        Narrows the queryset already built by formfield_for_foreignkey (which drops upsell categories
+        Narrows the queryset already built by formfield_for_foreignkey (which drops the 継続 category
         on the plain add form) so that exclusion is preserved. On the change form the currently-selected
         category is always kept selectable — even a legacy global (organization=null) row — so an edit
         can never silently drop it.
@@ -1552,8 +1550,8 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
             form.base_fields["category"].queryset = queryset.filter(organization__in=user_memberships)
 
     @staticmethod
-    def _apply_upsell_source_widgets(form: Form, user_memberships: models.QuerySet) -> None:
-        """Hide parent_project + organization on the upsell close-action redirect.
+    def _apply_continuation_source_widgets(form: Form, user_memberships: models.QuerySet) -> None:
+        """Hide parent_project + organization on the continuation close-action redirect.
 
         Values still POST and the existing validator runs; only the widgets are swapped to hidden.
         parent_project queryset is widened to all of the user's orgs because the default scope
@@ -1567,7 +1565,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
 
     def get_readonly_fields(self, request: DjangoRequest, obj: KippoProject | None = None) -> tuple[str, ...]:
         readonly_fields = tuple(super().get_readonly_fields(request, obj))
-        # show parent_project as readonly on the change form so admins can see the upsell parent
+        # show parent_project as readonly on the change form so admins can see the continuation parent
         if obj is not None and "parent_project" not in readonly_fields:
             readonly_fields = (*readonly_fields, "parent_project")
         # MTG calendar link fields are computed displays — readonly on the change form (kippo#13)
@@ -1717,7 +1715,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         """Create the default per-role assignment rates for a newly registered project.
 
         Idempotent against the (project, role) unique_together — only roles not already present are
-        created, so a re-save or an upsell copy never duplicates a rate.
+        created, so a re-save or a continuation copy never duplicates a rate.
         """
         existing_roles = set(project.assignment_rates.values_list("role", flat=True))
         for default in _default_assignment_rate_initial():
@@ -1836,7 +1834,7 @@ class ActiveKippoProjectAdmin(KippoProjectBaseAdmin):
         for field in PROJECT_CLOSURE_FIELDS:
             if field not in excluded:
                 excluded.append(field)
-        # parent_project is only relevant on add (manual upsell creation); hide on change
+        # parent_project is only relevant on add (manual continuation creation); hide on change
         if obj is not None and "parent_project" not in excluded:
             excluded.append("parent_project")
         return tuple(excluded)

--- a/kippo/projects/definitions.py
+++ b/kippo/projects/definitions.py
@@ -30,8 +30,7 @@ WEEKLY_EFFORT_CLOSED_MESSAGE = _("締め日時を過ぎているため編集で�
 # Default (global, organization=null) project categories seeded as KippoProjectOrganizationCategory rows.
 # (key, label, sort_order). KippoProject.category is a FK to KippoProjectOrganizationCategory; these are the
 # org-agnostic defaults an organization inherits until it defines its own categories (kippo#30 / T08, T20).
-# The upsell-* values are retained here — the close→follow-up workflow still depends on them; they are
-# dropped together with that workflow's rework in kippo#27 / #35.
+# "continuation" (継続) backs the close→follow-up wizard (a closing project spawns a continuation project).
 DEFAULT_KIPPOPROJECT_CATEGORIES = (
     ("ai-development", _("AI開発"), 10),
     ("mathematical-optimization", _("数理最適化"), 20),
@@ -40,16 +39,15 @@ DEFAULT_KIPPOPROJECT_CATEGORIES = (
     ("advisory", _("アドバイザリー"), 50),
     ("other", _("その他"), 60),
     ("non-project", _("非案件"), 70),
-    ("upsell-improvement", _("(Upsell) 追加改善・拡張"), 80),
-    ("upsell-new-proposal", _("(Upsell) 新規提案"), 90),
-    ("upsell-new-department", _("(Upsell) 別部署紹介"), 100),
+    ("continuation", _("継続"), 80),
 )
 KIPPOPROJECT_CATEGORY_CHOICES = tuple((key, label) for key, label, _sort in DEFAULT_KIPPOPROJECT_CATEGORIES)
 # Identifies "non-project" KippoProjects (replaces the retired phase=="anon-project"; consumed by kippo#37 / T10).
 NON_PROJECT_CATEGORY_VALUE = "non-project"
 # Fallback category for KippoProjects whose pre-migration category had no equivalent in the new taxonomy.
 DEFAULT_PROJECT_CATEGORY_VALUE = "other"
-UPSELL_CATEGORY_VALUES = ("upsell-improvement", "upsell-new-proposal", "upsell-new-department")
+# Category for follow-up projects spawned by the close→continuation wizard (requires a parent_project).
+CONTINUATION_CATEGORY_VALUE = "continuation"
 KIPPOPROJECT_CATEGORY_MAX_LENGTH = 32
 VALID_KIPPOPROJECT_CATEGORY_VALUES = tuple(choice[0] for choice in KIPPOPROJECT_CATEGORY_CHOICES)
 

--- a/kippo/projects/fixtures/default_kippoprojectorganizationcategory.json
+++ b/kippo/projects/fixtures/default_kippoprojectorganizationcategory.json
@@ -95,35 +95,9 @@
         "pk": "231a96f4-c247-5f58-90ca-ab0f0445037a",
         "fields": {
             "organization": null,
-            "key": "upsell-improvement",
-            "label": "(Upsell) 追加改善・拡張",
+            "key": "continuation",
+            "label": "継続",
             "sort_order": 80,
-            "is_active": true,
-            "created_datetime": "2026-06-09T00:00:00Z",
-            "updated_datetime": "2026-06-09T00:00:00Z"
-        }
-    },
-    {
-        "model": "projects.kippoprojectorganizationcategory",
-        "pk": "2fedd0b4-f774-5fd0-a65f-f90336baa3c2",
-        "fields": {
-            "organization": null,
-            "key": "upsell-new-proposal",
-            "label": "(Upsell) 新規提案",
-            "sort_order": 90,
-            "is_active": true,
-            "created_datetime": "2026-06-09T00:00:00Z",
-            "updated_datetime": "2026-06-09T00:00:00Z"
-        }
-    },
-    {
-        "model": "projects.kippoprojectorganizationcategory",
-        "pk": "f620cbaf-3cb7-5d61-a28e-a55ffe26660a",
-        "fields": {
-            "organization": null,
-            "key": "upsell-new-department",
-            "label": "(Upsell) 別部署紹介",
-            "sort_order": 100,
             "is_active": true,
             "created_datetime": "2026-06-09T00:00:00Z",
             "updated_datetime": "2026-06-09T00:00:00Z"

--- a/kippo/projects/migrations/0051_month_amount_and_continuation_rename.py
+++ b/kippo/projects/migrations/0051_month_amount_and_continuation_rename.py
@@ -1,0 +1,43 @@
+# Rename 仮月額 → 月額 (estimated_monthly_amount verbose_name) and retire the "upsell" naming on
+# parent_project (help_text + related_name) in favor of "continuation" (継続). No DB schema change —
+# these operations only update field metadata (verbose_name / help_text / reverse accessor name).
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("projects", "0050_saleskippoproject"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="kippoproject",
+            name="parent_project",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="継続プロジェクトの元（親）プロジェクト",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="continuation_children",
+                to="projects.kippoproject",
+                verbose_name="親プロジェクト",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="kippoprojectcontract",
+            name="estimated_monthly_amount",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=0,
+                help_text=(
+                    "JPY. Provisional (仮) monthly amount for effort + monthly contracts (kippo#46): every "
+                    "contract month is billed this amount up front, then corrected to actuals (実績) via the "
+                    "true-up admin action before the entry is received. Blank bills logged actuals directly."
+                ),
+                max_digits=12,
+                null=True,
+                verbose_name="月額",
+            ),
+        ),
+    ]

--- a/kippo/projects/migrations/0052_retire_upsell_seed_continuation.py
+++ b/kippo/projects/migrations/0052_retire_upsell_seed_continuation.py
@@ -1,0 +1,80 @@
+"""Retire the 3 upsell project categories in favor of a single 継続 (continuation) category.
+
+The fixture edit (default_kippoprojectorganizationcategory.json) only covers fresh installs — it is
+replayed by 0040_issue33_pending_consolidated.load_default_categories, which already ran on existing
+deployments and will not re-run. This RunPython reconciles already-migrated databases:
+
+  1. Ensure the global (organization=null) `continuation` row exists. On an existing DB this converts
+     the old global `upsell-improvement` row (same fixture pk, seeded by 0040) into `continuation`; on
+     a fresh DB the fixture already created that row → idempotent no-op.
+  2. Seed a `continuation` copy for every organization that still has an upsell category (copy-on-create
+     parity, kippo#49), so the close→continuation admin wizard's follow-up is selectable per org.
+  3. Deactivate every remaining upsell-* row (global leftovers + org copies). Deactivate rather than
+     delete to avoid a PROTECT error on any project still referencing one, and to stay reversible.
+
+No project references a global category after 0048 (all were remapped to org copies), so converting the
+global row in step 1 recategorizes nothing.
+"""
+
+import uuid
+
+from django.db import migrations
+
+UPSELL_KEYS = ("upsell-improvement", "upsell-new-proposal", "upsell-new-department")
+CONTINUATION_KEY = "continuation"
+CONTINUATION_LABEL = "継続"
+CONTINUATION_SORT_ORDER = 80
+# Matches the `continuation` pk in default_kippoprojectorganizationcategory.json (the former
+# `upsell-improvement` global slot) so fresh and existing databases converge on the same row.
+GLOBAL_CONTINUATION_PK = uuid.UUID("231a96f4-c247-5f58-90ca-ab0f0445037a")
+
+
+def retire_upsell_seed_continuation(apps, schema_editor):
+    Category = apps.get_model("projects", "KippoProjectOrganizationCategory")  # noqa: N806
+
+    # 1. Global continuation row (convert the old global upsell-improvement slot; no-op on fresh DBs).
+    Category.objects.update_or_create(
+        id=GLOBAL_CONTINUATION_PK,
+        defaults={
+            "organization_id": None,
+            "key": CONTINUATION_KEY,
+            "label": CONTINUATION_LABEL,
+            "sort_order": CONTINUATION_SORT_ORDER,
+            "is_active": True,
+        },
+    )
+
+    # 2. Per-org continuation copy for every org that still has an upsell category.
+    org_ids_with_upsell = set(
+        Category.objects.filter(organization__isnull=False, key__in=UPSELL_KEYS).values_list("organization_id", flat=True)
+    )
+    for organization_id in org_ids_with_upsell:
+        if not Category.objects.filter(organization_id=organization_id, key=CONTINUATION_KEY).exists():
+            Category.objects.create(
+                organization_id=organization_id,
+                key=CONTINUATION_KEY,
+                label=CONTINUATION_LABEL,
+                sort_order=CONTINUATION_SORT_ORDER,
+                is_active=True,
+            )
+
+    # 3. Deactivate every remaining upsell-* row (the step-1 conversion changed the global slot's key
+    #    to "continuation", so it is not matched here).
+    Category.objects.filter(key__in=UPSELL_KEYS).update(is_active=False)
+
+
+def reverse(apps, schema_editor):
+    # Best-effort reverse: reactivate the retired upsell rows. The seeded continuation rows are left in
+    # place (harmless) and the converted global slot is not restored to upsell-improvement.
+    Category = apps.get_model("projects", "KippoProjectOrganizationCategory")  # noqa: N806
+    Category.objects.filter(key__in=UPSELL_KEYS).update(is_active=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("projects", "0051_month_amount_and_continuation_rename"),
+    ]
+
+    operations = [
+        migrations.RunPython(retire_upsell_seed_continuation, reverse),
+    ]

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -392,9 +392,9 @@ class KippoProject(UserCreatedBaseModel):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        related_name="upsell_children",
+        related_name="continuation_children",
         verbose_name=_("親プロジェクト"),
-        help_text=_("アップセルプロジェクトの元（親）プロジェクト"),
+        help_text=_("継続プロジェクトの元（親）プロジェクト"),
     )
     customer = models.ForeignKey(
         "customers.KippoCustomer",
@@ -1006,7 +1006,7 @@ class KippoProjectContract(UserCreatedBaseModel):
         ),
     )
     estimated_monthly_amount = models.DecimalField(
-        _("仮月額"),
+        _("月額"),
         max_digits=12,
         decimal_places=0,
         null=True,
@@ -1064,7 +1064,7 @@ class KippoProjectContract(UserCreatedBaseModel):
         if self.estimated_monthly_amount is not None and not (
             self.pricing_basis == PRICING_BASIS_EFFORT and self.billing_type == BILLING_TYPE_MONTHLY
         ):
-            raise ValidationError({"estimated_monthly_amount": _("Estimated monthly amount (仮月額) only applies to effort + monthly contracts.")})
+            raise ValidationError({"estimated_monthly_amount": _("Estimated monthly amount (月額) only applies to effort + monthly contracts.")})
 
     def save(self, *args, **kwargs):
         is_initial_creation = self._state.adding
@@ -1221,7 +1221,7 @@ class KippoProjectContract(UserCreatedBaseModel):
         """
         if self.pricing_basis == PRICING_BASIS_EFFORT:
             if self.billing_type == BILLING_TYPE_MONTHLY:
-                # When the 仮月額 is set, bill it provisionally for every contract month (future months
+                # When the 月額 is set, bill it provisionally for every contract month (future months
                 # included, no proration for partial months) so entries and planned revenue exist before
                 # effort is logged; trueup_billing_entries() corrects to actuals later (kippo#46).
                 # Otherwise bill each month's logged actuals directly.

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -260,10 +260,10 @@ class KippoProjectContractSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"end_date": _("Contract start_date is after end_date")})
         if pricing_basis == PRICING_BASIS_FIXED and total_amount is None:
             raise serializers.ValidationError({"total_amount": _("Total amount is required for fixed-price contracts.")})
-        # 仮月額 (kippo#46) only drives effort + monthly billing — reject it elsewhere as a likely mistake.
+        # 月額 (kippo#46) only drives effort + monthly billing — reject it elsewhere as a likely mistake.
         if estimated_monthly_amount is not None and not (pricing_basis == PRICING_BASIS_EFFORT and billing_type == BILLING_TYPE_MONTHLY):
             raise serializers.ValidationError(
-                {"estimated_monthly_amount": _("Estimated monthly amount (仮月額) only applies to effort + monthly contracts.")}
+                {"estimated_monthly_amount": _("Estimated monthly amount (月額) only applies to effort + monthly contracts.")}
             )
         return attrs
 
@@ -361,14 +361,14 @@ class KippoProjectSerializer(serializers.ModelSerializer):
         required=False,
         help_text="ProjectColumnSet for this project. Defaults to the organization's default columnset when omitted.",
     )
-    # parent_project (親プロジェクト) — original project for upsell projects (admin parity). Writable
+    # parent_project (親プロジェクト) — original project for continuation projects (admin parity). Writable
     # FK; a cross-org or self-referencing parent is rejected in validate(). parent_project_name is the
     # read-only label so clients can render the selection without a second lookup.
     parent_project = serializers.PrimaryKeyRelatedField(
         queryset=KippoProject.objects.all(),
         required=False,
         allow_null=True,
-        help_text="Original (parent) project for upsell projects.",
+        help_text="Original (parent) project for continuation projects.",
     )
     parent_project_name = serializers.CharField(source="parent_project.name", read_only=True, allow_null=True)
     # MTG calendar template URL + dsearch tag — read-only, mirroring the admin's
@@ -568,7 +568,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"phase": UNDER_CONTRACT_REQUIRES_CONTRACT_MSG})
 
     def _validate_parent_project(self, attrs: dict, organization: "KippoOrganization | None") -> None:
-        """parent_project (upsell) must be same-org and not the project itself (admin parity)."""
+        """parent_project (continuation) must be same-org and not the project itself (admin parity)."""
         parent_project = attrs.get("parent_project")
         if parent_project is None:
             return

--- a/kippo/projects/templates/admin/projects/close_project_action.html
+++ b/kippo/projects/templates/admin/projects/close_project_action.html
@@ -58,7 +58,7 @@
           {{ form.close_comment.label }}:
           <span id="close-comment-required-indicator"
                 class="required-indicator"
-                data-no-upsell-value="{{ no_upsell_value }}"
+                data-no-continuation-value="{{ no_continuation_value }}"
                 data-comment-target="{{ form.close_comment.id_for_label }}"
                 aria-live="polite">{% trans "(required)" %}</span>
         </label>
@@ -75,11 +75,11 @@
   (function () {
     var indicator = document.getElementById("close-comment-required-indicator");
     if (!indicator) { return; }
-    var noUpsellValue = indicator.getAttribute("data-no-upsell-value");
+    var noContinuationValue = indicator.getAttribute("data-no-continuation-value");
     var commentInput = document.getElementById(indicator.getAttribute("data-comment-target"));
     var categorySelect = document.querySelector('select[name="category"]');
     function update() {
-      var isRequired = !!(categorySelect && categorySelect.value === noUpsellValue);
+      var isRequired = !!(categorySelect && categorySelect.value === noContinuationValue);
       indicator.classList.toggle("is-visible", isRequired);
       if (commentInput) {
         if (isRequired) {

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -37,7 +37,7 @@ from projects.admin import (
     ProjectAssignmentRateInline,
     ProjectWeeklyEffortAdminInline,
     SalesKippoProjectAdmin,
-    _next_upsell_project_name,
+    _next_continuation_project_name,
     _start_of_next_month,
 )
 from projects.definitions import DEFAULT_BILLING_TYPE, DEFAULT_PRICING_BASIS
@@ -578,14 +578,14 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         messages_list = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("re-open" in m.lower() for m in messages_list), messages_list)
 
-    def test_no_upsell_requires_close_comment(self):
+    def test_no_continuation_requires_close_comment(self):
         response = self.client.post(
             self.changelist_url,
             data={
                 "action": "close_kippoproject_action",
                 ACTION_CHECKBOX_NAME: [str(self.project1.id)],
                 "post": "yes",
-                "category": "__no_upsell__",
+                "category": "__no_continuation__",
                 "close_comment": "",
             },
         )
@@ -598,20 +598,20 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertIsNotNone(form)
         self.assertIn("close_comment", form.errors)
 
-    def test_no_upsell_flow_closes_project(self):
+    def test_no_continuation_flow_closes_project(self):
         response = self.client.post(
             self.changelist_url,
             data={
                 "action": "close_kippoproject_action",
                 ACTION_CHECKBOX_NAME: [str(self.project1.id)],
                 "post": "yes",
-                "category": "__no_upsell__",
+                "category": "__no_continuation__",
                 "close_comment": "Project completed successfully.",
             },
         )
         self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertIn("/admin/projects/kippoproject/", response["Location"])
-        # ensure no add page is requested for upsell-none
+        # ensure no add page is requested for continuation-none
         self.assertNotIn("/add/", response["Location"])
 
         self.project1.refresh_from_db()
@@ -625,14 +625,14 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         # confirm no new project was created
         self.assertEqual(KippoProject.objects.count(), 2)
 
-    def test_upsell_flow_closes_and_redirects(self):
+    def test_continuation_flow_closes_and_redirects(self):
         response = self.client.post(
             self.changelist_url,
             data={
                 "action": "close_kippoproject_action",
                 ACTION_CHECKBOX_NAME: [str(self.project1.id)],
                 "post": "yes",
-                "category": "upsell-improvement",
+                "category": "continuation",
                 "close_comment": "",
             },
         )
@@ -640,12 +640,12 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertIn("/admin/projects/kippoproject/add/", response["Location"])
         parsed = urlparse(response["Location"])
         params = parse_qs(parsed.query)
-        self.assertEqual(params.get("category"), [str(_global_category("upsell-improvement").pk)])
+        self.assertEqual(params.get("category"), [str(_global_category("continuation").pk)])
         self.assertEqual(params.get("parent_project"), [str(self.project1.id)])
-        # close-action upsell redirect must include the parent's organization and the upsell marker
+        # close-action continuation redirect must include the parent's organization and the continuation marker
         # so the add form can derive the org server-side and detect the entry point.
         self.assertEqual(params.get("organization"), [str(self.project1.organization_id)])
-        self.assertEqual(params.get("_upsell_source"), ["close"])
+        self.assertEqual(params.get("_continuation_source"), ["close"])
 
         self.project1.refresh_from_db()
         self.assertTrue(self.project1.is_closed)
@@ -654,8 +654,8 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         # category on the closing project is unchanged
         self.assertEqual(self.project1.category.key, "other")
 
-    def test_upsell_redirect_prefills_new_project_fields(self):
-        # populate source-project fields that should propagate to the upsell child
+    def test_continuation_redirect_prefills_new_project_fields(self):
+        # populate source-project fields that should propagate to the continuation child
         self.project1.slack_channel_name = "proj1"
         self.project1.slack_notification_channel_name = "proj1-notify"
         self.project1.document_folder_url = "https://docs.example.com/proj1"
@@ -670,7 +670,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
                 "action": "close_kippoproject_action",
                 ACTION_CHECKBOX_NAME: [str(self.project1.id)],
                 "post": "yes",
-                "category": "upsell-new-proposal",
+                "category": "continuation",
                 "close_comment": "",
             },
         )
@@ -689,7 +689,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         expected_start = (today.replace(day=1) + datetime.timedelta(days=32)).replace(day=1)
         self.assertEqual(params.get("start_date"), [expected_start.isoformat()])
 
-    def test_upsell_redirect_omits_blank_source_fields(self):
+    def test_continuation_redirect_omits_blank_source_fields(self):
         # leave optional source fields blank: prefill params should not include empty values
         response = self.client.post(
             self.changelist_url,
@@ -697,7 +697,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
                 "action": "close_kippoproject_action",
                 ACTION_CHECKBOX_NAME: [str(self.project1.id)],
                 "post": "yes",
-                "category": "upsell-improvement",
+                "category": "continuation",
                 "close_comment": "",
             },
         )
@@ -713,7 +713,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
             with self.subTest(field=blank_field):
                 self.assertNotIn(blank_field, params)
 
-    def test_close_form_category_dropdown_default_is_no_upsell(self):
+    def test_close_form_category_dropdown_default_is_no_continuation(self):
         response = self.client.post(
             self.changelist_url,
             data={
@@ -724,7 +724,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         form = response.context["form"]
         self.assertEqual(form.fields["category"].widget.__class__.__name__, "Select")
-        self.assertEqual(form.fields["category"].initial, "__no_upsell__")
+        self.assertEqual(form.fields["category"].initial, "__no_continuation__")
 
     def test_add_form_hides_close_comment_field(self):
         url = reverse("admin:projects_kippoproject_add")
@@ -746,14 +746,14 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertContains(response, "project1")
 
     def test_add_form_prefills_from_get_params(self):
-        # the close-wizard opens /add/?_upsell_source=close&... and prefills the new project's fields;
+        # the close-wizard opens /add/?_continuation_source=close&... and prefills the new project's fields;
         # parent_project is present (hidden) on this wizard add (kippo#41).
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(
             url,
             {
-                "_upsell_source": "close",
-                "category": "upsell-improvement",
+                "_continuation_source": "close",
+                "category": "continuation",
                 "parent_project": str(self.project1.id),
                 "name": "prefilled-name",
             },
@@ -775,8 +775,8 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
     def test_change_form_shows_parent_project_readonly(self):
         child = KippoProject.objects.create(
             organization=self.organization,
-            name="upsell-child",
-            category=_global_category("upsell-improvement"),
+            name="continuation-child",
+            category=_global_category("continuation"),
             columnset=ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK),
             parent_project=self.project1,
             start_date=self.current_date,
@@ -791,31 +791,31 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertContains(response, self.project1.name)
 
     def test_manual_add_form_omits_parent_project(self):
-        # kippo#41: the flat /add/ form no longer exposes parent_project (upsell creation is wizard-only)
+        # kippo#41: the flat /add/ form no longer exposes parent_project (continuation creation is wizard-only)
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertNotIn("parent_project", response.context["adminform"].form.fields)
 
-    def test_plain_add_excludes_upsell_categories(self):
-        # kippo#41: upsell categories are hidden on the plain add form (they need a parent_project)
-        from projects.definitions import UPSELL_CATEGORY_VALUES
+    def test_plain_add_excludes_continuation_category(self):
+        # kippo#41: the 継続 category is hidden on the plain add form (it needs a parent_project)
+        from projects.definitions import CONTINUATION_CATEGORY_VALUE
 
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(url)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         keys = set(response.context["adminform"].form.fields["category"].queryset.values_list("key", flat=True))
-        self.assertTrue(keys.isdisjoint(UPSELL_CATEGORY_VALUES), f"upsell categories leaked onto plain add: {keys & set(UPSELL_CATEGORY_VALUES)}")
+        self.assertNotIn(CONTINUATION_CATEGORY_VALUE, keys, "continuation category leaked onto plain add")
 
-    def test_upsell_wizard_add_keeps_upsell_categories(self):
-        # the close-wizard add (?_upsell_source=close) keeps upsell categories selectable
-        from projects.definitions import UPSELL_CATEGORY_VALUES
+    def test_continuation_wizard_add_keeps_continuation_category(self):
+        # the close-wizard add (?_continuation_source=close) keeps the 継続 category selectable
+        from projects.definitions import CONTINUATION_CATEGORY_VALUE
 
         url = reverse("admin:projects_kippoproject_add")
-        response = self.client.get(url, {"_upsell_source": "close"})
+        response = self.client.get(url, {"_continuation_source": "close"})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         keys = set(response.context["adminform"].form.fields["category"].queryset.values_list("key", flat=True))
-        self.assertFalse(keys.isdisjoint(UPSELL_CATEGORY_VALUES), "wizard add must keep upsell categories available")
+        self.assertIn(CONTINUATION_CATEGORY_VALUE, keys, "wizard add must keep the continuation category available")
 
     def test_add_form_category_scoped_to_user_organizations(self):
         # the category select must list only the user's organizations' categories, never another org's
@@ -853,15 +853,15 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(org_ids, {self.organization.id}, f"category select leaked non-project org categories: {org_ids}")
         self.assertNotIn(other_org_category.pk, set(queryset.values_list("pk", flat=True)))
 
-    def test_upsell_redirect_hides_parent_project_and_organization(self):
-        # close-action upsell redirect: parent_project and organization must render as hidden inputs
+    def test_continuation_redirect_hides_parent_project_and_organization(self):
+        # close-action continuation redirect: parent_project and organization must render as hidden inputs
         # so the user cannot edit them; the values still POST so the existing validator runs.
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(
             url,
             {
-                "_upsell_source": "close",
-                "category": "upsell-improvement",
+                "_continuation_source": "close",
+                "category": "continuation",
                 "parent_project": str(self.project1.id),
                 "organization": str(self.project1.organization_id),
             },
@@ -877,12 +877,12 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertIn('type="hidden" name="parent_project"', content)
         self.assertIn('type="hidden" name="organization"', content)
 
-    def test_upsell_form_with_derived_organization_is_valid_and_saves_parent(self):
-        # the upsell prefill always sets organization = parent_project.organization, so the form
+    def test_continuation_form_with_derived_organization_is_valid_and_saves_parent(self):
+        # the continuation prefill always sets organization = parent_project.organization, so the form
         # validator's parent-org invariant is satisfied by construction. Save and verify the result.
         customer = KippoCustomer.objects.create(
             organization=self.project1.organization,
-            name="upsell-form-customer",
+            name="continuation-form-customer",
             created_by=self.superuser_no_org,
             updated_by=self.superuser_no_org,
         )
@@ -893,7 +893,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
                 "name": "project1 Phase 2",
                 "phase": "proposing-low",
                 "confidence": "80",
-                "category": str(_global_category("upsell-improvement").pk),
+                "category": str(_global_category("continuation").pk),
                 "columnset": str(self.project1.columnset_id),
                 # required at registration (kippo#40 / T19, extended kippo#41)
                 "customer": str(customer.id),
@@ -901,7 +901,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
                 "start_date": self.current_date.isoformat(),
                 "target_date": self.current_date.isoformat(),
                 "allocated_staff_days": "10",
-                "problem_definition": "upsell problem",
+                "problem_definition": "continuation problem",
             },
         )
         self.assertTrue(form.is_valid(), form.errors)
@@ -912,7 +912,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(new_project.parent_project_id, self.project1.id)
         self.assertEqual(new_project.organization_id, self.project1.organization_id)
 
-    def test_upsell_form_with_mismatched_organization_is_rejected(self):
+    def test_continuation_form_with_mismatched_organization_is_rejected(self):
         # tampered POST: hidden organization differs from parent_project.organization — the existing
         # validator must catch the mismatch (no validator changes were made for this issue).
         form = KippoProjectAdminForm(
@@ -923,7 +923,7 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
                 "name": "tampered-project",
                 "phase": "proposing-low",
                 "confidence": "80",
-                "category": str(_global_category("upsell-improvement").pk),
+                "category": str(_global_category("continuation").pk),
                 "columnset": str(self.project1.columnset_id),
                 "start_date": self.current_date.isoformat(),
             },
@@ -977,18 +977,18 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
             data["parent_project"] = parent_project_id
         return data
 
-    def test_upsell_category_without_parent_project_is_invalid(self):
-        form = KippoProjectAdminForm(data=self._form_data(category="upsell-improvement"))
+    def test_continuation_category_without_parent_project_is_invalid(self):
+        form = KippoProjectAdminForm(data=self._form_data(category="continuation"))
         self.assertFalse(form.is_valid())
         self.assertIn("parent_project", form.errors)
 
-    def test_upsell_category_with_parent_project_is_valid(self):
+    def test_continuation_category_with_parent_project_is_valid(self):
         form = KippoProjectAdminForm(
-            data=self._form_data(category="upsell-improvement", parent_project_id=str(self.parent.id)),
+            data=self._form_data(category="continuation", parent_project_id=str(self.parent.id)),
         )
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_non_upsell_category_does_not_require_parent_project(self):
+    def test_non_continuation_category_does_not_require_parent_project(self):
         form = KippoProjectAdminForm(data=self._form_data(category="other"))
         self.assertTrue(form.is_valid(), form.errors)
 
@@ -1127,13 +1127,13 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
         self.assertNotIn(KippoProjectContractInline, modeladmin.get_inlines(self.super_user_request, obj=None))
         self.assertIn(KippoProjectContractInline, modeladmin.get_inlines(self.super_user_request, obj=self.parent))
 
-    def test_change_form_with_upsell_category_uses_persisted_parent_when_field_omitted(self):
+    def test_change_form_with_continuation_category_uses_persisted_parent_when_field_omitted(self):
         # change form: parent_project is readonly so it isn't submitted in POST data;
         # validation must fall back to the persisted instance value to avoid a false-positive error.
-        existing_upsell = KippoProject.objects.create(
+        existing_continuation = KippoProject.objects.create(
             organization=self.organization,
-            name="existing-upsell",
-            category=_global_category("upsell-improvement"),
+            name="existing-continuation",
+            category=_global_category("continuation"),
             columnset=self.columnset,
             parent_project=self.parent,
             start_date=self.current_date,
@@ -1141,8 +1141,8 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
             updated_by=self.github_manager,
         )
         form = KippoProjectAdminForm(
-            instance=existing_upsell,
-            data=self._form_data(category="upsell-improvement"),  # no parent_project key
+            instance=existing_continuation,
+            data=self._form_data(category="continuation"),  # no parent_project key
         )
         self.assertTrue(form.is_valid(), form.errors)
 
@@ -1158,21 +1158,21 @@ class KippoProjectAdminFormValidationTestCase(IsStaffModelAdminTestCaseBase):
             updated_by=self.github_manager,
         )
         form = KippoProjectAdminForm(
-            data=self._form_data(category="upsell-improvement", parent_project_id=str(cross_org_parent.id)),
+            data=self._form_data(category="continuation", parent_project_id=str(cross_org_parent.id)),
         )
         self.assertFalse(form.is_valid())
         self.assertIn("parent_project", form.errors)
 
 
-class UpsellPrefillHelpersTestCase(TestCase):
-    def test_next_upsell_project_name_appends_phase_2_when_no_existing_suffix(self):
-        self.assertEqual(_next_upsell_project_name("Foo"), "Foo Phase 2")
-        self.assertEqual(_next_upsell_project_name("Foo Bar"), "Foo Bar Phase 2")
+class ContinuationPrefillHelpersTestCase(TestCase):
+    def test_next_continuation_project_name_appends_phase_2_when_no_existing_suffix(self):
+        self.assertEqual(_next_continuation_project_name("Foo"), "Foo Phase 2")
+        self.assertEqual(_next_continuation_project_name("Foo Bar"), "Foo Bar Phase 2")
 
-    def test_next_upsell_project_name_increments_existing_phase_number(self):
-        self.assertEqual(_next_upsell_project_name("Foo Phase 2"), "Foo Phase 3")
-        self.assertEqual(_next_upsell_project_name("Foo Phase 9"), "Foo Phase 10")
-        self.assertEqual(_next_upsell_project_name("Foo Bar Phase 11"), "Foo Bar Phase 12")
+    def test_next_continuation_project_name_increments_existing_phase_number(self):
+        self.assertEqual(_next_continuation_project_name("Foo Phase 2"), "Foo Phase 3")
+        self.assertEqual(_next_continuation_project_name("Foo Phase 9"), "Foo Phase 10")
+        self.assertEqual(_next_continuation_project_name("Foo Bar Phase 11"), "Foo Bar Phase 12")
 
     def test_start_of_next_month(self):
         self.assertEqual(_start_of_next_month(datetime.date(2026, 1, 15)), datetime.date(2026, 2, 1))
@@ -1938,7 +1938,7 @@ class KippoProjectAdminContractPeriodFieldsTestCase(KippoProjectAdminFixtureTest
 
 
 class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixtureTestCaseBase):
-    """parent_project (kippo#41): absent from the flat /add/ form; exposed (hidden) only on the upsell
+    """parent_project (kippo#41): absent from the flat /add/ form; exposed (hidden) only on the continuation
     close-wizard add; in the Details section (readonly) on change.
     """
 
@@ -1975,7 +1975,7 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
         self.assertIn("slack_channel_name", details)  # merged in from the removed Extra section
 
     def test_active_admin_change_omits_parent_project(self):
-        # ActiveKippoProjectAdmin excludes parent_project on change (active projects aren't upsell-edited)
+        # ActiveKippoProjectAdmin excludes parent_project on change (active projects aren't continuation-edited)
         modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
         fieldsets = modeladmin.get_fieldsets(self.super_user_request, obj=self.existing_project)
         self.assertNotIn("parent_project", self._all_fieldset_fields(fieldsets))
@@ -1997,13 +1997,13 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertNotIn("parent_project", response.context["adminform"].form.fields)
 
-    def test_upsell_wizard_add_view_exposes_parent_project_hidden(self):
-        # the close-wizard add (?_upsell_source=close) keeps the full sectioned form so parent_project
+    def test_continuation_wizard_add_view_exposes_parent_project_hidden(self):
+        # the close-wizard add (?_continuation_source=close) keeps the full sectioned form so parent_project
         # renders (hidden) and POSTs — see KippoProjectBaseAdmin.get_fieldsets.
         url = reverse("admin:projects_kippoproject_add")
         response = self.client.get(
             url,
-            {"_upsell_source": "close", "category": "upsell-improvement", "parent_project": str(self.existing_project.id)},
+            {"_continuation_source": "close", "category": "continuation", "parent_project": str(self.existing_project.id)},
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
         adminform = response.context["adminform"]
@@ -2012,11 +2012,11 @@ class ActiveKippoProjectAdminParentProjectFieldTestCase(KippoProjectAdminFixture
         inner_widget = getattr(widget, "widget", widget)
         self.assertIsInstance(inner_widget, forms.HiddenInput)
 
-    def test_upsell_wizard_add_post_preserves_parent_project_field(self):
-        # form action="" posts to the same URL incl. its query string, so _upsell_source survives the
+    def test_continuation_wizard_add_post_preserves_parent_project_field(self):
+        # form action="" posts to the same URL incl. its query string, so _continuation_source survives the
         # POST and get_fieldsets rebuilds the full form — an invalid submit still re-renders parent_project.
-        url = reverse("admin:projects_kippoproject_add") + "?_upsell_source=close"
-        response = self.client.post(url, {"name": "incomplete-upsell"})  # intentionally invalid
+        url = reverse("admin:projects_kippoproject_add") + "?_continuation_source=close"
+        response = self.client.post(url, {"name": "incomplete-continuation"})  # intentionally invalid
         self.assertEqual(response.status_code, HTTPStatus.OK)  # re-rendered with errors, not a redirect
         self.assertIn("parent_project", response.context["adminform"].form.fields)
 

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -1846,7 +1846,7 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
 
     def test_estimated_monthly_amount_round_trips_for_effort_monthly(self):
-        """仮月額 (kippo#46) is settable/readable on the contract endpoint for effort + monthly terms."""
+        """月額 (kippo#46) is settable/readable on the contract endpoint for effort + monthly terms."""
         url = f"{self.base}/{self.project.id}/contract/"
         resp = self.client.post(
             url,
@@ -1858,7 +1858,7 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         self.assertEqual(self.project.contract.estimated_monthly_amount, 500000)
 
     def test_estimated_monthly_amount_rejected_off_effort_monthly(self):
-        """Mirror KippoProjectContract.clean(): 仮月額 anywhere but effort + monthly → 400."""
+        """Mirror KippoProjectContract.clean(): 月額 anywhere but effort + monthly → 400."""
         url = f"{self.base}/{self.project.id}/contract/"
         resp = self.client.post(
             url,

--- a/kippo/projects/tests/test_migrations.py
+++ b/kippo/projects/tests/test_migrations.py
@@ -1,9 +1,24 @@
 import importlib
 
+from accounts.models import KippoOrganization, KippoUser
+from django.apps import apps as django_apps
 from django.test import TestCase
+
+from projects.models import KippoProjectOrganizationCategory
 
 migration_module = importlib.import_module("projects.migrations.0031_kippoproject_category_choices_close_fields")
 map_invalid_categories_to_other = migration_module.map_invalid_categories_to_other
+
+retire_upsell_module = importlib.import_module("projects.migrations.0052_retire_upsell_seed_continuation")
+retire_upsell_seed_continuation = retire_upsell_module.retire_upsell_seed_continuation
+GLOBAL_CONTINUATION_PK = retire_upsell_module.GLOBAL_CONTINUATION_PK
+UPSELL_KEYS = retire_upsell_module.UPSELL_KEYS
+
+_LEGACY_UPSELL_ROWS = (
+    ("upsell-improvement", "(Upsell) 追加改善・拡張", 80),
+    ("upsell-new-proposal", "(Upsell) 新規提案", 90),
+    ("upsell-new-department", "(Upsell) 別部署紹介", 100),
+)
 
 
 class FakeQuerySet:
@@ -60,3 +75,57 @@ class CategoryDataMigrationTestCase(TestCase):
         self.assertEqual(projects[2]["category"], "poc")
         self.assertEqual(projects[3]["category"], "new-proposal")
         self.assertEqual(projects[4]["category"], "upsell-improvement")
+
+
+class RetireUpsellSeedContinuationTestCase(TestCase):
+    """0052 reconciles already-migrated databases (the fixture edit only covers fresh installs)."""
+
+    fixtures = ["required_bot_users", "default_columnset", "default_labelset", "default_kippoprojectorganizationcategory"]
+
+    def _simulate_pre_migration_database(self) -> KippoOrganization:
+        """Undo the new fixture's global continuation row and recreate the legacy upsell rows (global +
+        an org's copies) so the DB looks like one migrated before this change.
+        """
+        category = KippoProjectOrganizationCategory
+        category.objects.filter(organization__isnull=True, key="continuation").delete()
+        # legacy global rows — upsell-improvement reuses the shared fixture pk (the slot 0052 converts).
+        imp_key, imp_label, imp_order = _LEGACY_UPSELL_ROWS[0]
+        category.objects.create(id=GLOBAL_CONTINUATION_PK, organization=None, key=imp_key, label=imp_label, sort_order=imp_order)
+        for key, label, order in _LEGACY_UPSELL_ROWS[1:]:
+            category.objects.create(organization=None, key=key, label=label, sort_order=order)
+        manager = KippoUser.objects.get(username="github-manager")
+        # Creating the org fires seed_organization_project_categories (post_save), which copies the
+        # then-active globals — including the 3 upsell rows above — into org-scoped copies, exactly as
+        # a real organization created before this change would have them. No continuation copy exists
+        # (the global continuation row was deleted above).
+        org = KippoOrganization.objects.create(
+            name="legacy-upsell-org", github_organization_name="legacy-upsell-org", created_by=manager, updated_by=manager
+        )
+        assert category.objects.filter(organization=org, key__in=UPSELL_KEYS).count() == len(UPSELL_KEYS)
+        assert not category.objects.filter(organization=org, key="continuation").exists()
+        return org
+
+    def test_reconciles_existing_database(self):
+        org = self._simulate_pre_migration_database()
+        category = KippoProjectOrganizationCategory
+
+        retire_upsell_seed_continuation(django_apps, schema_editor=None)
+
+        # the global upsell-improvement slot is converted in-place to an active continuation row
+        global_continuation = category.objects.get(organization__isnull=True, key="continuation")
+        self.assertEqual(global_continuation.pk, GLOBAL_CONTINUATION_PK)
+        self.assertTrue(global_continuation.is_active)
+        # the org gains its own active continuation copy
+        self.assertTrue(category.objects.filter(organization=org, key="continuation", is_active=True).exists())
+        # every upsell row (global leftovers + org copies) is deactivated, not deleted
+        self.assertFalse(category.objects.filter(key__in=UPSELL_KEYS, is_active=True).exists())
+        self.assertEqual(category.objects.filter(organization=org, key__in=UPSELL_KEYS).count(), 3)
+
+    def test_idempotent_on_fresh_database(self):
+        # a fresh DB already carries the global continuation row (from the fixture) and no upsell rows
+        category = KippoProjectOrganizationCategory
+
+        retire_upsell_seed_continuation(django_apps, schema_editor=None)
+
+        self.assertEqual(category.objects.filter(organization__isnull=True, key="continuation").count(), 1)
+        self.assertFalse(category.objects.filter(key__in=UPSELL_KEYS).exists())

--- a/kippo/projects/tests/test_models.py
+++ b/kippo/projects/tests/test_models.py
@@ -10,11 +10,11 @@ from django.utils import timezone
 from tasks.models import KippoTask, KippoTaskStatus
 
 from projects.definitions import (
+    CONTINUATION_CATEGORY_VALUE,
     DEFAULT_PROJECT_CATEGORY_VALUE,
     FULL_CONFIDENCE_PERCENTAGE,
     KIPPOPROJECT_CATEGORY_CHOICES,
     NON_PROJECT_CATEGORY_VALUE,
-    UPSELL_CATEGORY_VALUES,
     VALID_KIPPOPROJECT_CATEGORY_VALUES,
 )
 from projects.models import (
@@ -641,10 +641,9 @@ class KippoProjectCategoryChoicesTestCase(TestCase):
         self.assertEqual(field.default(), other.pk)
         self.assertEqual(settings.DEFAULT_KIPPOPROJECT_CATEGORY, DEFAULT_PROJECT_CATEGORY_VALUE)
 
-    def test_upsell_category_values_present_as_global_categories(self):
-        for value in UPSELL_CATEGORY_VALUES:
-            self.assertIn(value, VALID_KIPPOPROJECT_CATEGORY_VALUES)
-            self.assertTrue(KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, key=value).exists())
+    def test_continuation_category_value_present_as_global_category(self):
+        self.assertIn(CONTINUATION_CATEGORY_VALUE, VALID_KIPPOPROJECT_CATEGORY_VALUES)
+        self.assertTrue(KippoProjectOrganizationCategory.objects.filter(organization__isnull=True, key=CONTINUATION_CATEGORY_VALUE).exists())
 
     def test_close_comment_field_defaults(self):
         field = KippoProject._meta.get_field("close_comment")

--- a/kippo/projects/tests/test_models_billing.py
+++ b/kippo/projects/tests/test_models_billing.py
@@ -817,7 +817,7 @@ class EffortProvisionalBillingTestCase(TestCase):
         )
 
     def test_provisional_amount_bills_every_month_upfront(self):
-        # no effort logged at all — every contract month (future included) still gets the 仮月額,
+        # no effort logged at all — every contract month (future included) still gets the 月額,
         # and a partial first month is NOT prorated
         contract = self._provisional_contract(datetime.date(2026, 1, 15), datetime.date(2026, 3, 31))
         self.assertEqual(
@@ -913,7 +913,7 @@ class EffortProvisionalBillingTestCase(TestCase):
         self.assertEqual([e.amount for e in contract.billing_entries.all()], [Decimal("300000")] * 3)
 
     def test_blank_provisional_amount_keeps_actuals_generation(self):
-        # backwards compatible: without 仮月額 the effort contract bills logged actuals directly
+        # backwards compatible: without 月額 the effort contract bills logged actuals directly
         self._log_effort(datetime.date(2026, 1, 5), 40)
         contract = KippoProjectContract.objects.create(
             project=self.project,


### PR DESCRIPTION
## Summary

Two changes to the `projects` app:

1. **Retire the 3 `(Upsell)` project categories** (`upsell-improvement`, `upsell-new-proposal`, `upsell-new-department`) in favor of a single **`継続` (continuation)** category. The admin close→follow-up wizard now spawns a *continuation* project instead of an *upsell* one.
2. **Rename the `KippoProjectContract.estimated_monthly_amount` label `仮月額` → `月額`** (verbose_name + validation messages).

## Changes

- `definitions.py`: drop the 3 upsell defaults + `UPSELL_CATEGORY_VALUES`; add `continuation`/`継続` to `DEFAULT_KIPPOPROJECT_CATEGORIES` and a scalar `CONTINUATION_CATEGORY_VALUE`.
- `fixtures/default_kippoprojectorganizationcategory.json`: replace the 3 upsell global rows with a single `continuation` row (reusing the former `upsell-improvement` pk so fresh/existing DBs converge).
- `admin.py`: repoint the close→follow-up wizard — `CloseProjectActionForm` (now `継続` / `継続なし`), `_build_continuation_prefill_params`, the `parent_project` requirement (now keyed on `continuation`), the plain-add category exclusion, and the `UPSELL_SOURCE_*` → `CONTINUATION_SOURCE_*` plumbing. Rename `_is_upsell_add`/`_apply_upsell_source_widgets`/`_next_upsell_project_name` accordingly.
- `models.py`: `parent_project.related_name` `upsell_children` → `continuation_children`; `estimated_monthly_amount` verbose_name `仮月額` → `月額`.
- `serializers.py`, `close_project_action.html`: matching rename.
- **Migration `0051`** (metadata-only): the two `AlterField`s above (verbose_name / help_text / related_name — no schema change).
- **Migration `0052`** (data): reconcile already-migrated databases — the fixture edit alone only covers fresh installs. It converts the global `upsell-improvement` slot to `continuation`, seeds a per-org `continuation` copy for every org that had upsell categories (copy-on-create parity, kippo#49), and **deactivates** (not deletes) the remaining upsell rows so a `PROTECT`ed reference can't fail the migration and the change stays reversible.

## Testing

- `uv run poe test projects.tests.test_admin projects.tests.test_models projects.tests.test_migrations projects.tests.test_models_billing` and the contract API tests — all green.
- New `RetireUpsellSeedContinuationTestCase` drives `0052` against a simulated pre-migration database (asserts the global-slot conversion, per-org continuation seeding, and upsell deactivation) plus an idempotency check on a fresh DB.
- `ruff check` / `ruff-format` clean.

Refs kiconiaworks/kippo (upsell retirement).