### PR TITLE
Add lead_source to project add form; couple completed-phase to close flow

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -69,6 +69,7 @@ from .functions import (
 )
 from .models import (
     _COMPUTE,
+    PHASE_COMPLETED,
     PHASE_CONFIDENCE,
     ActiveKippoProject,
     CollectIssuesAction,
@@ -800,6 +801,9 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
         if form.is_valid():
             follow_up = form.cleaned_data["follow_up"]
             project.close_comment = form.cleaned_data["close_comment"]
+            # A closed project is delivered — stamp the 完了 phase (idempotent; save() re-derives
+            # confidence only when the phase actually changes).
+            project.phase = PHASE_COMPLETED
             project.is_closed = True
             project.actual_date = timezone.now().date()
             project.display_as_active = False
@@ -1087,9 +1091,10 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         KippoProjectStatusAdminInline,
     )
     # /add/ form (kippo#41, slimmed for the contract-driven flow): flat, no sections — registration
-    # collects only these fields; everything else (contract, PM, estimates, …) is added on a later
-    # edit. The continuation close-wizard add (?_continuation_source=close) instead gets the full sectioned
-    # form (see get_fieldsets) so its prefilled optional fields (parent_project, lead_source, slack, …) render.
+    # collects only these fields (the required set plus the optional lead_source); everything else
+    # (contract, PM, estimates, …) is added on a later edit. The continuation close-wizard add
+    # (?_continuation_source=close) instead gets the full sectioned form (see get_fieldsets) so its
+    # prefilled optional fields (parent_project, lead_source, slack, …) render.
     ADD_FIELDS = (
         "organization",
         "customer",
@@ -1097,6 +1102,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         "start_date",
         "phase",
         "category",
+        "lead_source",
     )
     # Shared base columns. KippoProjectAdmin appends display_as_active (it lists closed/inactive
     # projects too); the active admin uses this set as-is.
@@ -1744,9 +1750,18 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         return self._redirect_back_after_save(request, super().response_add(request, obj, post_url_continue))
 
     def response_change(self, request: DjangoRequest, obj: KippoProject):
+        # Manually flipping an open project's phase to 完了 routes into the close wizard so closure
+        # fields (comment / continuation) are captured. The change itself is already saved; the wizard
+        # is the offer to finish closing (set in save_model).
+        if getattr(request, "_phase_changed_to_completed", False):
+            return close_kippoproject_action(self, request, KippoProject.objects.filter(pk=obj.pk))
         return self._redirect_back_after_save(request, super().response_change(request, obj))
 
     def save_model(self, request: DjangoRequest, obj: KippoProject, form: Form, change: bool):
+        # Detect a manual phase→完了 on an open project so response_change can route to the close wizard.
+        request._phase_changed_to_completed = (
+            change and "phase" in getattr(form, "changed_data", ()) and obj.phase == PHASE_COMPLETED and not obj.is_closed
+        )
         if obj.pk is None:
             # expect only not not exist IF creating a new Project via ADMIN
             obj.created_by = request.user

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -168,6 +168,9 @@ class ProjectColumn(models.Model):
 # user-editable). The old anon-project value is retired — non-projects are identified by category=="non-project".
 DEFAULT_PROJECT_PHASE = "proposing-low"
 PHASE_UNDER_CONTRACT = "under-contract"
+# Terminal delivery phase. The close action stamps this on the project being closed, and manually
+# selecting it on the change form re-routes the user into the close wizard (see admin).
+PHASE_COMPLETED = "completed"
 # Shared by KippoProject.clean() (admin) and KippoProjectSerializer (API) so the gate message stays
 # in one place (and translated) across both layers.
 UNDER_CONTRACT_REQUIRES_CONTRACT_MSG = _("フェーズを契約(稼働中)にするには、開始日・終了日のある契約を保存してください。")
@@ -178,7 +181,7 @@ VALID_PROJECT_PHASES = (
     ("proposing-high", _("提案(高)")),
     ("verbal-order", _("口頭受注")),
     (PHASE_UNDER_CONTRACT, _("契約(稼働中)")),
-    ("completed", _("完了")),
+    (PHASE_COMPLETED, _("完了")),
     ("lost", _("失注")),
 )
 # Phases pre-selected on the active-project admin changelist when the フェーズ filter has no query

--- a/kippo/projects/templates/admin/projects/close_project_action.html
+++ b/kippo/projects/templates/admin/projects/close_project_action.html
@@ -40,7 +40,7 @@
 {% block content %}
 <div id="content-main">
   <h1>{% trans "Close Project" %}: {{ project.name }}</h1>
-  <form method="post">{% csrf_token %}
+  <form method="post" action="{% url opts|admin_urlname:'changelist' %}">{% csrf_token %}
     <input type="hidden" name="action" value="close_kippoproject_action">
     <input type="hidden" name="post" value="yes">
     <input type="hidden" name="_selected_action" value="{{ project.id }}">

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -19,6 +19,7 @@ from customers.models import KippoCustomer
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME, AdminForm
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.db import connection
 from django.forms.models import BaseInlineFormSet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -49,6 +50,7 @@ from projects.definitions import CONTINUATION_LEAD_SOURCE_VALUE, DEFAULT_BILLING
 from projects.filters import PhaseMultiSelectListFilter
 from projects.models import (
     DEFAULT_ACTIVE_PROJECT_PHASES,
+    PHASE_COMPLETED,
     PHASE_UNDER_CONTRACT,
     SALES_PROJECT_PHASES,
     VALID_PROJECT_PHASES,
@@ -766,6 +768,23 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
 
         # confirm no new project was created
         self.assertEqual(KippoProject.objects.count(), 2)
+
+    def test_close_stamps_completed_phase(self):
+        # project1 starts at the default proposing-low phase; closing stamps 完了 automatically.
+        self.assertNotEqual(self.project1.phase, "completed")
+        self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                "post": "yes",
+                "follow_up": CLOSE_PROJECT_NO_CONTINUATION_VALUE,
+                "close_comment": "done",
+            },
+        )
+        self.project1.refresh_from_db()
+        self.assertTrue(self.project1.is_closed)
+        self.assertEqual(self.project1.phase, "completed")
 
     def test_continuation_flow_closes_and_redirects(self):
         response = self.client.post(
@@ -1491,6 +1510,58 @@ class KippoProjectAdminReturnToTestCase(KippoProjectAdminFixtureTestCaseBase):
         request = self._add_request({}, {"_save": ""})
         original = HttpResponse()
         self.assertIs(self.modeladmin._redirect_back_after_save(request, original), original)
+
+
+class KippoProjectAdminCompletedPhaseRedirectTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """Manually setting an open project's phase to 完了 on the change form routes into the close wizard."""
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        self.project = self.make_project("phase-redirect-project")
+
+    def _save_model(self, obj: KippoProject, changed_data: list[str]) -> HttpRequest:
+        request = self.factory.post(reverse("admin:projects_kippoproject_change", args=[obj.id]))
+        request.user = self.superuser_no_org
+        form = MagicMock()
+        form.changed_data = changed_data
+        self.modeladmin.save_model(request, obj, form, change=True)
+        return request
+
+    def test_manual_phase_completed_flags_request(self):
+        self.project.phase = PHASE_COMPLETED
+        request = self._save_model(self.project, ["phase"])
+        self.assertTrue(request._phase_changed_to_completed)
+
+    def test_phase_unchanged_does_not_flag(self):
+        # already 完了, edited some other field — no re-route.
+        self.project.phase = PHASE_COMPLETED
+        self.project.save()
+        request = self._save_model(self.project, ["name"])
+        self.assertFalse(request._phase_changed_to_completed)
+
+    def test_phase_changed_to_non_completed_does_not_flag(self):
+        self.project.phase = PHASE_UNDER_CONTRACT
+        request = self._save_model(self.project, ["phase"])
+        self.assertFalse(request._phase_changed_to_completed)
+
+    def test_response_change_renders_close_wizard(self):
+        self.project.phase = PHASE_COMPLETED
+        request = self._save_model(self.project, ["phase"])
+        response = self.modeladmin.response_change(request, self.project)
+        self.assertIn("admin/projects/close_project_action.html", response.template_name)
+        self.assertEqual(response.context_data["project"], self.project)
+
+    def test_response_change_without_flag_uses_default(self):
+        request = self.factory.post(reverse("admin:projects_kippoproject_change", args=[self.project.id]), {"_save": ""})
+        request.user = self.superuser_no_org
+        # Django's default response_change queues a success message — give the request message storage.
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        # no flag set → normal post-change redirect (not the wizard template response)
+        response = self.modeladmin.response_change(request, self.project)
+        self.assertIsInstance(response, HttpResponseRedirect)
 
 
 class KippoProjectAdminActiveParityTestCase(KippoProjectAdminFixtureTestCaseBase):


### PR DESCRIPTION
## Summary

Two related updates to `KippoProjectAdmin` form behavior.

### 1. `lead_source` on the project add form
- The slim `/add/` (create) form now includes the optional `lead_source` (リード) field immediately after `category`, via `ADD_FIELDS`. Previously it only appeared on the change form and the continuation close-wizard add.

### 2. Completed-phase ⇄ close-wizard coupling
- **Close action stamps 完了**: closing a project now sets its phase to `completed` (if not already), so a delivered project reflects the terminal phase. `save()` re-derives confidence only when the phase actually changes, so the assignment is idempotent.
- **Manual 完了 routes to the close wizard**: when a user manually changes an open project's phase to `完了` on the change form and saves, they are redirected into the close wizard so closure fields (close comment / continuation) are captured. Detection uses `form.changed_data` in `save_model`, handled in `response_change`.
- **Wizard form target**: the close-wizard `<form>` now posts explicitly to the changelist URL (`admin_urlname:'changelist'`) so it dispatches the close action correctly when rendered from the change page. Behavior when triggered from the changelist is unchanged (same URL).
- Adds a `PHASE_COMPLETED` constant (`projects/models.py`).

## Tests
- `CloseProjectActionTestCase.test_close_stamps_completed_phase`
- New `KippoProjectAdminCompletedPhaseRedirectTestCase` (flag set on manual 完了; not set when phase unchanged or changed to a non-completed value; `response_change` renders the wizard; default path when unflagged).
- Full `projects.tests.test_admin` suite passes; `ruff` clean. No migration needed (`VALID_PROJECT_PHASES` value unchanged).