### PR TITLE
Return the close action to the admin it was run from

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -35,6 +35,7 @@ from django.http import (
     request as DjangoRequest,  # noqa: N812
 )
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html, format_html_join
 from django.utils.http import url_has_allowed_host_and_scheme
@@ -123,6 +124,11 @@ PROJECT_CLOSURE_FIELDS = ("close_comment", "survey_issued")
 # fields render and save), instead of the flat required-only plain add.
 CONTINUATION_SOURCE_PARAM = "_continuation_source"
 CONTINUATION_SOURCE_VALUE = "close"
+
+# Hidden field on the close-confirmation form naming the admin the action was started from (e.g.
+# "activekippoproject"). The form always posts to the all-projects changelist (see the template
+# comment), so the origin has to travel with the POST for the close to land back where it began.
+CLOSE_ORIGIN_PARAM = "_close_origin"
 
 # confidence (%, derived from phase via PHASE_CONFIDENCE) at which a non-closed project must carry a
 # positive allocated_staff_days estimate (kippo#41).
@@ -781,6 +787,22 @@ def _build_continuation_prefill_params(project: KippoProject) -> dict[str, str]:
     return {k: v for k, v in params.items() if v}
 
 
+def _close_origin_opts(modeladmin: admin.ModelAdmin, request: DjangoRequest) -> "models.options.Options":
+    """Meta options of the admin the close action was started from.
+
+    The confirmation form posts to the all-projects changelist, so on that POST `modeladmin` is
+    always KippoProjectAdmin — the origin comes from the form's hidden CLOSE_ORIGIN_PARAM instead.
+    Only registered KippoProject admins are accepted (no arbitrary reverse target); anything else
+    falls back to the dispatching admin.
+    """
+    requested = request.POST.get(CLOSE_ORIGIN_PARAM)
+    if requested:
+        for model in modeladmin.admin_site._registry:
+            if issubclass(model, KippoProject) and model._meta.model_name == requested:
+                return model._meta
+    return modeladmin.model._meta
+
+
 def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoRequest, queryset: models.QuerySet):
     """Close a KippoProject with an optional 継続 (continuation) follow-up project."""
     if queryset.count() != 1:
@@ -795,6 +817,11 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
             level=messages.ERROR,
         )
         return None
+
+    # Send the user back to the changelist (or continuation add form) of the admin they started
+    # from — 実行中/営業中 proxies included — instead of always the all-projects admin.
+    origin_opts = _close_origin_opts(modeladmin, request)
+    origin_urlname = f"admin:{origin_opts.app_label}_{origin_opts.model_name}"
 
     if request.POST.get("post") == "yes":
         form = CloseProjectActionForm(request.POST)
@@ -815,8 +842,8 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
 
             if follow_up == CONTINUATION_LEAD_SOURCE_VALUE:
                 params = urllib.parse.urlencode(_build_continuation_prefill_params(project))
-                return HttpResponseRedirect(f"{settings.URL_PREFIX}/admin/projects/kippoproject/add/?{params}")
-            return HttpResponseRedirect(f"{settings.URL_PREFIX}/admin/projects/kippoproject/")
+                return HttpResponseRedirect(f"{reverse(f'{origin_urlname}_add')}?{params}")
+            return HttpResponseRedirect(reverse(f"{origin_urlname}_changelist"))
     else:
         form = CloseProjectActionForm()
 
@@ -826,7 +853,10 @@ def close_kippoproject_action(modeladmin: admin.ModelAdmin, request: DjangoReque
         "project": project,
         "form": form,
         "action": "close_kippoproject_action",
-        "opts": modeladmin.model._meta,
+        # origin_opts (not modeladmin's) so the breadcrumbs/Cancel link keep pointing at the
+        # originating admin when the confirmation page re-renders with form errors.
+        "opts": origin_opts,
+        "close_origin": origin_opts.model_name,
         "no_continuation_value": CLOSE_PROJECT_NO_CONTINUATION_VALUE,
     }
     return TemplateResponse(request, "admin/projects/close_project_action.html", context)

--- a/kippo/projects/filters.py
+++ b/kippo/projects/filters.py
@@ -11,7 +11,8 @@ from .models import DEFAULT_ACTIVE_PROJECT_PHASES, VALID_PROJECT_PHASES
 class PhaseMultiSelectListFilter(MultiSelectListFilter):
     """Multi-select フェーズ filter for the active-project changelist.
 
-    With no `phase` query param the two in-flight phases are pre-selected (DEFAULT_ACTIVE_PROJECT_PHASES).
+    With no `phase` query param the in-flight phases plus 完了 are pre-selected
+    (DEFAULT_ACTIVE_PROJECT_PHASES) — a 完了 row here is one that was never closed.
     """
 
     title = _("フェーズ")

--- a/kippo/projects/models.py
+++ b/kippo/projects/models.py
@@ -185,8 +185,12 @@ VALID_PROJECT_PHASES = (
     ("lost", _("失注")),
 )
 # Phases pre-selected on the active-project admin changelist when the フェーズ filter has no query
-# param — the two "in-flight" phases. See projects.filters.PhaseMultiSelectListFilter.
-DEFAULT_ACTIVE_PROJECT_PHASES = ("verbal-order", "under-contract")
+# param — the two in-flight phases plus 完了. See projects.filters.PhaseMultiSelectListFilter.
+# 完了 is included deliberately: ActiveKippoProjectManager already drops closed projects
+# (is_closed=True / display_as_active=False), so the only 完了 rows this surfaces are the ones
+# stamped 完了 without being closed — the inconsistent state we want visible, and the state whose
+# row must stay selectable for the close action.
+DEFAULT_ACTIVE_PROJECT_PHASES = ("verbal-order", PHASE_UNDER_CONTRACT, PHASE_COMPLETED)
 # Pre-contract sales-pipeline phases — everything before delivery (under-contract) and before a
 # terminal outcome (completed/lost). Consumed by SalesKippoProjectManager (プロジェクト(営業中)).
 SALES_PROJECT_PHASES = ("keep-in-touch", "proposing-low", "proposing-mid", "proposing-high", "verbal-order")

--- a/kippo/projects/templates/admin/projects/close_project_action.html
+++ b/kippo/projects/templates/admin/projects/close_project_action.html
@@ -44,10 +44,13 @@
     Dispatch on the all-projects changelist: the active/sales changelists filter by phase (and by their
     proxy managers), so a project just moved to 完了 is excluded there and the action would see an empty
     queryset ("Select exactly one project to close."). The all-projects changelist has no such filter.
+    _close_origin (admin.CLOSE_ORIGIN_PARAM) carries the admin the action started from so the redirect
+    after closing returns there rather than to the all-projects changelist we dispatch on.
   {% endcomment %}
   <form method="post" action="{% url 'admin:projects_kippoproject_changelist' %}">{% csrf_token %}
     <input type="hidden" name="action" value="close_kippoproject_action">
     <input type="hidden" name="post" value="yes">
+    <input type="hidden" name="_close_origin" value="{{ close_origin }}">
     <input type="hidden" name="_selected_action" value="{{ project.id }}">
     <fieldset class="module aligned">
       {% if form.non_field_errors %}

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -29,6 +29,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from projects.admin import (
+    CLOSE_ORIGIN_PARAM,
     CLOSE_PROJECT_NO_CONTINUATION_VALUE,
     CONTINUATION_SOURCE_PARAM,
     CONTINUATION_SOURCE_VALUE,
@@ -914,6 +915,98 @@ class CloseProjectActionTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertTemplateUsed(response, "admin/projects/close_project_action.html")
         self.assertContains(response, "project1")
+
+    def test_intermediate_form_carries_originating_admin(self):
+        """Started from プロジェクト(実行中), the confirmation form remembers that admin as the origin."""
+        # the 実行中 changelist filters to the in-flight phases -- put the project where it is selectable
+        self.project1.phase = DEFAULT_ACTIVE_PROJECT_PHASES[0]
+        self.project1.save()
+        response = self.client.post(
+            reverse("admin:projects_activekippoproject_changelist"),
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        # breadcrumbs/Cancel (opts) and the hidden origin field both point back at the active admin
+        self.assertEqual(response.context["opts"].model_name, "activekippoproject")
+        self.assertContains(response, f'name="{CLOSE_ORIGIN_PARAM}" value="activekippoproject"')
+
+    def test_completed_but_unclosed_project_is_closable_from_active_changelist(self):
+        """A 完了 project that was never closed stays selectable on プロジェクト(実行中).
+
+        The action runs against the *filtered* changelist queryset, so before 完了 joined
+        DEFAULT_ACTIVE_PROJECT_PHASES the row fell out of the フェーズ filter and the action
+        answered "Select exactly one project to close." instead of opening the wizard.
+        """
+        self.project1.phase = PHASE_COMPLETED
+        self.project1.save()
+        self.assertFalse(self.project1.is_closed)
+
+        response = self.client.post(
+            reverse("admin:projects_activekippoproject_changelist"),
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertTemplateUsed(response, "admin/projects/close_project_action.html")
+
+    def test_close_redirects_to_originating_admin(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                "post": "yes",
+                CLOSE_ORIGIN_PARAM: "activekippoproject",
+                "follow_up": CLOSE_PROJECT_NO_CONTINUATION_VALUE,
+                "close_comment": "Project completed successfully.",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertEqual(response["Location"], reverse("admin:projects_activekippoproject_changelist"))
+        self.project1.refresh_from_db()
+        self.assertTrue(self.project1.is_closed)
+
+    def test_continuation_redirects_to_originating_admin_add(self):
+        response = self.client.post(
+            self.changelist_url,
+            data={
+                "action": "close_kippoproject_action",
+                ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                "post": "yes",
+                CLOSE_ORIGIN_PARAM: "activekippoproject",
+                "follow_up": CONTINUATION_LEAD_SOURCE_VALUE,
+                "close_comment": "",
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        parsed = urlparse(response["Location"])
+        self.assertEqual(parsed.path, reverse("admin:projects_activekippoproject_add"))
+        # the continuation prefill still travels with the redirect
+        self.assertEqual(parse_qs(parsed.query).get("parent_project"), [str(self.project1.id)])
+
+    def test_unregistered_origin_falls_back_to_dispatching_admin(self):
+        for origin in ("notanadmin", "kippouser"):  # unknown model, and a registered non-project model
+            with self.subTest(origin=origin):
+                self.project1.is_closed = False
+                self.project1.save()
+                response = self.client.post(
+                    self.changelist_url,
+                    data={
+                        "action": "close_kippoproject_action",
+                        ACTION_CHECKBOX_NAME: [str(self.project1.id)],
+                        "post": "yes",
+                        CLOSE_ORIGIN_PARAM: origin,
+                        "follow_up": CLOSE_PROJECT_NO_CONTINUATION_VALUE,
+                        "close_comment": "done",
+                    },
+                )
+                self.assertEqual(response.status_code, HTTPStatus.FOUND)
+                self.assertEqual(response["Location"], self.changelist_url)
 
     def test_add_form_prefills_from_get_params(self):
         # the close-wizard opens /add/?_continuation_source=close&... and prefills the new project's
@@ -2748,6 +2841,12 @@ class ActiveProjectPhaseFilterTestCase(IsStaffModelAdminTestCaseBase):
         changelist = self.modeladmin.get_changelist_instance(request)
         return set(changelist.queryset.values_list("phase", flat=True))
 
+    def _changelist_ids(self, query: str = "") -> set:
+        request = RequestFactory().get(f"/admin/projects/activekippoproject/{query}")
+        request.user = self.superuser_no_org
+        changelist = self.modeladmin.get_changelist_instance(request)
+        return set(changelist.queryset.values_list("id", flat=True))
+
     def _phase_filter_choices(self, query: str = "") -> list:
         request = RequestFactory().get(f"/admin/projects/activekippoproject/{query}")
         request.user = self.superuser_no_org
@@ -2761,8 +2860,24 @@ class ActiveProjectPhaseFilterTestCase(IsStaffModelAdminTestCaseBase):
         self.assertNotIn(PhaseMultiSelectListFilter, KippoProjectAdmin(KippoProject, self.site).list_filter)
 
     def test_default_phases_preselected_when_no_param(self):
-        # no `phase` query param => only the two in-flight phases show
+        # no `phase` query param => the in-flight phases plus 完了 show
         self.assertEqual(self._changelist_phases(), set(DEFAULT_ACTIVE_PROJECT_PHASES))
+
+    def test_completed_included_by_default_only_while_not_closed(self):
+        """完了 is a default phase so an unclosed 完了 project stays visible; closing it removes the row."""
+        completed = KippoProject.objects.get(name="project-completed")
+        self.assertIn(PHASE_COMPLETED, DEFAULT_ACTIVE_PROJECT_PHASES)
+        self.assertIn(completed.id, self._changelist_ids())
+
+        # the close action's field set: ActiveKippoProjectManager drops the row on is_closed /
+        # display_as_active, independent of the phase filter
+        completed.is_closed = True
+        completed.display_as_active = False
+        completed.save()
+        self.assertNotIn(completed.id, self._changelist_ids())
+        self.assertNotIn(PHASE_COMPLETED, self._changelist_phases())
+        # and it is still absent when 完了 is the only phase explicitly selected
+        self.assertNotIn(completed.id, self._changelist_ids(f"?phase={PHASE_COMPLETED}"))
 
     def test_single_phase_param_filters(self):
         self.assertEqual(self._changelist_phases("?phase=completed"), {"completed"})
@@ -2775,7 +2890,7 @@ class ActiveProjectPhaseFilterTestCase(IsStaffModelAdminTestCaseBase):
         self.assertEqual(self._changelist_phases("?phase="), set(self.all_phases))
 
     def test_default_phases_rendered_selected(self):
-        # the sidebar pre-highlights the two default phases when no param is present
+        # the sidebar pre-highlights the default phases when no param is present
         phase_labels = dict(VALID_PROJECT_PHASES)
         expected = {str(phase_labels[phase]) for phase in DEFAULT_ACTIVE_PROJECT_PHASES}
         selected = {str(choice["display"]) for choice in self._phase_filter_choices() if choice["selected"]}


### PR DESCRIPTION
## What

Two related fixes to the Close Project flow in the project admins.

### 1. The close action now returns to the admin it was started from

The confirmation form must post to the all-projects changelist — the 実行中/営業中 proxies filter by phase, so a project just moved to 完了 is excluded there and the action would see an empty queryset. Both of its redirects were hardcoded to that same admin, so running Close Project from プロジェクト(実行中) dropped the user on プロジェクト一覧.

The originating admin now travels with the POST in a hidden `_close_origin` field. `_close_origin_opts()` resolves it against the registered `KippoProject` admins — an unknown or non-project value falls back to the dispatching admin, so it can never become an arbitrary reverse target. Both redirects (changelist, and the 継続 continuation `/add/`) are built from it with `reverse()`. The template context's `opts` comes from the origin as well, so the breadcrumbs and Cancel link keep pointing there when the confirmation page re-renders with validation errors.

### 2. 完了 added to `DEFAULT_ACTIVE_PROJECT_PHASES`

`ActiveKippoProjectManager` already drops closed projects (`is_closed=True` / `display_as_active=False`), independent of the phase filter. So the only 完了 rows this surfaces on プロジェクト(実行中) are the ones stamped 完了 **without ever being closed** — an inconsistent state that is worth being able to see. A properly closed project stays hidden even when 完了 is the only phase selected.

This also fixes a reported "the first Close Project does nothing, the second opens the wizard": the admin hands an action the *filtered* changelist queryset, so while 完了 sat outside the default phase filter, selecting such a project answered `Select exactly one project to close.` and redirected instead of opening the wizard.

`SalesKippoProjectAdmin` shares the filter, but `SalesKippoProjectManager` restricts to `SALES_PROJECT_PHASES` (no `completed`), so プロジェクト(営業中) is unchanged.

## Notes for review

- The redirects move from `f"{settings.URL_PREFIX}/admin/projects/kippoproject/…"` to `reverse()`. `URL_PREFIX` is unset in deployment (so `""`) while the API Gateway stage prefix arrives via `SCRIPT_NAME`, which `reverse()` honours and an f-string does not.
- `_close_origin_opts()` reads `modeladmin.admin_site._registry` (private Django API, stable) rather than hardcoding the proxy model names.
- The template hardcodes the `_close_origin` field name; `test_intermediate_form_carries_originating_admin` asserts the rendered name matches `CLOSE_ORIGIN_PARAM`, so a rename can't silently break the wiring.
- **Not** addressed here: an action still receives the filtered changelist queryset, so a row selected from a stale page in any other non-default phase fails the same way. Scoping actions to the explicit selection is a separate change.

## Tests

New in `CloseProjectActionTestCase`:
- origin carried into the confirmation form from the 実行中 changelist
- close redirect to the origin changelist
- continuation redirect to the origin `/add/` with prefill intact
- fallback for unregistered / non-project origins
- a 完了-but-unclosed project is closable directly from the 実行中 changelist

New in `ActiveProjectPhaseFilterTestCase`:
- 完了 visible by default only while unclosed; gone once closed, including under `?phase=completed`

`projects.tests.test_admin`: 187 passed. Full `projects` app: 749 run, 12 errors, all the pre-existing AWS-credential baseline (`InvalidAccessKeyId` in the weekly-effort admin / CSV / download tests). `ruff check` clean.