### PR TITLE
Exclude (unassigned) from weekly-effort close reminder; add entry-UI link

### DIFF
--- a/kippo/projects/services/weekly_effort_reminder.py
+++ b/kippo/projects/services/weekly_effort_reminder.py
@@ -69,7 +69,11 @@ class WeeklyEffortCloseReminderManager:
                 "user_id", "week_start"
             )
         )
-        memberships = OrganizationMembership.objects.filter(organization=self.organization, is_developer=True).select_related("user")
+        memberships = (
+            OrganizationMembership.objects.filter(organization=self.organization, is_developer=True)
+            .exclude(user__username__startswith=settings.UNASSIGNED_USER_GITHUB_LOGIN_PREFIX)  # 組織の (unassigned) 番人ユーザは対象外
+            .select_related("user")
+        )
         results = []
         for membership in memberships:
             missing = [week_start for week_start in week_starts if (membership.user_id, week_start) not in logged]
@@ -98,9 +102,12 @@ class WeeklyEffortCloseReminderManager:
         for membership, missing in missing_by_member:
             weeks = "、".join(week_start.strftime("%-m月%-d日週") for week_start in missing)
             lines.append(f"• {self._mention(membership)}: {weeks}")
+        # 入力画面への絶対URL。Slack はリンクを解決できないため HOST_URL (デプロイ先オリジン) を使う (ui_url は prod で相対パス)。
+        weekly_effort_url = f"{settings.HOST_URL}{settings.URL_PREFIX}/ui/weekly-effort"
         return [
             {"type": "section", "text": {"type": "mrkdwn", "text": header}},
             {"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": f":memo: <{weekly_effort_url}|週間稼働の入力はこちら>"}},
         ]
 
     def post(self, within: datetime.timedelta = DEFAULT_REMINDER_WINDOW) -> list[dict] | None:

--- a/kippo/projects/tests/test_weekly_effort_close.py
+++ b/kippo/projects/tests/test_weekly_effort_close.py
@@ -490,6 +490,14 @@ class WeeklyEffortCloseReminderTestCase(WeeklyEffortCloseTestCaseBase):
         self.assertNotIn(datetime.date(2024, 4, 8), missing_map[self.user.pk])
 
     @freeze_time(WITHIN_WINDOW)
+    def test_get_missing_by_member__excludes_unassigned_user(self):
+        # the org's auto-created (unassigned) sentinel is is_developer=True but must not be reminded
+        unassigned = self.organization.get_unassigned_kippouser()
+        user_ids = {m.user_id for m, _ in self._manager().get_missing_by_member(datetime.date(2024, 4, 1))}
+        self.assertIn(self.user.pk, user_ids)
+        self.assertNotIn(unassigned.pk, user_ids)
+
+    @freeze_time(WITHIN_WINDOW)
     def test_post__mentions_missing_member_in_org_channel(self):
         manager = self._manager()
         blocks = manager.post()
@@ -500,6 +508,7 @@ class WeeklyEffortCloseReminderTestCase(WeeklyEffortCloseTestCaseBase):
         text = json.dumps(blocks, ensure_ascii=False)
         self.assertIn("<@U12345678>", text)  # @-mention via slack_user_id
         self.assertIn("4月1日週", text)  # per-week gap listed
+        self.assertIn(f"{settings.HOST_URL}{settings.URL_PREFIX}/ui/weekly-effort", text)  # entry-UI deep link
 
     @freeze_time(OUTSIDE_WINDOW)
     def test_post__no_post_outside_window(self):


### PR DESCRIPTION
## Summary

Two improvements to the weekly-effort close Slack reminder (`projects/services/weekly_effort_reminder.py`):

1. **Exclude the `(unassigned)` sentinel user** from the reminder list. Each org's auto-created unassigned user is created with `is_developer=True`, so it was swept into the `get_missing_by_member` query and appeared (as `unassigned-<slug>`) in the reminder. Now excluded via the same `username__startswith=UNASSIGNED_USER_GITHUB_LOGIN_PREFIX` match that `KippoOrganization.get_unassigned_kippouser` uses.

2. **Add a deep-link to the weekly-effort entry UI** as a third Slack block (`📝 週間稼働の入力はこちら`), so reminded members can jump straight to input. Built from `HOST_URL` + `URL_PREFIX` (the deployed origin, same pattern as `WEBHOOK_URL`) rather than `ui_url()`, because `ui_url()` yields a *relative* path in production (empty `UI_BASE_URL`) that Slack cannot resolve.

## Tests

- New `test_get_missing_by_member__excludes_unassigned_user` asserting the sentinel is absent and a real developer is present.
- Extended `test_post__mentions_missing_member_in_org_channel` to assert the entry-UI link is in the posted blocks.
- Full `WeeklyEffortCloseReminderTestCase`: 6/6 pass. `ruff check` + `ruff format --check` clean.

## Deploy note

The link renders correctly only if `HOST_URL` is set to the API-Gateway origin in the prod Lambda env (it defaults to `http://127.0.0.1`). `WEBHOOK_URL` already depends on this, so it should already be set.

Refs kiconiaworks/kippo#3