### PR TITLE
Fix close wizard rendering its explanatory template comment as visible text

### DIFF
--- a/kippo/projects/templates/admin/projects/close_project_action.html
+++ b/kippo/projects/templates/admin/projects/close_project_action.html
@@ -40,9 +40,11 @@
 {% block content %}
 <div id="content-main">
   <h1>{% trans "Close Project" %}: {{ project.name }}</h1>
-  {# Dispatch on the all-projects changelist: the active/sales changelists filter by phase (and by their
-     proxy managers), so a project just moved to 完了 is excluded there and the action would see an empty
-     queryset ("Select exactly one project to close."). The all-projects changelist has no such filter. #}
+  {% comment %}
+    Dispatch on the all-projects changelist: the active/sales changelists filter by phase (and by their
+    proxy managers), so a project just moved to 完了 is excluded there and the action would see an empty
+    queryset ("Select exactly one project to close."). The all-projects changelist has no such filter.
+  {% endcomment %}
   <form method="post" action="{% url 'admin:projects_kippoproject_changelist' %}">{% csrf_token %}
     <input type="hidden" name="action" value="close_kippoproject_action">
     <input type="hidden" name="post" value="yes">

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1566,8 +1566,11 @@ class KippoProjectAdminCompletedPhaseRedirectTestCase(KippoProjectAdminFixtureTe
         active_admin.save_model(request, self.project, form, change=True)
         response = active_admin.response_change(request, self.project)
         response.render()
+        content = response.content.decode()
         all_projects_changelist = reverse("admin:projects_kippoproject_changelist")
-        self.assertIn(f'action="{all_projects_changelist}"', response.content.decode())
+        self.assertIn(f'action="{all_projects_changelist}"', content)
+        # the template comment explaining the changelist choice must not leak into the rendered page
+        self.assertNotIn("Dispatch on the all-projects changelist", content)
 
     def test_response_change_without_flag_uses_default(self):
         request = self.factory.post(reverse("admin:projects_kippoproject_change", args=[self.project.id]), {"_save": ""})


### PR DESCRIPTION
## Problem

Follow-up to #383. The close wizard page displayed its own explanatory note as literal text:

> {# Dispatch on the all-projects changelist: … #}

## Cause

The note was written with Django's `{# … #}` comment syntax, which **cannot span multiple lines** — only `{% comment %}…{% endcomment %}` supports multi-line comments. Because the `{# #}` block spanned three lines, Django did not treat it as a comment and rendered it verbatim.

## Fix

Switch the multi-line note to `{% comment %}…{% endcomment %}` so it is stripped from the output.

## Test

Extended `KippoProjectAdminCompletedPhaseRedirectTestCase.test_close_wizard_dispatches_on_all_projects_changelist` to render the wizard and assert the explanatory text does not appear in the rendered page.