### PR TITLE
Fix admin change_list comment rendering as visible text

### DIFF
--- a/kippo/projects/templates/admin/projects/kippoproject/change_list.html
+++ b/kippo/projects/templates/admin/projects/kippoproject/change_list.html
@@ -1,8 +1,10 @@
 {% extends "admin/change_list.html" %}
 {% block extrahead %}{{ block.super }}
-{# Keep the プロジェクト名(name), 顧客(customer) and フェーズ(phase) columns on a single line so their
-   values are not wrapped across rows. Inline here rather than a static file because this app's static/
-   dirs are gitignored. #}
+{% comment %}
+Keep the プロジェクト名(name), 顧客(customer) and フェーズ(phase) columns on a single line so their
+values are not wrapped across rows. Inline here rather than a static file because this app's static/
+dirs are gitignored.
+{% endcomment %}
 <style>
   #result_list th.column-name,
   #result_list td.field-name,


### PR DESCRIPTION
The multi-line `{# ... #}` comment in `projects/templates/admin/projects/kippoproject/change_list.html` was rendered literally in the Django admin project list — Django's `{# #}` comment syntax is single-line only, so a comment containing newlines is not parsed as a comment.

Replaced it with the `{% comment %}` block tag, which supports multiple lines and renders to nothing.

Verified by compiling the template and rendering the comment block in isolation (empty output).