### PR TITLE
Add category exclude filter to ActiveKippoProject admin

### DIFF
--- a/kippo/commons/filters.py
+++ b/kippo/commons/filters.py
@@ -1,0 +1,47 @@
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
+
+if TYPE_CHECKING:
+    from django.contrib.admin.views.main import ChangeList
+
+
+class MultiSelectListFilter(admin.SimpleListFilter):
+    """Reusable base for multi-select toggle changelist filters.
+
+    Django's built-in field filter is single-select; this renders each lookup as a toggle so several
+    can be active at once, plus a 全て option that clears to an explicit empty param. With no query
+    param `default_values()` is pre-selected; the explicit empty param (全て, or deselecting the last
+    toggle) overrides that default so it does not re-apply. Subclasses supply `lookups()`, `queryset()`
+    (include vs exclude semantics differ), and optionally `default_values()`.
+    """
+
+    def default_values(self) -> list[str]:
+        # Applied when the query param is absent. Empty means "no default selection".
+        return []
+
+    def selected_values(self) -> list[str]:
+        # value() is None only when the param is absent -> fall back to the defaults; an explicit empty
+        # string (全て or deselecting the last toggle) means "no selection".
+        value = self.value()
+        if value is None:
+            return self.default_values()
+        return [item for item in value.split(",") if item]
+
+    def choices(self, changelist: "ChangeList") -> Iterator[dict]:
+        selected = set(self.selected_values())
+        yield {
+            "selected": not selected,
+            "query_string": changelist.get_query_string({self.parameter_name: ""}),
+            "display": _("全て"),
+        }
+        for lookup, title in self.lookup_choices:
+            item = str(lookup)
+            toggled = selected ^ {item}  # add if absent, remove if present
+            yield {
+                "selected": item in selected,
+                "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
+                "display": title,
+            }

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -57,7 +57,7 @@ from .definitions import (
     ProjectRoles,
 )
 from .exceptions import GithubMilestoneAlreadyExistsError, SlackChannelNotFoundError
-from .filters import PhaseMultiSelectListFilter
+from .filters import CategoryExcludeListFilter, PhaseMultiSelectListFilter
 from .functions import (
     generate_kippoprojectusermonthlystatisfaction_csv,
     generate_kippoprojectuserstatisfactionresult_csv,
@@ -1899,7 +1899,8 @@ class ActiveKippoProjectAdmin(KippoProjectBaseAdmin):
     # manager) restricts it to open + display_as_active projects. The only form difference is
     # below — closure fields never apply to an active project.
     # Multi-select フェーズ filter, defaulting to the two in-flight phases (kippo new filter).
-    list_filter = (PhaseMultiSelectListFilter,)
+    # CategoryExcludeListFilter lets the user drop one or more categories from the changelist.
+    list_filter = (PhaseMultiSelectListFilter, CategoryExcludeListFilter)
 
     def get_exclude(self, request: DjangoRequest, obj: KippoProject | None = None):
         excluded: list[str] = list(super().get_exclude(request, obj) or ())

--- a/kippo/projects/filters.py
+++ b/kippo/projects/filters.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 from django.contrib import admin
@@ -12,70 +13,88 @@ if TYPE_CHECKING:
     from django.contrib.admin.views.main import ChangeList
 
 
-class PhaseMultiSelectListFilter(admin.SimpleListFilter):
-    """Multi-select フェーズ filter for the active-project changelist.
+class _MultiSelectListFilter(admin.SimpleListFilter):
+    """Base for the multi-select toggle filters on the project changelists.
 
-    Django's built-in field filter is single-select; this renders each phase as a toggle so several
-    can be active at once. With no `phase` query param the two in-flight phases are pre-selected
-    (DEFAULT_ACTIVE_PROJECT_PHASES); the 全て option clears to an explicit empty param so the defaults
-    don't re-apply.
+    Django's built-in field filter is single-select; this renders each lookup as a toggle so several
+    can be active at once, plus a 全て option that clears to an explicit empty param. With no query
+    param `default_values()` is pre-selected; the explicit empty param (全て, or deselecting the last
+    toggle) overrides that default so it does not re-apply. Subclasses supply `lookups()`, `queryset()`
+    (include vs exclude semantics differ), and optionally `default_values()`.
     """
 
-    title = _("フェーズ")
-    parameter_name = "phase"
+    def default_values(self) -> list[str]:
+        # Applied when the query param is absent. Empty means "no default selection".
+        return []
 
-    def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
-        return list(VALID_PROJECT_PHASES)
-
-    def selected_phases(self) -> list[str]:
-        # value() is None only when the param is absent -> fall back to the defaults; an empty string
-        # (user cleared the selection via 全て or by deselecting the last phase) means "no filter".
+    def selected_values(self) -> list[str]:
+        # value() is None only when the param is absent -> fall back to the defaults; an explicit empty
+        # string (全て or deselecting the last toggle) means "no selection".
         value = self.value()
         if value is None:
-            return list(DEFAULT_ACTIVE_PROJECT_PHASES)
-        return [phase for phase in value.split(",") if phase]
+            return self.default_values()
+        return [item for item in value.split(",") if item]
 
-    def queryset(self, request: DjangoRequest, queryset: models.QuerySet) -> models.QuerySet:
-        selected = self.selected_phases()
-        return queryset.filter(phase__in=selected) if selected else queryset
-
-    def choices(self, changelist: "ChangeList"):
-        selected = set(self.selected_phases())
+    def choices(self, changelist: "ChangeList") -> Iterator[dict]:
+        selected = set(self.selected_values())
         yield {
             "selected": not selected,
             "query_string": changelist.get_query_string({self.parameter_name: ""}),
             "display": _("全て"),
         }
         for lookup, title in self.lookup_choices:
-            phase = str(lookup)
-            toggled = selected ^ {phase}  # add if absent, remove if present
+            item = str(lookup)
+            toggled = selected ^ {item}  # add if absent, remove if present
             yield {
-                "selected": phase in selected,
+                "selected": item in selected,
                 "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
                 "display": title,
             }
 
 
-class CategoryExcludeListFilter(admin.SimpleListFilter):
+class PhaseMultiSelectListFilter(_MultiSelectListFilter):
+    """Multi-select フェーズ filter for the active-project changelist.
+
+    With no `phase` query param the two in-flight phases are pre-selected (DEFAULT_ACTIVE_PROJECT_PHASES).
+    """
+
+    title = _("フェーズ")
+    parameter_name = "phase"
+
+    def default_values(self) -> list[str]:
+        return list(DEFAULT_ACTIVE_PROJECT_PHASES)
+
+    def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
+        return list(VALID_PROJECT_PHASES)
+
+    def queryset(self, request: DjangoRequest, queryset: models.QuerySet) -> models.QuerySet:
+        selected = self.selected_values()
+        return queryset.filter(phase__in=selected) if selected else queryset
+
+
+class CategoryExcludeListFilter(_MultiSelectListFilter):
     """Multi-select カテゴリ *exclude* filter for the active-project changelist.
 
-    The inverse of Django's built-in (include) field filter: each category renders as a toggle and
-    selecting one or more categories drops their rows from the changelist. With no query param the
-    非案件 (non-project) category is excluded by default; the 全て option clears to an explicit empty
-    param so the default no longer applies and every category shows.
+    The inverse of the include filters above: a selected (highlighted) toggle drops that category's
+    rows from the changelist. With no query param the 非案件 (non-project) category is excluded by
+    default; the 全て option clears to an explicit empty param so every category shows.
     """
 
     title = _("カテゴリ (除外)")
     parameter_name = "exclude_category"
 
+    def default_values(self) -> list[str]:
+        return [NON_PROJECT_CATEGORY_VALUE]
+
     def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
         # Offer only the categories present on the rows the admin queryset already scopes to the user;
-        # keyed by category__key (labels are the org's copy of the shared label) and deduped in order.
+        # keyed by category__key (labels are the org's copy of the shared label). Ordering by (key, label)
+        # makes the deduped label deterministic when one key carries divergent labels across orgs.
         pairs = (
             model_admin.get_queryset(request)
             .exclude(category__isnull=True)
             .values_list("category__key", "category__label")
-            .order_by("category__key")
+            .order_by("category__key", "category__label")
             .distinct()
         )
         deduped: dict[str, str] = {}
@@ -83,30 +102,6 @@ class CategoryExcludeListFilter(admin.SimpleListFilter):
             deduped.setdefault(key, label)
         return list(deduped.items())
 
-    def excluded_keys(self) -> list[str]:
-        # value() is None only when the param is absent -> fall back to the default (非案件); an explicit
-        # empty string (全て or deselecting the last category) means "exclude nothing".
-        value = self.value()
-        if value is None:
-            return [NON_PROJECT_CATEGORY_VALUE]
-        return [key for key in value.split(",") if key]
-
     def queryset(self, request: DjangoRequest, queryset: models.QuerySet) -> models.QuerySet:
-        excluded = self.excluded_keys()
+        excluded = self.selected_values()
         return queryset.exclude(category__key__in=excluded) if excluded else queryset
-
-    def choices(self, changelist: "ChangeList"):
-        excluded = set(self.excluded_keys())
-        yield {
-            "selected": not excluded,
-            "query_string": changelist.get_query_string({self.parameter_name: ""}),
-            "display": _("全て"),
-        }
-        for lookup, title in self.lookup_choices:
-            key = str(lookup)
-            toggled = excluded ^ {key}  # add if absent, remove if present
-            yield {
-                "selected": key in excluded,
-                "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
-                "display": title,
-            }

--- a/kippo/projects/filters.py
+++ b/kippo/projects/filters.py
@@ -1,6 +1,4 @@
-from collections.abc import Iterator
-from typing import TYPE_CHECKING
-
+from commons.filters import MultiSelectListFilter
 from django.contrib import admin
 from django.db import models
 from django.http import request as DjangoRequest  # noqa: N812
@@ -9,50 +7,8 @@ from django.utils.translation import gettext_lazy as _
 from .definitions import NON_PROJECT_CATEGORY_VALUE
 from .models import DEFAULT_ACTIVE_PROJECT_PHASES, VALID_PROJECT_PHASES
 
-if TYPE_CHECKING:
-    from django.contrib.admin.views.main import ChangeList
 
-
-class _MultiSelectListFilter(admin.SimpleListFilter):
-    """Base for the multi-select toggle filters on the project changelists.
-
-    Django's built-in field filter is single-select; this renders each lookup as a toggle so several
-    can be active at once, plus a 全て option that clears to an explicit empty param. With no query
-    param `default_values()` is pre-selected; the explicit empty param (全て, or deselecting the last
-    toggle) overrides that default so it does not re-apply. Subclasses supply `lookups()`, `queryset()`
-    (include vs exclude semantics differ), and optionally `default_values()`.
-    """
-
-    def default_values(self) -> list[str]:
-        # Applied when the query param is absent. Empty means "no default selection".
-        return []
-
-    def selected_values(self) -> list[str]:
-        # value() is None only when the param is absent -> fall back to the defaults; an explicit empty
-        # string (全て or deselecting the last toggle) means "no selection".
-        value = self.value()
-        if value is None:
-            return self.default_values()
-        return [item for item in value.split(",") if item]
-
-    def choices(self, changelist: "ChangeList") -> Iterator[dict]:
-        selected = set(self.selected_values())
-        yield {
-            "selected": not selected,
-            "query_string": changelist.get_query_string({self.parameter_name: ""}),
-            "display": _("全て"),
-        }
-        for lookup, title in self.lookup_choices:
-            item = str(lookup)
-            toggled = selected ^ {item}  # add if absent, remove if present
-            yield {
-                "selected": item in selected,
-                "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
-                "display": title,
-            }
-
-
-class PhaseMultiSelectListFilter(_MultiSelectListFilter):
+class PhaseMultiSelectListFilter(MultiSelectListFilter):
     """Multi-select フェーズ filter for the active-project changelist.
 
     With no `phase` query param the two in-flight phases are pre-selected (DEFAULT_ACTIVE_PROJECT_PHASES).
@@ -72,7 +28,7 @@ class PhaseMultiSelectListFilter(_MultiSelectListFilter):
         return queryset.filter(phase__in=selected) if selected else queryset
 
 
-class CategoryExcludeListFilter(_MultiSelectListFilter):
+class CategoryExcludeListFilter(MultiSelectListFilter):
     """Multi-select カテゴリ *exclude* filter for the active-project changelist.
 
     The inverse of the include filters above: a selected (highlighted) toggle drops that category's

--- a/kippo/projects/filters.py
+++ b/kippo/projects/filters.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.http import request as DjangoRequest  # noqa: N812
 from django.utils.translation import gettext_lazy as _
 
+from .definitions import NON_PROJECT_CATEGORY_VALUE
 from .models import DEFAULT_ACTIVE_PROJECT_PHASES, VALID_PROJECT_PHASES
 
 if TYPE_CHECKING:
@@ -50,6 +51,62 @@ class PhaseMultiSelectListFilter(admin.SimpleListFilter):
             toggled = selected ^ {phase}  # add if absent, remove if present
             yield {
                 "selected": phase in selected,
+                "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
+                "display": title,
+            }
+
+
+class CategoryExcludeListFilter(admin.SimpleListFilter):
+    """Multi-select カテゴリ *exclude* filter for the active-project changelist.
+
+    The inverse of Django's built-in (include) field filter: each category renders as a toggle and
+    selecting one or more categories drops their rows from the changelist. With no query param the
+    非案件 (non-project) category is excluded by default; the 全て option clears to an explicit empty
+    param so the default no longer applies and every category shows.
+    """
+
+    title = _("カテゴリ (除外)")
+    parameter_name = "exclude_category"
+
+    def lookups(self, request: DjangoRequest, model_admin: admin.ModelAdmin) -> list[tuple[str, str]]:
+        # Offer only the categories present on the rows the admin queryset already scopes to the user;
+        # keyed by category__key (labels are the org's copy of the shared label) and deduped in order.
+        pairs = (
+            model_admin.get_queryset(request)
+            .exclude(category__isnull=True)
+            .values_list("category__key", "category__label")
+            .order_by("category__key")
+            .distinct()
+        )
+        deduped: dict[str, str] = {}
+        for key, label in pairs:
+            deduped.setdefault(key, label)
+        return list(deduped.items())
+
+    def excluded_keys(self) -> list[str]:
+        # value() is None only when the param is absent -> fall back to the default (非案件); an explicit
+        # empty string (全て or deselecting the last category) means "exclude nothing".
+        value = self.value()
+        if value is None:
+            return [NON_PROJECT_CATEGORY_VALUE]
+        return [key for key in value.split(",") if key]
+
+    def queryset(self, request: DjangoRequest, queryset: models.QuerySet) -> models.QuerySet:
+        excluded = self.excluded_keys()
+        return queryset.exclude(category__key__in=excluded) if excluded else queryset
+
+    def choices(self, changelist: "ChangeList"):
+        excluded = set(self.excluded_keys())
+        yield {
+            "selected": not excluded,
+            "query_string": changelist.get_query_string({self.parameter_name: ""}),
+            "display": _("全て"),
+        }
+        for lookup, title in self.lookup_choices:
+            key = str(lookup)
+            toggled = excluded ^ {key}  # add if absent, remove if present
+            yield {
+                "selected": key in excluded,
                 "query_string": changelist.get_query_string({self.parameter_name: ",".join(sorted(toggled))}),
                 "display": title,
             }

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -46,8 +46,14 @@ from projects.admin import (
     _next_continuation_project_name,
     _start_of_next_month,
 )
-from projects.definitions import CONTINUATION_LEAD_SOURCE_VALUE, DEFAULT_BILLING_TYPE, DEFAULT_PRICING_BASIS, PRICING_BASIS_EFFORT
-from projects.filters import PhaseMultiSelectListFilter
+from projects.definitions import (
+    CONTINUATION_LEAD_SOURCE_VALUE,
+    DEFAULT_BILLING_TYPE,
+    DEFAULT_PRICING_BASIS,
+    KIPPOPROJECT_CATEGORY_CHOICES,
+    PRICING_BASIS_EFFORT,
+)
+from projects.filters import CategoryExcludeListFilter, PhaseMultiSelectListFilter
 from projects.models import (
     DEFAULT_ACTIVE_PROJECT_PHASES,
     PHASE_COMPLETED,
@@ -2780,6 +2786,80 @@ class ActiveProjectPhaseFilterTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(str(choices[0]["display"]), "全て")
         self.assertTrue(choices[0]["selected"])
         self.assertFalse(any(choice["selected"] for choice in choices[1:]))
+
+
+class ActiveProjectCategoryExcludeFilterTestCase(IsStaffModelAdminTestCaseBase):
+    """CategoryExcludeListFilter on the ActiveKippoProject changelist (multi-select, excludes selected)."""
+
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        super().setUp()
+        columnset = ProjectColumnSet.objects.get(pk=DEFAULT_COLUMNSET_PK)
+        # include 非案件(non-project) so the default exclusion is exercised
+        self.categories = ("ai-development", "system-development", "consulting", "other", "non-project")
+        # one active project per category (all in-flight phases so no phase default hides them)
+        for category in self.categories:
+            KippoProject.objects.create(
+                organization=self.organization,
+                name=f"project-{category}",
+                phase="under-contract",
+                category=_global_category(category),
+                columnset=columnset,
+                start_date=timezone.now().date(),
+                created_by=self.github_manager,
+                updated_by=self.github_manager,
+            )
+        self.modeladmin = ActiveKippoProjectAdmin(ActiveKippoProject, self.site)
+
+    def _changelist_categories(self, query: str = "") -> set:
+        request = RequestFactory().get(f"/admin/projects/activekippoproject/{query}")
+        request.user = self.superuser_no_org
+        changelist = self.modeladmin.get_changelist_instance(request)
+        return set(changelist.queryset.values_list("category__key", flat=True))
+
+    def _category_filter_choices(self, query: str = "") -> list:
+        request = RequestFactory().get(f"/admin/projects/activekippoproject/{query}")
+        request.user = self.superuser_no_org
+        changelist = self.modeladmin.get_changelist_instance(request)
+        spec = next(f for f in changelist.filter_specs if isinstance(f, CategoryExcludeListFilter))
+        return list(spec.choices(changelist))
+
+    def test_filter_registered_on_active_admin_only(self):
+        self.assertIn(CategoryExcludeListFilter, self.modeladmin.list_filter)
+        # the all-projects admin keeps the default (empty) list_filter — the filter is active-only
+        self.assertNotIn(CategoryExcludeListFilter, KippoProjectAdmin(KippoProject, self.site).list_filter)
+
+    def test_non_project_excluded_by_default(self):
+        # no param => 非案件(non-project) is dropped, everything else shows
+        self.assertEqual(self._changelist_categories(), set(self.categories) - {"non-project"})
+
+    def test_single_category_excluded(self):
+        self.assertEqual(self._changelist_categories("?exclude_category=other"), set(self.categories) - {"other"})
+
+    def test_multiple_categories_excluded(self):
+        expected = set(self.categories) - {"consulting", "other"}
+        self.assertEqual(self._changelist_categories("?exclude_category=consulting,other"), expected)
+
+    def test_empty_param_excludes_nothing(self):
+        # an explicit empty param (全て) overrides the default and shows every category
+        self.assertEqual(self._changelist_categories("?exclude_category="), set(self.categories))
+
+    def test_non_project_preselected_when_no_param(self):
+        # the sidebar pre-highlights 非案件 (and 全て is not selected) when no param is present
+        labels = dict(KIPPOPROJECT_CATEGORY_CHOICES)
+        selected = {str(choice["display"]) for choice in self._category_filter_choices() if choice["selected"]}
+        self.assertEqual(selected, {str(labels["non-project"])})
+
+    def test_all_option_selected_when_param_empty(self):
+        choices = self._category_filter_choices("?exclude_category=")
+        self.assertEqual(str(choices[0]["display"]), "全て")
+        self.assertTrue(choices[0]["selected"])
+        self.assertFalse(any(choice["selected"] for choice in choices[1:]))
+
+    def test_excluded_categories_rendered_selected(self):
+        selected = {str(choice["display"]) for choice in self._category_filter_choices("?exclude_category=other") if choice["selected"]}
+        self.assertEqual(selected, {str(dict(KIPPOPROJECT_CATEGORY_CHOICES)["other"])})
 
 
 class _AdminFormFieldParser(HTMLParser):


### PR DESCRIPTION
## Summary

Adds a **category exclude** filter to the active-project changelist (`ActiveKippoProjectAdmin`). It's a multi-select sidebar filter (same UX as the existing `PhaseMultiSelectListFilter`) that drops one or more categories from the display — the inverse of Django's built-in include filter.

- With **no query param**, the 非案件 (non-project) category is **excluded by default**.
- The **全て** option clears to an explicit empty param, so the default no longer applies and every category shows.
- Selecting/deselecting categories toggles their exclusion.

## Details

- New `CategoryExcludeListFilter` in `projects/filters.py`, registered only on `ActiveKippoProjectAdmin.list_filter` (alongside the phase filter).
- **Org-aware options**: `lookups()` derives the toggle list from the org-scoped admin queryset, so each org only sees its own configured categories (categories are per-organization — copy-on-create, kippo#49).
- **Stable default anchor**: the default exclusion keys on `NON_PROJECT_CATEGORY_VALUE` (`"non-project"`), the same system identifier used elsewhere (e.g. the estimate-exemption in the project form), so it survives per-org label/sort customization. The default is structurally safe even if an org has no non-project category — `.exclude(category__key__in=...)` is a harmless no-op when nothing matches.

## Tests

`ActiveProjectCategoryExcludeFilterTestCase` (8 tests): active-admin-only registration, non-project excluded by default, single/multi-category exclusion, explicit-empty shows all, and sidebar selected-state rendering. Full `projects` admin suite green.

Refs kiconiaworks/kippo