### PR TITLE
Fix duplicate categories in KippoProject /add/ category select

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -1557,9 +1557,9 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         # customer: scope queryset to the project's organization (on change) or the user's orgs (on add).
         self._scope_customer_queryset(form, obj, user_memberships)
 
-        # category: scope to the project's organization (on change) or the user's orgs (on add) so the
-        # select never lists other organizations' categories.
-        self._scope_category_queryset(form, obj, user_memberships)
+        # category: scope to the project's organization (on change) or the preselected session
+        # organization (on add) so the select never lists other organizations' categories.
+        self._scope_category_queryset(form, obj, user_initial_organization)
 
         # On /add/ the model default is a GLOBAL template row, which the org-scoped queryset above drops;
         # pre-select the initial organization's OWN default category so the required field renders selected
@@ -1591,20 +1591,25 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
             form.base_fields["customer"].queryset = KippoCustomer.objects.filter(organization__in=user_memberships)
 
     @staticmethod
-    def _scope_category_queryset(form: Form, obj: KippoProject | None, user_memberships: models.QuerySet) -> None:
-        """Scope the category select to the project's organization (or the user's orgs on /add/).
+    def _scope_category_queryset(form: Form, obj: KippoProject | None, add_organization: "KippoOrganization | None") -> None:
+        """Scope the category select to the project's organization (change) or the preselected /add/ org.
 
         Narrows the queryset already built by formfield_for_foreignkey. On the change form the currently-
         selected category is always kept selectable — even a legacy global (organization=null) row — so an
-        edit can never silently drop it.
+        edit can never silently drop it. On /add/ the select is scoped to the single session organization
+        (the one preselected in the 組織 field), NOT to every organization the user belongs to: each org
+        owns its own identical-label copy of the default category set (kippo#49), so scoping to all
+        memberships rendered the same labels once per org — the duplicates in the カテゴリ dropdown.
         """
         if "category" not in form.base_fields:
             return
         queryset = form.base_fields["category"].queryset
         if obj is not None and obj.organization_id:
             form.base_fields["category"].queryset = queryset.filter(models.Q(organization=obj.organization) | models.Q(pk=obj.category_id))
+        elif add_organization is not None:
+            form.base_fields["category"].queryset = queryset.filter(organization=add_organization)
         else:
-            form.base_fields["category"].queryset = queryset.filter(organization__in=user_memberships)
+            form.base_fields["category"].queryset = queryset.none()
 
     @staticmethod
     def _apply_continuation_source_widgets(form: Form, user_memberships: models.QuerySet) -> None:

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -908,6 +908,28 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(str(field.initial), str(default_category.pk))
         self.assertIn(default_category.pk, set(field.queryset.values_list("pk", flat=True)))
 
+    def test_add_form_category_scoped_to_session_org_not_all_memberships(self):
+        # regression: a user in multiple orgs must see ONLY the session org's categories on /add/.
+        # Each org owns an identical-label copy of the default set (kippo#49), so scoping to every
+        # membership rendered the same labels once per org — duplicates in the カテゴリ dropdown.
+        OrganizationMembership.objects.create(
+            user=self.superuser_no_org,
+            organization=self.other_organization,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        session = self.client.session
+        session["organization_id"] = str(self.organization.id)
+        session.save()
+        url = reverse("admin:projects_kippoproject_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        queryset = response.context["adminform"].form.fields["category"].queryset
+        org_ids = set(queryset.values_list("organization_id", flat=True))
+        self.assertEqual(org_ids, {self.organization.id}, f"category select leaked other membership orgs: {org_ids}")
+        labels = list(queryset.values_list("label", flat=True))
+        self.assertEqual(len(labels), len(set(labels)), f"duplicate category labels in select: {labels}")
+
     def test_change_form_category_scoped_to_project_organization(self):
         # editing a project must only offer that project's organization's categories
         other_org_category = KippoProjectOrganizationCategory.objects.filter(organization=self.other_organization).first()


### PR DESCRIPTION
## Problem

On the KippoProject **/add/** (create) screen, the カテゴリ (category) select displayed **duplicate** entries for multi-organization users — the same label (「その他」「受託」 etc.) appeared once per organization the user belongs to.

## Root cause

`KippoProjectAdmin._scope_category_queryset` scoped the `/add/` category queryset to `organization__in=user_memberships` — **every** org the user is a member of. Under copy-on-create (kippo#49) each organization owns its own identical-label copy of the default category set, so a user in more than one org saw each label repeated per org.

The `/add/` form already preselects a single **session organization** (the 組織 field's `initial`, and the default category via `get_default_for_organization`), so listing categories from all memberships was both duplicated and inconsistent with the preselected org.

## Fix

- `get_form` passes `user_initial_organization` (the session org) to `_scope_category_queryset` instead of `user_memberships`.
- `_scope_category_queryset` scopes the `/add/` category queryset to that single org (`organization=add_organization`), falling back to `.none()` when the user has no org (preserving prior empty-result behavior). The change-form branch (scope to the project's org, keep the selected row selectable) is unchanged.

## Tests

Added `test_add_form_category_scoped_to_session_org_not_all_memberships`: gives the acting user a second org membership, pins the session to the primary org, and asserts the select shows only the session org's categories **with no duplicate labels**. Fails on the old code, passes on the fix.

`projects.tests.test_admin.CloseProjectActionTestCase` — 22 passed (incl. existing single-org and change-form scoping tests). `ruff` clean.

Refs kiconiaworks/kippo

🤖 Generated with [Claude Code](https://claude.com/claude-code)