### PR TITLE
Expose billed_to_name on the contract API for display

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -246,6 +246,9 @@ class KippoProjectContractSerializer(serializers.ModelSerializer):
     """The project's contract (kippo#31) — billing terms. project is set from the nested route."""
 
     project_name = serializers.CharField(source="project.name", read_only=True)
+    # Human-readable 請求先 name for display (parity with project_name / KippoProject.customer_name), so a
+    # client can render the billed customer without a second lookup. Null when billed_to is unset.
+    billed_to_name = serializers.CharField(source="billed_to.name", read_only=True, allow_null=True)
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -260,6 +263,7 @@ class KippoProjectContractSerializer(serializers.ModelSerializer):
             "project",
             "project_name",
             "billed_to",
+            "billed_to_name",
             "billing_type",
             "pricing_basis",
             "total_amount",
@@ -271,7 +275,7 @@ class KippoProjectContractSerializer(serializers.ModelSerializer):
             "updated_datetime",
         ]
         # project comes from the URL (nested under projects/) — set in the viewset, not the payload.
-        read_only_fields = ["id", "project", "project_name", "created_datetime", "updated_datetime"]
+        read_only_fields = ["id", "project", "project_name", "billed_to_name", "created_datetime", "updated_datetime"]
 
     def validate(self, attrs: dict) -> dict:
         # DRF does not run model.clean(); mirror KippoProjectContract.clean() so the API enforces the

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -1774,6 +1774,18 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         )
         self.assertEqual(resp.status_code, HTTPStatus.CREATED, resp.content)
         self.assertEqual(resp.json()["billed_to"], str(customer.id))
+        # billed_to_name is exposed read-only for display (parity with project_name / customer_name)
+        self.assertEqual(resp.json()["billed_to_name"], "BillCo")
+
+    def test_contract_billed_to_name_null_when_unset(self):
+        # no billed_to (project has no customer to default from) → billed_to_name is null.
+        url = f"{self.base}/{self.project.id}/contract/"
+        resp = self.client.post(
+            url, {"billing_type": "delivery", "pricing_basis": "fixed", "total_amount": "1500000", "end_date": "2026-09-30"}, format="json"
+        )
+        self.assertEqual(resp.status_code, HTTPStatus.CREATED, resp.content)
+        self.assertIsNone(resp.json()["billed_to"])
+        self.assertIsNone(resp.json()["billed_to_name"])
 
     def test_contract_billed_to_from_non_member_org_rejected(self):
         # requirement 2: a customer in an org the user does not belong to is not assignable (the field


### PR DESCRIPTION
## Summary

Follow-up to #375 (which added `billed_to` / 請求先 to `KippoProjectContract`). The contract API returned `billed_to` as a bare customer UUID, so a client (kippo-ui) would need a second lookup to render the billed customer. Add a read-only **`billed_to_name`** (`source="billed_to.name"`) — matching the existing `project_name` and the project serializer's `customer_name` — so 請求先 can be displayed directly. Null when `billed_to` is unset. `drf-spectacular` documents it in the schema.

This unblocks a clean kippo-ui reflection of `billed_to` in the contract editor (display the current billed customer name without an extra customers fetch).

## Tests

`billed_to_name` returned on contract create; null when `billed_to` is unset. Full contract API suite green; ruff + `manage.py check` clean; schema regenerates with `billed_to_name`.

Refs kiconiaworks/kippo (billed-customer support).