### PR TITLE
Add flat cross-project billing list endpoint (/api/billing/)

### DIFF
--- a/kippo/commons/admin.py
+++ b/kippo/commons/admin.py
@@ -8,6 +8,8 @@ from django.db.models import Model, QuerySet
 from django.forms import BaseFormSet, Form, widgets
 from django.http import request as DjangoRequest  # noqa: N812
 
+from commons.functions import ui_url
+
 if TYPE_CHECKING:
     from accounts.models import KippoUser
 
@@ -129,7 +131,7 @@ class KippoAdminSite(admin.AdminSite):
     # update displayed header/title
     site_header = settings.SITE_HEADER
     site_title = settings.SITE_TITLE
-    site_url = f"{settings.URL_PREFIX}/ui/weekly-effort"
+    site_url = ui_url("weekly-effort")
 
     # apps pinned to the top of the admin index, in this order; remaining apps keep Django's default order
     APP_PRIORITY = ("customers", "projects")

--- a/kippo/commons/functions.py
+++ b/kippo/commons/functions.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 from calendar import monthrange
 
+from django.conf import settings
 from django.utils import timezone
 
 DECEMBER = 12
@@ -14,6 +15,16 @@ def is_uuid(value: str) -> bool:
     except (ValueError, TypeError):
         return False
     return True
+
+
+def ui_url(path: str) -> str:
+    """Absolute-or-relative URL to a kippo-ui SPA route, e.g. ``ui_url("billing?month=2026-04")``.
+
+    Prefixes ``settings.UI_BASE_URL`` (empty in production → same-origin; the Vite dev server origin
+    in local dev) + ``settings.URL_PREFIX`` + ``/ui/``. Use for every admin→UI deep-link so the
+    local-dev origin fix applies uniformly.
+    """
+    return f"{settings.UI_BASE_URL}{settings.URL_PREFIX}/ui/{path.lstrip('/')}"
 
 
 def get_current_month_date_range() -> tuple[timezone.datetime, timezone.datetime]:

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -4,9 +4,8 @@ from collections.abc import Iterator
 
 from accounts.models import KippoOrganization, KippoUser
 from commons.admin import AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin
-from commons.functions import is_uuid
+from commons.functions import is_uuid, ui_url
 from django import forms
-from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.contrib.admin.views.main import ChangeList
@@ -44,10 +43,6 @@ def _visible_organizations(user: KippoUser) -> models.QuerySet:
 
 
 def _yen(amount: object) -> str:
-    # None → "-" (e.g. an effort-priced contract has no fixed total_amount / 契約金額); mirrors the
-    # kippo-ui formatJpy convention and keeps the changelist from crashing on a NoneType format.
-    if amount is None:
-        return "-"
     return f"¥{amount:,.0f}"
 
 
@@ -321,7 +316,13 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
         contract = getattr(project, "contract", None)
         received = project_received_total_current_fy(project, fiscal_year_start)
         name_link = format_html('<a href="{}">{}</a>', project.get_admin_url(), project.name)
-        total_display = _yen(contract.total_amount) if contract else "-"
+        # Mirror get_contract_total: no contract → "-"; effort pricing (total_amount None) → 実績.
+        if not contract:
+            total_display = "-"
+        elif contract.total_amount is not None:
+            total_display = _yen(contract.total_amount)
+        else:
+            total_display = _("実績")
         end_display = contract.end_date.isoformat() if contract and contract.end_date else "-"
         return (name_link, _yen(received), total_display, end_display)
 
@@ -354,9 +355,8 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
                         "month": row["month"],
                         "amount_display": _yen(row["amount"]),
                         # Deep-link into the kippo-ui プロジェクト請求一覧, pre-filtered to this month
-                        # (row["month"] is "YYYY/MM"; the UI's ?month= expects "YYYY-MM"). UI_BASE_URL is
-                        # empty in prod (same-origin) and the Vite dev server origin in local dev.
-                        "url": f"{settings.UI_BASE_URL}{settings.URL_PREFIX}/ui/billing?month={row['month'].replace('/', '-')}",
+                        # (row["month"] is "YYYY/MM"; the UI's ?month= expects "YYYY-MM").
+                        "url": ui_url(f"billing?month={row['month'].replace('/', '-')}"),
                     }
                     for row in summary["monthly_planned_breakdown"]
                 ],

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -6,6 +6,7 @@ from accounts.models import KippoOrganization, KippoUser
 from commons.admin import AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin
 from commons.functions import is_uuid
 from django import forms
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.utils import unquote
 from django.contrib.admin.views.main import ChangeList
@@ -345,7 +346,14 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
                 "received_total_display": _yen(summary["received_total"]),
                 "planned_total_display": _yen(summary["planned_total"]),
                 "monthly_planned_breakdown": [
-                    {"month": row["month"], "amount_display": _yen(row["amount"])} for row in summary["monthly_planned_breakdown"]
+                    {
+                        "month": row["month"],
+                        "amount_display": _yen(row["amount"]),
+                        # Deep-link into the kippo-ui プロジェクト請求一覧, pre-filtered to this month
+                        # (row["month"] is "YYYY/MM"; the UI's ?month= expects "YYYY-MM").
+                        "url": f"{settings.URL_PREFIX}/ui/billing?month={row['month'].replace('/', '-')}",
+                    }
+                    for row in summary["monthly_planned_breakdown"]
                 ],
             }
             for summary in fiscal_year_org_summaries(customers)

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -354,8 +354,9 @@ class KippoCustomerAdmin(AllowIsStaffAdminMixin, UserCreatedBaseModelAdmin):
                         "month": row["month"],
                         "amount_display": _yen(row["amount"]),
                         # Deep-link into the kippo-ui プロジェクト請求一覧, pre-filtered to this month
-                        # (row["month"] is "YYYY/MM"; the UI's ?month= expects "YYYY-MM").
-                        "url": f"{settings.URL_PREFIX}/ui/billing?month={row['month'].replace('/', '-')}",
+                        # (row["month"] is "YYYY/MM"; the UI's ?month= expects "YYYY-MM"). UI_BASE_URL is
+                        # empty in prod (same-origin) and the Vite dev server origin in local dev.
+                        "url": f"{settings.UI_BASE_URL}{settings.URL_PREFIX}/ui/billing?month={row['month'].replace('/', '-')}",
                     }
                     for row in summary["monthly_planned_breakdown"]
                 ],

--- a/kippo/customers/admin.py
+++ b/kippo/customers/admin.py
@@ -44,6 +44,10 @@ def _visible_organizations(user: KippoUser) -> models.QuerySet:
 
 
 def _yen(amount: object) -> str:
+    # None → "-" (e.g. an effort-priced contract has no fixed total_amount / 契約金額); mirrors the
+    # kippo-ui formatJpy convention and keeps the changelist from crashing on a NoneType format.
+    if amount is None:
+        return "-"
     return f"¥{amount:,.0f}"
 
 

--- a/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
+++ b/kippo/customers/templates/admin/customers/kippocustomer/change_list.html
@@ -36,13 +36,13 @@
     <thead>
       <tr>
         <th>{{ summary.organization }}</th>
-        {% for month in summary.monthly_planned_breakdown %}<th style="text-align:right">{{ month.month }}</th>{% endfor %}
+        {% for month in summary.monthly_planned_breakdown %}<th style="text-align:right"><a href="{{ month.url }}" title="{{ month.month }} のプロジェクト請求一覧を開く">{{ month.month }}</a></th>{% endfor %}
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>契約予定</td>
-        {% for month in summary.monthly_planned_breakdown %}<td style="text-align:right">{{ month.amount_display }}</td>{% endfor %}
+        {% for month in summary.monthly_planned_breakdown %}<td style="text-align:right"><a href="{{ month.url }}" title="{{ month.month }} のプロジェクト請求一覧を開く">{{ month.amount_display }}</a></td>{% endfor %}
       </tr>
     </tbody>
   </table>

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -452,8 +452,11 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
             updated_by=self.github_manager,
         )
         response = self.client.get(reverse("admin:customers_kippocustomer_changelist"))
+        content = response.content.decode()
         self.assertEqual(response.status_code, 200)  # no NoneType-format crash
-        self.assertIn("effort-tm", response.content.decode())
+        self.assertIn("effort-tm", content)
+        # effort contract → 契約金額 renders 実績 (matching get_contract_total), not "-"
+        self.assertIn("実績", content)
 
     def test_fiscal_year_summary_is_filter_aware(self):
         from decimal import Decimal

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -429,6 +429,32 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertEqual(march_row["url"], f"{settings.URL_PREFIX}/ui/billing?month={today.year}-03")
         self.assertIn(f"/ui/billing?month={today.year}-03", response.content.decode())  # link rendered in the chart
 
+    def test_changelist_active_project_detail_effort_contract_no_total(self):
+        # Regression: an effort-priced contract has total_amount=None; the active-project detail row
+        # (get_active_project_count → _active_project_row) must render "-" for 契約金額 instead of
+        # crashing on a NoneType format ("unsupported format string passed to NoneType.__format__").
+        from decimal import Decimal
+
+        from django.utils import timezone
+        from projects.models import KippoProjectContract
+
+        today = timezone.localdate()
+        project = self._make_customer_project("effort-tm", self.customer, date(today.year, 9, 30))
+        KippoProjectContract.objects.create(
+            project=project,
+            billing_type="monthly",
+            pricing_basis="effort",
+            total_amount=None,
+            estimated_monthly_amount=Decimal("500000"),
+            start_date=date(today.year, 7, 1),
+            end_date=date(today.year, 9, 30),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        response = self.client.get(reverse("admin:customers_kippocustomer_changelist"))
+        self.assertEqual(response.status_code, 200)  # no NoneType-format crash
+        self.assertIn("effort-tm", response.content.decode())
+
     def test_fiscal_year_summary_is_filter_aware(self):
         from decimal import Decimal
 

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -426,7 +426,7 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         from django.conf import settings
 
         march_row = next(row for row in summary["monthly_planned_breakdown"] if row["month"] == f"{today.year}/03")
-        self.assertEqual(march_row["url"], f"{settings.URL_PREFIX}/ui/billing?month={today.year}-03")
+        self.assertEqual(march_row["url"], f"{settings.UI_BASE_URL}{settings.URL_PREFIX}/ui/billing?month={today.year}-03")
         self.assertIn(f"/ui/billing?month={today.year}-03", response.content.decode())  # link rendered in the chart
 
     def test_changelist_active_project_detail_effort_contract_no_total(self):

--- a/kippo/customers/tests/test_admin.py
+++ b/kippo/customers/tests/test_admin.py
@@ -422,6 +422,13 @@ class KippoCustomerAdminProjectsInlineTestCase(KippoProjectAdminFixtureTestCaseB
         self.assertEqual(breakdown[f"{today.year}/01"], "¥0")  # months with no billing → 0
         self.assertIn("月別契約予定合計", response.content.decode())  # monthly header block rendered
 
+        # each month cell deep-links into the kippo-ui プロジェクト請求一覧 filtered to that month (?month=YYYY-MM)
+        from django.conf import settings
+
+        march_row = next(row for row in summary["monthly_planned_breakdown"] if row["month"] == f"{today.year}/03")
+        self.assertEqual(march_row["url"], f"{settings.URL_PREFIX}/ui/billing?month={today.year}-03")
+        self.assertIn(f"/ui/billing?month={today.year}-03", response.content.decode())  # link rendered in the chart
+
     def test_fiscal_year_summary_is_filter_aware(self):
         from decimal import Decimal
 

--- a/kippo/kippo/settings.py
+++ b/kippo/kippo/settings.py
@@ -217,6 +217,13 @@ URL_PREFIX = os.getenv("URL_PREFIX", DEFAULT_URL_PREFIX)
 if URL_PREFIX and not URL_PREFIX.startswith("/"):
     URL_PREFIX = f"/{URL_PREFIX}"
 STATIC_URL = f"{URL_PREFIX}/static/"
+
+# Absolute origin of the kippo-ui SPA, used to build admin→UI deep-links (e.g. the KippoCustomerAdmin
+# per-month chart → プロジェクト請求一覧). Empty in production, where the SPA is same-origin under
+# {URL_PREFIX}/ui/ (a relative link is correct). For local development set UI_BASE_URL to the Vite dev
+# server (http://localhost:5173) — Django's own /ui/ serves a *production* bundle whose assets 404
+# locally, so a same-origin link would hang on the loading shell.
+UI_BASE_URL = os.getenv("UI_BASE_URL", "").rstrip("/")
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # UI static files source directory (populated by 'update_ui' management command)

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -360,6 +360,7 @@ class BillingListEntrySerializer(serializers.ModelSerializer):
     billing_type = serializers.CharField(source="contract.billing_type", read_only=True)
     pricing_basis = serializers.CharField(source="contract.pricing_basis", read_only=True)
     contract_total_amount = serializers.DecimalField(source="contract.total_amount", max_digits=12, decimal_places=0, read_only=True, allow_null=True)
+    contract_end_date = serializers.DateField(source="contract.end_date", read_only=True, allow_null=True)
     received_by_username = serializers.CharField(source="received_by.username", read_only=True, allow_null=True)
 
     class Meta:
@@ -383,6 +384,7 @@ class BillingListEntrySerializer(serializers.ModelSerializer):
             "billing_type",
             "pricing_basis",
             "contract_total_amount",
+            "contract_end_date",
         ]
         read_only_fields = fields
 

--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -340,6 +340,53 @@ class KippoProjectBillingEntrySerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "contract", "received_datetime", "received_by", "created_datetime", "updated_datetime"]
 
 
+class BillingListEntrySerializer(serializers.ModelSerializer):
+    """Flat, read-only billing-ledger row for the cross-project 請求一覧 (billing list) UI.
+
+    One row per ``KippoProjectBillingEntry``, denormalized with the project / contract / customer
+    display fields the 請求一覧 needs so the UI can render, filter and sum without a second lookup
+    per row. Read-only — the ledger is edited through the nested per-project billing-entries endpoint.
+    """
+
+    project_id = serializers.UUIDField(source="contract.project.id", read_only=True)
+    project_name = serializers.CharField(source="contract.project.name", read_only=True)
+    organization_name = serializers.CharField(source="contract.project.organization.name", read_only=True)
+    project_phase = serializers.CharField(source="contract.project.phase", read_only=True)
+    project_actual_date = serializers.DateField(source="contract.project.actual_date", read_only=True, allow_null=True)
+    # 請求先: the contract's billed_to (may be null if later cleared); customer_name is the project's
+    # 顧客 fallback so the UI can render a 請求先 even when billed_to is unset.
+    billed_to_name = serializers.CharField(source="contract.billed_to.name", read_only=True, allow_null=True)
+    customer_name = serializers.CharField(source="contract.project.customer.name", read_only=True, allow_null=True)
+    billing_type = serializers.CharField(source="contract.billing_type", read_only=True)
+    pricing_basis = serializers.CharField(source="contract.pricing_basis", read_only=True)
+    contract_total_amount = serializers.DecimalField(source="contract.total_amount", max_digits=12, decimal_places=0, read_only=True, allow_null=True)
+    received_by_username = serializers.CharField(source="received_by.username", read_only=True, allow_null=True)
+
+    class Meta:
+        model = KippoProjectBillingEntry
+        fields = [
+            "id",
+            "billing_date",
+            "amount",
+            "is_manual",
+            "is_received",
+            "received_datetime",
+            "received_by_username",
+            "note",
+            "project_id",
+            "project_name",
+            "organization_name",
+            "project_phase",
+            "project_actual_date",
+            "billed_to_name",
+            "customer_name",
+            "billing_type",
+            "pricing_basis",
+            "contract_total_amount",
+        ]
+        read_only_fields = fields
+
+
 @extend_schema_field(OpenApiTypes.STR)
 class ProjectCategoryKeyField(serializers.Field):
     """Read/write the KippoProject.category as its KEY string.

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -17,6 +17,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from ..models import (
     PHASE_CONFIDENCE,
     KippoProject,
+    KippoProjectBillingEntry,
     KippoProjectContract,
     KippoProjectOrganizationCategory,
     KippoProjectStatus,
@@ -27,6 +28,7 @@ from ..models import (
 
 if TYPE_CHECKING:
     from customers.models import KippoCustomer
+    from rest_framework.response import Response
 
 
 def _registration_fields(organization: KippoOrganization, project_manager: KippoUser) -> dict:
@@ -2029,6 +2031,124 @@ class ContractAndBillingEntryAPITestCase(TestCase):
         # same (contract, billing_date) → clean 400 (the unique constraint would otherwise 500)
         dup = self.client.post(url, {"billing_date": "2026-09-30", "amount": "5"}, format="json")
         self.assertEqual(dup.status_code, HTTPStatus.BAD_REQUEST)
+
+
+class BillingListAPITestCase(TestCase):
+    """Flat cross-project billing list endpoint (/api/billing/) backing the 請求一覧 UI."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        from customers.models import KippoCustomer
+
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.user = created["KippoUser"]
+        self.project = created["KippoProject"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+
+        self.customer = KippoCustomer.objects.create(organization=self.organization, name="BillCo", created_by=self.user, updated_by=self.user)
+        # fixed + monthly over 2026-07..2026-09 → auto-generates 3 month-end entries (7/31, 8/31, 9/30).
+        self.contract = KippoProjectContract.objects.create(
+            project=self.project,
+            billed_to=self.customer,
+            billing_type="monthly",
+            pricing_basis="fixed",
+            total_amount=3000000,
+            start_date=datetime.date(2026, 7, 1),
+            end_date=datetime.date(2026, 9, 30),
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        # project + contract in an org the user does NOT belong to (scoping check). delivery+fixed →
+        # a single entry at end_date (2026-08-31).
+        self.other_org = KippoOrganization.objects.create(
+            name="billing-other-org",
+            github_organization_name="billing-other-org",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.other_project = KippoProject.objects.create(
+            name="Other Project",
+            organization=self.other_org,
+            columnset=self.project.columnset,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        KippoProjectContract.objects.create(
+            project=self.other_project,
+            billing_type="delivery",
+            pricing_basis="fixed",
+            total_amount=9000000,
+            start_date=datetime.date(2026, 7, 1),
+            end_date=datetime.date(2026, 8, 31),
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.base = f"{settings.URL_PREFIX}/api/billing/"
+
+    @staticmethod
+    def _results(resp: "Response") -> list:
+        data = resp.json()
+        return data["results"] if isinstance(data, dict) else data
+
+    def test_lists_accessible_rows_denormalized(self):
+        # sanity: 3 (self.project monthly) + 1 (other_project delivery) exist in the DB
+        self.assertEqual(KippoProjectBillingEntry.objects.count(), 4)
+        resp = self.client.get(self.base)
+        self.assertEqual(resp.status_code, HTTPStatus.OK, resp.content)
+        results = self._results(resp)
+        # only self.project's 3 entries — the other org's entry is filtered out (org-scoped)
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all(r["project_name"] == self.project.name for r in results))
+        row = results[0]
+        self.assertEqual(row["billed_to_name"], "BillCo")
+        self.assertEqual(row["billing_type"], "monthly")
+        self.assertEqual(row["pricing_basis"], "fixed")
+        self.assertEqual(row["organization_name"], self.organization.name)
+        self.assertIn("amount", row)
+
+    def test_month_filter(self):
+        results = self._results(self.client.get(self.base, {"month": "2026-08"}))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["billing_date"], "2026-08-31")
+
+    def test_date_range_filter(self):
+        results = self._results(self.client.get(self.base, {"from": "2026-08-01", "to": "2026-09-30"}))
+        self.assertEqual({r["billing_date"] for r in results}, {"2026-08-31", "2026-09-30"})
+
+    def test_project_filter(self):
+        results = self._results(self.client.get(self.base, {"project": str(self.project.id)}))
+        self.assertEqual(len(results), 3)
+
+    def test_bad_month_format_rejected(self):
+        resp = self.client.get(self.base, {"month": "2026/07"})
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("month", resp.json())
+
+    def test_bad_date_format_rejected(self):
+        resp = self.client.get(self.base, {"from": "07-01-2026"})
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("from", resp.json())
+
+    def test_superuser_sees_all_orgs(self):
+        self.user.is_superuser = True
+        self.user.save()
+        results = self._results(self.client.get(self.base))
+        self.assertEqual(len(results), 4)
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        resp = self.client.get(self.base)
+        self.assertIn(resp.status_code, (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))
+
+    def test_is_read_only(self):
+        resp = self.client.post(self.base, {}, format="json")
+        self.assertEqual(resp.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
 
 
 class KippoProjectListQueryCountTestCase(TestCase):

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -2136,6 +2136,12 @@ class BillingListAPITestCase(TestCase):
         self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
         self.assertIn("from", resp.json())
 
+    def test_bad_project_format_rejected(self):
+        # a malformed project UUID must 400 (like month/from/to), not 500 on the UUIDField lookup
+        resp = self.client.get(self.base, {"project": "notauuid"})
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("project", resp.json())
+
     def test_superuser_sees_all_orgs(self):
         self.user.is_superuser = True
         self.user.save()

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -2110,6 +2110,7 @@ class BillingListAPITestCase(TestCase):
         self.assertEqual(row["billing_type"], "monthly")
         self.assertEqual(row["pricing_basis"], "fixed")
         self.assertEqual(row["organization_name"], self.organization.name)
+        self.assertEqual(row["contract_end_date"], "2026-09-30")
         self.assertIn("amount", row)
 
     def test_month_filter(self):

--- a/kippo/projects/urls.py
+++ b/kippo/projects/urls.py
@@ -15,6 +15,7 @@ from .views import (
     WeeklyEffortMissingWeeksView,
 )
 from .viewsets import (
+    BillingEntryListViewSet,
     KippoProjectBillingEntryViewSet,
     KippoProjectContractViewSet,
     KippoProjectOrganizationCategoryViewSet,
@@ -39,6 +40,9 @@ router.register(r"personal-holidays", PersonalHolidayViewSet, basename="personal
 router.register(r"public-holidays", PublicHolidayViewSet, basename="publicholiday")
 router.register(r"organizations", OrganizationViewSet, basename="kippoorganization")
 router.register(r"weekly-effort-unlocks", ProjectWeeklyEffortUnlockViewSet, basename="projectweeklyeffortunlock")
+# Flat cross-project billing ledger for the 請求一覧 (billing list) UI — read-only, org-scoped.
+# /api/billing/  (per-project ledger writes stay on projects/{pk}/billing-entries/)
+router.register(r"billing", BillingEntryListViewSet, basename="billing")
 
 # Contract + billing-entries nested under projects/ (kippo#31) — read+write, org-scoped.
 # /api/projects/{project_pk}/contract/ and /api/projects/{project_pk}/billing-entries/

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from typing import Any
 
 from accounts.models import KippoUser
+from commons.functions import is_uuid
 from commons.viewsets import OrganizationFilterMixin, organization_ids_for_user
 from django.conf import settings
 from django.db.models import Exists, OuterRef, Prefetch, QuerySet, Sum
@@ -903,6 +904,8 @@ class BillingEntryListViewSet(OrganizationFilterMixin, viewsets.ReadOnlyModelVie
             queryset = queryset.filter(billing_date__lte=self._parse_date(date_to, "to"))
         project_id = params.get("project")
         if project_id:
+            if not is_uuid(project_id):
+                raise ValidationError({"project": "Expected a project UUID."})
             queryset = queryset.filter(contract__project_id=project_id)
         return queryset
 

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -38,6 +38,7 @@ from .models import (
 )
 from .permissions import IsSuperuserOrOrgMemberForCategory, IsSuperuserOrOwnOrgReadUpdateCreate, IsSuperuserOrReadUpdateCreateOwn
 from .serializers import (
+    BillingListEntrySerializer,
     KippoProjectBillingEntrySerializer,
     KippoProjectContractSerializer,
     KippoProjectOrganizationCategorySerializer,
@@ -843,6 +844,67 @@ class KippoProjectBillingEntryViewSet(viewsets.ModelViewSet):
         is_received = serializer.validated_data.get("is_received", serializer.instance.is_received)
         received_by = self.request.user if is_received and not serializer.instance.received_by else serializer.instance.received_by
         serializer.save(received_by=received_by, updated_by=self.request.user)
+
+
+@extend_schema(
+    parameters=[
+        OpenApiParameter("month", str, description="Filter to a single billing month, format YYYY-MM (e.g. 2026-07)."),
+        OpenApiParameter("from", str, description="Filter to billing_date on/after this date, format YYYY-MM-DD."),
+        OpenApiParameter("to", str, description="Filter to billing_date on/before this date, format YYYY-MM-DD."),
+        OpenApiParameter("project", str, description="Filter to a single project (UUID)."),
+    ]
+)
+class BillingEntryListViewSet(OrganizationFilterMixin, viewsets.ReadOnlyModelViewSet):
+    """Flat, cross-project billing ledger for the 請求一覧 (billing list) UI — read-only.
+
+    One row per ``KippoProjectBillingEntry`` across the request user's accessible projects
+    (superusers see all), denormalized with its project / contract / customer display fields via
+    ``BillingListEntrySerializer``. Org-scoped through the contract's project organization. Supports
+    ``month`` / ``from`` / ``to`` / ``project`` server-side filtering to bound the window; the UI does
+    its own free-text search, 完了 toggle and summation client-side over the returned rows.
+    """
+
+    serializer_class = BillingListEntrySerializer
+    permission_classes = [IsAuthenticated]
+    organization_lookup = "contract__project__organization"
+    queryset = (
+        KippoProjectBillingEntry.objects.all()
+        .select_related(
+            "contract__project__organization",
+            "contract__project__customer",
+            "contract__billed_to",
+            "received_by",
+        )
+        .order_by("-billing_date", "contract__project__name")
+    )
+
+    @staticmethod
+    def _parse_date(value: str, field: str) -> datetime.date:
+        try:
+            return datetime.date.fromisoformat(value)
+        except ValueError as e:
+            raise ValidationError({field: "Expected date format YYYY-MM-DD."}) from e
+
+    def get_queryset(self):
+        queryset = self.filter_by_organization(super().get_queryset())
+        params = self.request.query_params
+        month = params.get("month")
+        if month:
+            try:
+                month_start = datetime.datetime.strptime(month, "%Y-%m").date()  # noqa: DTZ007
+            except ValueError as e:
+                raise ValidationError({"month": "Expected format YYYY-MM."}) from e
+            queryset = queryset.filter(billing_date__year=month_start.year, billing_date__month=month_start.month)
+        date_from = params.get("from")
+        if date_from:
+            queryset = queryset.filter(billing_date__gte=self._parse_date(date_from, "from"))
+        date_to = params.get("to")
+        if date_to:
+            queryset = queryset.filter(billing_date__lte=self._parse_date(date_to, "to"))
+        project_id = params.get("project")
+        if project_id:
+            queryset = queryset.filter(contract__project_id=project_id)
+        return queryset
 
 
 class ProjectMonthlyAssignmentViewSet(OrganizationFilterMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary

Adds a flat, read-only, org-scoped **`GET /api/billing/`** endpoint that returns every billing-ledger row across the caller's accessible projects in one call. This backs a new kippo-ui **請求一覧 (billing list)** view (separate PR on `monkut/kippo-ui`).

The existing ledger endpoint is per-project only (`projects/{pk}/billing-entries/`), so a cross-project list would need N fan-out calls and couldn't sum server-side. This adds the one endpoint that view needs.

## Changes

- **`BillingListEntrySerializer`** — read-only, one row per `KippoProjectBillingEntry`, denormalized with the display fields the list needs: `project_name`, `organization_name`, `project_phase`, `project_actual_date`, `billed_to_name` (請求先), `customer_name` fallback, `billing_type` (請求方法), `pricing_basis` (料金体系), `contract_total_amount` (契約金額), `received_by_username`.
- **`BillingEntryListViewSet`** — `ReadOnlyModelViewSet`, `IsAuthenticated`, org-scoped via `OrganizationFilterMixin(organization_lookup="contract__project__organization")`, `select_related` for a constant query count. Server-side `?month=YYYY-MM` / `?from=` / `?to=` / `?project=` filters bound the window; the UI does free-text search, a 完了 toggle and summation client-side.
- Registered on the flat router at **`/api/billing/`**. Per-project ledger writes stay on `projects/{pk}/billing-entries/`.

## Tests

`BillingListAPITestCase` (9 tests): denormalized listing, org-scoping (other-org rows excluded), month / date-range / project filters, malformed `month`/`from` → 400, superuser-sees-all, auth-required (401/403), read-only (POST → 405). Full `projects` suite + `ruff check`/`format` green.

Refs kiconiaworks/kippo billing-list work.