### PR TITLE
Fix close wizard 'Select exactly one project to close.' when phase already set to 完了

### DIFF
--- a/kippo/projects/templates/admin/projects/close_project_action.html
+++ b/kippo/projects/templates/admin/projects/close_project_action.html
@@ -40,7 +40,10 @@
 {% block content %}
 <div id="content-main">
   <h1>{% trans "Close Project" %}: {{ project.name }}</h1>
-  <form method="post" action="{% url opts|admin_urlname:'changelist' %}">{% csrf_token %}
+  {# Dispatch on the all-projects changelist: the active/sales changelists filter by phase (and by their
+     proxy managers), so a project just moved to 完了 is excluded there and the action would see an empty
+     queryset ("Select exactly one project to close."). The all-projects changelist has no such filter. #}
+  <form method="post" action="{% url 'admin:projects_kippoproject_changelist' %}">{% csrf_token %}
     <input type="hidden" name="action" value="close_kippoproject_action">
     <input type="hidden" name="post" value="yes">
     <input type="hidden" name="_selected_action" value="{{ project.id }}">

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1553,6 +1553,22 @@ class KippoProjectAdminCompletedPhaseRedirectTestCase(KippoProjectAdminFixtureTe
         self.assertIn("admin/projects/close_project_action.html", response.template_name)
         self.assertEqual(response.context_data["project"], self.project)
 
+    def test_close_wizard_dispatches_on_all_projects_changelist(self):
+        # Reached from the active admin: the wizard OK button must post to the all-projects changelist,
+        # not the active one — the active/sales changelists filter out a 完了 project, which would make
+        # the close action see an empty queryset ("Select exactly one project to close.").
+        active_admin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+        request = self.factory.post(reverse("admin:projects_activekippoproject_change", args=[self.project.id]))
+        request.user = self.superuser_no_org
+        self.project.phase = PHASE_COMPLETED
+        form = MagicMock()
+        form.changed_data = ["phase"]
+        active_admin.save_model(request, self.project, form, change=True)
+        response = active_admin.response_change(request, self.project)
+        response.render()
+        all_projects_changelist = reverse("admin:projects_kippoproject_changelist")
+        self.assertIn(f'action="{all_projects_changelist}"', response.content.decode())
+
     def test_response_change_without_flag_uses_default(self):
         request = self.factory.post(reverse("admin:projects_kippoproject_change", args=[self.project.id]), {"_save": ""})
         request.user = self.superuser_no_org


### PR DESCRIPTION
## Problem

Follow-up to #382. When a user manually sets an open project's phase to 完了 on the change form, they are redirected into the close wizard (as intended). **Submitting the wizard failed** with:

> Select exactly one project to close.

## Root cause

The wizard `<form>` posted to the triggering admin's changelist (`{% url opts|admin_urlname:'changelist' %}`). When the wizard is reached from the **active** or **sales** project admin, that changelist:
- applies `PhaseMultiSelectListFilter`, which defaults to the in-flight phases (`verbal-order`, `under-contract`) when no `phase` query param is present, and
- is backed by a proxy manager (`ActiveKippoProjectManager` / `SalesKippoProjectManager`) that excludes completed projects.

On submit, Django's admin action machinery rebuilds the action queryset from that changelist's `get_queryset`, so the just-completed project is filtered out → the action receives an empty queryset → `count() != 1` → the error.

## Fix

Dispatch the close action on the **all-projects** `kippoproject` changelist, which has no phase filter (base manager, org-scoped only) and always contains the project. This is also where `close_kippoproject_action` already redirects on completion, so it's consistent.

One-line template change: the wizard form now posts to `admin:projects_kippoproject_changelist` instead of the triggering admin's changelist. Behavior when the action is triggered normally from the all-projects changelist is unchanged.

## Test

- `KippoProjectAdminCompletedPhaseRedirectTestCase.test_close_wizard_dispatches_on_all_projects_changelist`: reaches the wizard via `ActiveKippoProjectAdmin`, renders it, and asserts the form posts to the all-projects changelist (fails against the old template, which targeted `/admin/projects/activekippoproject/`).
- Full `projects.tests.test_admin` (173 tests) passes; `ruff` clean.