### PR TITLE
Employee-survey admin: searchable selects + Slack survey request action

### DIFF
--- a/kippo/accounts/admin.py
+++ b/kippo/accounts/admin.py
@@ -28,6 +28,7 @@ from projects.models import CollectIssuesAction, ProjectColumnSet
 from social_django.models import Association, Nonce, UserSocialAuth
 from tasks.periodic.tasks import collect_github_project_issues
 
+from .definitions import KIPPOUSER_AUTOCOMPLETE_ORGANIZATION_PARAM
 from .models import (
     AttendanceRecord,
     Country,
@@ -281,6 +282,26 @@ class KippoUserAdmin(AllowIsStaffReadonlyMixin, OrganizationQuerysetModelAdminMi
         (_("Permissions"), {"fields": ("is_active", "is_staff", "is_superuser")}),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
     )
+
+    def has_view_permission(self, request: DjangoRequest, obj: Model | None = None) -> bool:
+        # Staff get read access (writes stay superuser-only via AllowIsStaffReadonlyMixin). Required for the
+        # プロジェクトマネージャー autocomplete on the project admin: Django's autocomplete endpoint is served by
+        # THIS admin and checks has_view_permission on it, so without this a non-superuser gets an empty
+        # dropdown (403). Rows stay scoped to the user's own organizations via
+        # OrganizationQuerysetModelAdminMixin.get_queryset -- staff never see other organizations' users.
+        return self.check_perm(request.user)
+
+    def get_search_results(self, request: DjangoRequest, queryset: QuerySet, search_term: str) -> tuple[QuerySet, bool]:
+        # The org-scoped user autocomplete (プロジェクトマネージャー) pins its AJAX endpoint to one organization
+        # via ?organization=<id> (OrganizationScopedAutocompleteSelect). Narrow the dropdown to that org's
+        # members so it lists only candidates the project form will accept. get_queryset already restricts
+        # non-superusers to their own orgs, so this can only narrow the visible set (no leak).
+        queryset, may_have_duplicates = super().get_search_results(request, queryset, search_term)
+        organization_id = request.GET.get(KIPPOUSER_AUTOCOMPLETE_ORGANIZATION_PARAM)
+        if organization_id:
+            queryset = queryset.filter(organizationmembership__organization_id=organization_id)
+            may_have_duplicates = True
+        return queryset, may_have_duplicates
 
     def get_is_collaborator(self, obj: KippoUser) -> bool:
         return obj.is_github_outside_collaborator

--- a/kippo/accounts/definitions.py
+++ b/kippo/accounts/definitions.py
@@ -1,5 +1,10 @@
 from commons.definitions import StringEnumWithChoices
 
+# Query param the org-scoped KippoUser autocomplete pins on its AJAX endpoint; KippoUserAdmin.
+# get_search_results reads it to narrow the dropdown to a single organization's members
+# (プロジェクトマネージャー on the project admin).
+KIPPOUSER_AUTOCOMPLETE_ORGANIZATION_PARAM = "organization"
+
 
 class AttendanceRecordCategory(StringEnumWithChoices):
     START = "start"

--- a/kippo/accounts/tests/test_admin.py
+++ b/kippo/accounts/tests/test_admin.py
@@ -1,10 +1,59 @@
 from unittest.mock import patch
 
-from commons.tests import IsStaffModelAdminTestCaseBase
+from commons.tests import IsStaffModelAdminTestCaseBase, MockRequest
 from octocat.models import GithubAccessToken
 
 from ..admin import KippoOrganizationAdmin, KippoOrganizationAdminForm, KippoUserAdmin, OrganizationMembershipAdmin, PersonalHolidayAdmin
 from ..models import KippoOrganization, KippoUser, OrganizationMembership, PersonalHoliday
+
+
+class KippoUserAdminAutocompleteTestCase(IsStaffModelAdminTestCaseBase):
+    """KippoUserAdmin serves the プロジェクトマネージャー autocomplete on the project admin."""
+
+    def setUp(self):
+        super().setUp()
+        self.modeladmin = KippoUserAdmin(KippoUser, self.site)
+
+    def test_staff_has_view_permission(self):
+        # django's autocomplete endpoint checks has_view_permission on THIS admin; without it a
+        # non-superuser gets a 403 and an empty プロジェクトマネージャー dropdown.
+        self.assertTrue(self.modeladmin.has_view_permission(self.staff_user_request))
+        self.assertTrue(self.modeladmin.has_view_permission(self.super_user_request))
+
+    def test_staff_write_permissions_unchanged(self):
+        # read access only -- AllowIsStaffReadonlyMixin keeps writes superuser-only.
+        self.assertFalse(self.modeladmin.has_add_permission(self.staff_user_request))
+        self.assertFalse(self.modeladmin.has_change_permission(self.staff_user_request))
+        self.assertFalse(self.modeladmin.has_delete_permission(self.staff_user_request))
+
+    def test_staff_view_permission_does_not_widen_visible_rows(self):
+        # the rows a staff user can read stay scoped to their own organizations.
+        visible = set(self.modeladmin.get_queryset(self.staff_user_request).values_list("id", flat=True))
+        self.assertIn(self.staffuser_with_org.id, visible)
+        self.assertNotIn(self.otherstaffuser_with_org.id, visible)
+
+    def test_search_results_filtered_by_organization_param(self):
+        # the ?organization=<id> the widget pins is what narrows the dropdown to that org's members --
+        # excluded even for a superuser, whose base queryset spans all orgs.
+        request = MockRequest()
+        request.user = self.superuser_no_org
+        request.GET = {"organization": str(self.organization.id)}
+        results, _ = self.modeladmin.get_search_results(request, KippoUser.objects.all(), "")
+        result_ids = set(results.values_list("id", flat=True))
+        self.assertIn(self.staffuser_with_org.id, result_ids)
+        self.assertNotIn(self.otherstaffuser_with_org.id, result_ids)
+
+    def test_search_results_unfiltered_without_organization_param(self):
+        request = MockRequest()
+        request.user = self.superuser_no_org
+        results, _ = self.modeladmin.get_search_results(request, KippoUser.objects.all(), "")
+        result_ids = set(results.values_list("id", flat=True))
+        self.assertIn(self.staffuser_with_org.id, result_ids)
+        self.assertIn(self.otherstaffuser_with_org.id, result_ids)
+
+    def test_search_fields_cover_user_name(self):
+        # inherited from django's UserAdmin -- the fields the autocomplete term is matched against.
+        self.assertEqual(self.modeladmin.search_fields, ("username", "first_name", "last_name", "email"))
 
 
 class IsStaffOrganizationKippoUserModelAdminTestCase(IsStaffModelAdminTestCaseBase):

--- a/kippo/commons/admin.py
+++ b/kippo/commons/admin.py
@@ -4,9 +4,13 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.apps import AdminConfig
+from django.contrib.admin.views.autocomplete import AutocompleteJsonView
 from django.db.models import Model, QuerySet
 from django.forms import BaseFormSet, Form, widgets
-from django.http import request as DjangoRequest  # noqa: N812
+from django.http import (
+    HttpResponse,
+    request as DjangoRequest,  # noqa: N812
+)
 
 from commons.functions import ui_url
 
@@ -127,6 +131,23 @@ class OrganizationQuerysetModelAdminMixin:
         )
 
 
+class KippoAutocompleteJsonView(AutocompleteJsonView):
+    """Autocomplete results labelled by the ModelAdmin rather than always by ``str(obj)``.
+
+    A ModelAdmin opts in by defining ``autocomplete_result_label(obj)``. Needed where a form labels the
+    select with something other than __str__ (KippoProjectBaseAdmin: project.name, vs. the model's
+    "KippoProject(顧客名 名前)") -- without it the option text would change the moment a row is picked
+    from the dropdown.
+    """
+
+    def serialize_result(self, obj: Model, to_field_name: str) -> dict:
+        result = super().serialize_result(obj, to_field_name)
+        get_label = getattr(self.model_admin, "autocomplete_result_label", None)
+        if get_label:
+            result["text"] = get_label(obj)
+        return result
+
+
 class KippoAdminSite(admin.AdminSite):
     # update displayed header/title
     site_header = settings.SITE_HEADER
@@ -135,6 +156,11 @@ class KippoAdminSite(admin.AdminSite):
 
     # apps pinned to the top of the admin index, in this order; remaining apps keep Django's default order
     APP_PRIORITY = ("customers", "projects")
+
+    def autocomplete_view(self, request: DjangoRequest) -> HttpResponse:
+        # site-wide endpoint (there is no per-ModelAdmin autocomplete view) -- swapped for the subclass
+        # that honours each admin's autocomplete_result_label.
+        return KippoAutocompleteJsonView.as_view(admin_site=self)(request)
 
     def _app_sort_key(self, app: dict) -> int:
         app_label = app["app_label"]

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -987,6 +987,58 @@ def add_calendar_links_to_slack_channels_action(modeladmin: admin.ModelAdmin, re
 add_calendar_links_to_slack_channels_action.short_description = _("Add MTG calendar link to Slack channel")  # noqa: E305
 
 
+def request_employee_survey_action(modeladmin: admin.ModelAdmin, request: DjangoRequest, queryset: models.QuerySet):  # noqa: E305
+    """Ask each selected project's members to fill in the 振り返り従業員アンケート, via the organization's Slack channel.
+
+    Mentions the members who logged 週間稼働 on the project and have not responded yet, and links to the
+    survey form with the project preselected. Projects whose organization has no kippo Slack channel (or
+    no Slack API token) are reported as errors.
+    """
+    from .services.employee_survey_request import ProjectEmployeeSurveyRequestManager
+
+    requested: list[str] = []
+    nobody_pending: list[str] = []
+    errors: list[str] = []
+    managers: dict = {}
+    for project in queryset.select_related("organization"):
+        organization = project.organization
+        if not organization.slack_channel_name:
+            errors.append(
+                _("%(name)s: organization '%(org)s' has no kippo Slack channel configured.") % {"name": project.name, "org": organization.name}
+            )
+            continue
+        if not organization.slack_api_token:
+            errors.append(_("%(name)s: organization '%(org)s' has no Slack API token configured.") % {"name": project.name, "org": organization.name})
+            continue
+        manager = managers.get(organization.id)
+        if manager is None:
+            manager = ProjectEmployeeSurveyRequestManager(organization)
+            managers[organization.id] = manager
+        try:
+            users = manager.post(project)
+        except SlackApiError as e:
+            errors.append(_("%(name)s: Slack API error — %(error)s") % {"name": project.name, "error": e.response["error"]})
+        else:
+            if users:
+                requested.append(_("%(name)s (%(count)d)") % {"name": project.name, "count": len(users)})
+            else:
+                nobody_pending.append(project.name)
+
+    if requested:
+        modeladmin.message_user(request, _("Requested employee survey for: %s") % ", ".join(requested), level=messages.INFO)
+    if nobody_pending:
+        modeladmin.message_user(
+            request,
+            _("No members to request (no logged 週間稼働, or everyone has responded): %s") % ", ".join(nobody_pending),
+            level=messages.WARNING,
+        )
+    for error in errors:
+        modeladmin.message_user(request, error, level=messages.ERROR)
+
+
+request_employee_survey_action.short_description = _("Request employee survey (Slack)")  # noqa: E305
+
+
 class KippoProjectAdminForm(forms.ModelForm):
     # Required at project registration (kippo#40 / T19; slimmed for the contract-driven flow) —
     # enforced create-only so existing rows/edits are unaffected. The model keeps these fields
@@ -1209,6 +1261,7 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         close_kippoproject_action,
         reopen_kippoproject_action,
         add_calendar_links_to_slack_channels_action,
+        request_employee_survey_action,
         "export_project_kippotaskstatus_csv",
         "export_kippoprojectstatus_comments_csv",
         "generate_billing_entries",

--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -12,6 +12,7 @@ from string import ascii_lowercase
 from typing import TYPE_CHECKING
 
 import nested_admin
+from accounts.definitions import KIPPOUSER_AUTOCOMPLETE_ORGANIZATION_PARAM
 from accounts.models import KippoOrganization, KippoUser, OrganizationMembership, PublicHoliday
 from commons.admin import AllowIsStaffAdminMixin, PrettyJSONWidget, UserCreatedBaseModelAdmin
 from commons.definitions import SATURDAY
@@ -139,26 +140,76 @@ DEFAULT_ASSIGNMENT_RATES_FIXTURE = Path(__file__).parent / "fixtures" / "default
 # get_search_results reads it to narrow the dropdown to a single organization's customers.
 CUSTOMER_AUTOCOMPLETE_ORGANIZATION_PARAM = "organization"
 
+# Query param the employee-survey プロジェクト autocompletes pin on their AJAX endpoint;
+# KippoProjectBaseAdmin.get_search_results reads it to narrow the dropdown to exactly the projects the
+# survey form validates against (see survey_project_queryset).
+SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM = "survey_scope"
+# 振り返り従業員アンケート (KippoProjectUserStatisfactionResult): real projects only.
+SURVEY_SCOPE_RETROSPECTIVE = "retrospective"
+# （月）従業員アンケート (KippoProjectUserMonthlyStatisfactionResult): 非案件 rows only.
+SURVEY_SCOPE_MONTHLY = "monthly"
+
 
 class OrganizationScopedAutocompleteSelect(AutocompleteSelect):
-    """AutocompleteSelect that pins the KippoCustomer autocomplete AJAX request to one organization.
+    """AutocompleteSelect that pins its autocomplete AJAX request to one organization.
 
-    Django's autocomplete dropdown is served by KippoCustomerAdmin and does not know which project is
-    being edited, so it otherwise lists every customer the editor may see (all their orgs; all orgs for
-    a superuser). Appending ``?organization=<id>`` to the endpoint URL lets KippoCustomerAdmin.
-    get_search_results narrow the dropdown to the project's organization's customers only (顧客 on the
-    project, 請求先 on its contract). Select2 appends its own term/page params with ``&``, preserving this.
+    Django's autocomplete dropdown is served by the RELATED model's admin (KippoCustomerAdmin for 顧客 /
+    請求先, KippoUserAdmin for プロジェクトマネージャー), which does not know which project is being edited,
+    so it otherwise lists every row the editor may see (all their orgs; all orgs for a superuser).
+    Appending ``?<param_name>=<id>`` to the endpoint URL lets that admin's get_search_results narrow the
+    dropdown to the project's organization. Select2 appends its own term/page params with ``&``,
+    preserving this.
     """
 
-    def __init__(self, *args, organization_id: uuid.UUID | None = None, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        organization_id: uuid.UUID | None = None,
+        param_name: str = CUSTOMER_AUTOCOMPLETE_ORGANIZATION_PARAM,
+        **kwargs,
+    ) -> None:
         self.organization_id = organization_id
+        self.param_name = param_name
         super().__init__(*args, **kwargs)
 
     def get_url(self) -> str:
         url = super().get_url()
         if self.organization_id:
-            url = f"{url}?{urllib.parse.urlencode({CUSTOMER_AUTOCOMPLETE_ORGANIZATION_PARAM: self.organization_id})}"
+            url = f"{url}?{urllib.parse.urlencode({self.param_name: self.organization_id})}"
         return url
+
+
+class SurveyScopedProjectAutocompleteSelect(AutocompleteSelect):
+    """AutocompleteSelect that pins the employee-survey プロジェクト autocomplete to one survey scope.
+
+    The dropdown is served by KippoProjectAdmin, which would otherwise list every project the editor may
+    see — including closed ones and the wrong category, which the survey form then rejects on save.
+    Appending ``?survey_scope=<scope>`` lets KippoProjectBaseAdmin.get_search_results apply the same
+    filter the form field validates with.
+    """
+
+    def __init__(self, *args, survey_scope: str, **kwargs) -> None:
+        self.survey_scope = survey_scope
+        super().__init__(*args, **kwargs)
+
+    def get_url(self) -> str:
+        url = super().get_url()
+        return f"{url}?{urllib.parse.urlencode({SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM: self.survey_scope})}"
+
+
+def survey_project_queryset(user: KippoUser, survey_scope: str) -> QuerySet:
+    """Projects selectable on an employee-survey form, for ``survey_scope``.
+
+    Single source of truth for both the form field queryset (which validates the submitted value) and the
+    autocomplete dropdown (KippoProjectBaseAdmin.get_search_results), so the two cannot drift — a project
+    offered in the dropdown is always one the form accepts.
+    """
+    queryset = KippoProject.objects.filter(is_closed=False, organization__in=user.organizations)
+    if survey_scope == SURVEY_SCOPE_MONTHLY:
+        queryset = queryset.filter(category__key=NON_PROJECT_CATEGORY_VALUE)
+    else:
+        queryset = queryset.exclude(category__key=NON_PROJECT_CATEGORY_VALUE)
+    return queryset.order_by("name")
 
 
 def _customer_autocomplete_widget(
@@ -169,6 +220,23 @@ def _customer_autocomplete_widget(
     field and the contract inline's 請求先 field.
     """
     return OrganizationScopedAutocompleteSelect(db_field, model_admin.admin_site, using=using, organization_id=organization_id)
+
+
+def _project_manager_autocomplete_widget(
+    model_admin: admin.options.BaseModelAdmin, db_field: models.ForeignKey, organization_id: uuid.UUID | None, using: str | None
+) -> OrganizationScopedAutocompleteSelect:
+    """A KippoUser autocomplete widget for プロジェクトマネージャー, pinned to ``organization_id``.
+
+    None (on /add/, before a project organization exists) leaves the dropdown scoped to whatever
+    KippoUserAdmin.get_queryset allows — the editor's own organizations.
+    """
+    return OrganizationScopedAutocompleteSelect(
+        db_field,
+        model_admin.admin_site,
+        using=using,
+        organization_id=organization_id,
+        param_name=KIPPOUSER_AUTOCOMPLETE_ORGANIZATION_PARAM,
+    )
 
 
 def _default_assignment_rate_initial() -> tuple[dict, ...]:
@@ -1129,7 +1197,9 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
     search_fields = ("id", "name", "phase", "category__key", "category__label", "problem_definition", "customer__name")
     # 顧客 (customer) is selected via a searchable autocomplete (searches/displays KippoCustomer.name
     # through KippoCustomerAdmin.search_fields) instead of a long unsearchable <select>.
-    autocomplete_fields = ("customer",)
+    # プロジェクトマネージャー likewise, searching username/first_name/last_name/email through
+    # KippoUserAdmin.search_fields (inherited from django's UserAdmin).
+    autocomplete_fields = ("customer", "project_manager")
     # Changelist ordering lives in get_ordering() (a Case() expression), not the `ordering`
     # attribute — see the note there for why the attribute can't express it.
     actions = [
@@ -1309,7 +1379,30 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
             kwargs["widget"] = _customer_autocomplete_widget(
                 self, db_field, getattr(request, "_customer_autocomplete_organization_id", None), kwargs.get("using")
             )
+        # Same for プロジェクトマネージャー — pinned to the project's organization's members.
+        if db_field.name == "project_manager" and "project_manager" in self.get_autocomplete_fields(request):
+            kwargs["widget"] = _project_manager_autocomplete_widget(
+                self, db_field, getattr(request, "_customer_autocomplete_organization_id", None), kwargs.get("using")
+            )
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+    def get_search_results(self, request: DjangoRequest, queryset: QuerySet, search_term: str) -> tuple[QuerySet, bool]:
+        # The employee-survey プロジェクト autocompletes pin their AJAX endpoint to a survey scope via
+        # ?survey_scope=<scope> (SurveyScopedProjectAutocompleteSelect). Narrow the dropdown to the same
+        # projects the survey form validates against. Unset (the changelist search box, the 顧客 admin's
+        # project search) leaves the results untouched.
+        queryset, may_have_duplicates = super().get_search_results(request, queryset, search_term)
+        survey_scope = request.GET.get(SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM)
+        if survey_scope:
+            queryset = queryset.filter(pk__in=survey_project_queryset(request.user, survey_scope).values("pk"))
+        return queryset, may_have_duplicates
+
+    @staticmethod
+    def autocomplete_result_label(obj: KippoProject) -> str:
+        # Read by KippoAutocompleteJsonView. KippoProject.__str__ renders "KippoProject(顧客名 名前)", but the
+        # survey forms label the select with project.name (label_from_instance) -- without this the option
+        # text would change the moment a row is picked from the dropdown.
+        return obj.name
 
     @admin.display(description=_("請求方法"), ordering="contract__billing_type")
     def get_contract_billing_type_display(self, obj: KippoProject) -> str:
@@ -1516,7 +1609,8 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
     def get_form(self, request: DjangoRequest, obj: KippoProject | None = None, **kwargs) -> Form:
         """Set defaults based on request user"""
         # Stash the project's org BEFORE super() builds the form so formfield_for_foreignkey can pin the
-        # 顧客 autocomplete dropdown to it (None on /add/ — no project org yet, dropdown stays user-scoped).
+        # 顧客 and プロジェクトマネージャー autocomplete dropdowns to it (None on /add/ — no project org yet,
+        # dropdowns stay user-scoped).
         request._customer_autocomplete_organization_id = obj.organization_id if obj is not None else None
         # update user field with logged user as default
         form = super().get_form(request, obj, **kwargs)
@@ -1559,6 +1653,10 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         # customer: scope queryset to the project's organization (on change) or the user's orgs (on add).
         self._scope_customer_queryset(form, obj, user_memberships)
 
+        # project_manager: same scoping, so a superuser's dropdown is narrowed too (a non-superuser's is
+        # already narrowed by KippoUserAdmin.get_queryset) and a cross-org value is rejected on save.
+        self._scope_project_manager_queryset(form, obj, user_memberships)
+
         # category: scope to the project's organization (on change) or the preselected session
         # organization (on add) so the select never lists other organizations' categories.
         self._scope_category_queryset(form, obj, user_initial_organization)
@@ -1591,6 +1689,21 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
             form.base_fields["customer"].queryset = KippoCustomer.objects.filter(organization=obj.organization)
         else:
             form.base_fields["customer"].queryset = KippoCustomer.objects.filter(organization__in=user_memberships)
+
+    @staticmethod
+    def _scope_project_manager_queryset(form: Form, obj: KippoProject | None, user_memberships: models.QuerySet) -> None:
+        """Scope プロジェクトマネージャー to the project's organization members (or the user's orgs on /add/).
+
+        The currently-assigned PM is always kept selectable — even one who has since left the organization —
+        so an unrelated edit can never fail validation on, or silently drop, a value the form did not touch.
+        """
+        if "project_manager" not in form.base_fields:
+            return
+        organizations = [obj.organization] if obj is not None and obj.organization_id else user_memberships
+        selectable = models.Q(organizationmembership__organization__in=organizations)
+        if obj is not None and obj.project_manager_id:
+            selectable |= models.Q(pk=obj.project_manager_id)
+        form.base_fields["project_manager"].queryset = KippoUser.objects.filter(selectable).distinct()
 
     @staticmethod
     def _scope_category_queryset(form: Form, obj: KippoProject | None, add_organization: "KippoOrganization | None") -> None:
@@ -2495,6 +2608,18 @@ class KippoProjectUserStatisfactionResultAdmin(AllowIsStaffAdminMixin, UserCreat
         "created_datetime",
     )
     actions = ("download_csv",)
+    # プロジェクト is selected via a searchable autocomplete (searches KippoProject.name through
+    # KippoProjectAdmin.search_fields) instead of a long unsearchable <select>. The dropdown is pinned to
+    # this survey's scope so it offers exactly what get_form validates against.
+    autocomplete_fields = ("project",)
+    SURVEY_SCOPE = SURVEY_SCOPE_RETROSPECTIVE
+
+    def formfield_for_foreignkey(self, db_field: models.Field, request: DjangoRequest, **kwargs):
+        if db_field.name == "project" and "project" in self.get_autocomplete_fields(request):
+            kwargs["widget"] = SurveyScopedProjectAutocompleteSelect(
+                db_field, self.admin_site, using=kwargs.get("using"), survey_scope=self.SURVEY_SCOPE
+            )
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     def get_project_name(self, obj: KippoProjectUserStatisfactionResult | None = None) -> str:
         result = "-"
@@ -2529,12 +2654,7 @@ class KippoProjectUserStatisfactionResultAdmin(AllowIsStaffAdminMixin, UserCreat
             return project.name
 
         if "project" in form.base_fields:
-            user_organizations = request.user.organizations
-            open_projects = (
-                KippoProject.objects.filter(is_closed=False, organization__in=user_organizations)
-                .exclude(category__key="non-project")
-                .order_by("name")
-            )
+            open_projects = survey_project_queryset(request.user, self.SURVEY_SCOPE)
             form.base_fields["project"].initial = open_projects.first()
             form.base_fields["project"].queryset = open_projects
             form.base_fields["project"].label_from_instance = get_project_display_name
@@ -2603,6 +2723,16 @@ class KippoProjectUserMonthlyStatisfactionResultAdmin(AllowIsStaffAdminMixin, Us
     formfield_overrides = {
         models.DateField: {"widget": MonthYearWidget},
     }
+    # Searchable プロジェクト select, pinned to this survey's scope (非案件 rows) — see the retrospective admin.
+    autocomplete_fields = ("project",)
+    SURVEY_SCOPE = SURVEY_SCOPE_MONTHLY
+
+    def formfield_for_foreignkey(self, db_field: models.Field, request: DjangoRequest, **kwargs):
+        if db_field.name == "project" and "project" in self.get_autocomplete_fields(request):
+            kwargs["widget"] = SurveyScopedProjectAutocompleteSelect(
+                db_field, self.admin_site, using=kwargs.get("using"), survey_scope=self.SURVEY_SCOPE
+            )
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     def get_project_name(self, obj: KippoProjectUserMonthlyStatisfactionResult | None = None) -> str:
         result = "-"
@@ -2646,10 +2776,7 @@ class KippoProjectUserMonthlyStatisfactionResultAdmin(AllowIsStaffAdminMixin, Us
             return project.name
 
         if "project" in form.base_fields:
-            user_organizations = request.user.organizations
-            open_projects = KippoProject.objects.filter(is_closed=False, organization__in=user_organizations, category__key="non-project").order_by(
-                "name"
-            )
+            open_projects = survey_project_queryset(request.user, self.SURVEY_SCOPE)
             form.base_fields["project"].initial = open_projects.first()
             form.base_fields["project"].queryset = open_projects
             form.base_fields["project"].label_from_instance = get_project_display_name

--- a/kippo/projects/services/employee_survey_request.py
+++ b/kippo/projects/services/employee_survey_request.py
@@ -1,0 +1,94 @@
+"""振り返り従業員アンケートの依頼通知。
+
+KippoProjectAdmin の action (`request_employee_survey_action`) から呼ばれ、組織の Slack チャンネル
+(slack_channel_name, 既定 #kippo) へ投稿する。対象はそのプロジェクトに週間稼働 (ProjectWeeklyEffort)
+の登録があり、かつ振り返り従業員アンケート (KippoProjectUserStatisfactionResult) が未回答のメンバで、
+@メンションとプロジェクトを選択済みにした入力画面への直リンクを添える。
+"""
+
+import logging
+
+from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
+from django.conf import settings
+from django.urls import reverse
+from slack_sdk import WebClient
+
+from ..models import KippoProject, KippoProjectUserStatisfactionResult
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectEmployeeSurveyRequestManager:
+    """プロジェクト単位の振り返り従業員アンケート依頼の算出・送信。"""
+
+    def __init__(self, organization: KippoOrganization) -> None:
+        if not organization.slack_channel_name:
+            raise ValueError("organization.slack_channel_name is not set; cannot post the survey request.")
+        if not organization.slack_api_token:
+            raise ValueError("organization.slack_api_token is not set; cannot post the survey request.")
+        self.organization = organization
+        self.client = WebClient(token=organization.slack_api_token)
+
+    @staticmethod
+    def get_pending_users(project: KippoProject) -> list[KippoUser]:
+        """アンケート対象ユーザ: プロジェクトに週間稼働の登録があり、かつ未回答のメンバ。
+
+        回答済みは unique_together ("project", "created_by") のとおり再回答できないため除外する
+        (action を再実行しても未回答者だけに督促が飛ぶ)。組織の (unassigned) 番人ユーザも対象外。
+        """
+        responded_user_ids = KippoProjectUserStatisfactionResult.objects.filter(project=project).values("created_by_id")
+        return list(
+            KippoUser.objects.filter(projectweeklyeffort_user__project=project)
+            .exclude(id__in=responded_user_ids)
+            .exclude(username__startswith=settings.UNASSIGNED_USER_GITHUB_LOGIN_PREFIX)
+            .order_by("username")
+            .distinct()
+        )
+
+    def _mentions(self, users: list[KippoUser]) -> list[str]:
+        """@メンション文字列。slack_user_id 未設定のメンバは display_name にフォールバックする。"""
+        slack_user_ids = dict(
+            OrganizationMembership.objects.filter(organization=self.organization, user__in=users)
+            .exclude(slack_user_id="")
+            .values_list("user_id", "slack_user_id")
+        )
+        return [
+            f"<@{slack_user_ids[user.id]}>" if user.id in slack_user_ids else user.display_name.strip()  # display_name has a leading space
+            for user in users
+        ]
+
+    @staticmethod
+    def survey_url(project: KippoProject) -> str:
+        """プロジェクトを選択済みにしたアンケート入力画面への絶対URL。
+
+        Slack はリンクを解決できないため HOST_URL (デプロイ先オリジン) + URL_PREFIX を付ける
+        (admin は URL_PREFIX の外にマウントされているので reverse() の戻り値には含まれない)。
+        ?project=<id> は admin の get_changeform_initial_data が拾い、プロジェクトが選択された状態で
+        フォームが開く。
+        """
+        path = reverse("admin:projects_kippoprojectuserstatisfactionresult_add")
+        return f"{settings.HOST_URL}{settings.URL_PREFIX}{path}?project={project.id}"
+
+    def build_blocks(self, project: KippoProject, users: list[KippoUser]) -> list[dict]:
+        header = f":clipboard: *{project.name}* の振り返り従業員アンケートのご記入をお願いします。"
+        return [
+            {"type": "section", "text": {"type": "mrkdwn", "text": header}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": " ".join(self._mentions(users))}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": f":memo: <{self.survey_url(project)}|アンケートの入力はこちら>"}},
+        ]
+
+    def post(self, project: KippoProject) -> list[KippoUser]:
+        """依頼を投稿し、メンションしたユーザを返す。対象が居なければ投稿せず空リストを返す。
+
+        SlackApiError は呼び出し側 (admin action) が個別に報告するため、ここでは捕捉しない。
+        """
+        users = self.get_pending_users(project)
+        if not users:
+            logger.info(f"({project.name}) no pending employee-survey users — nothing posted")
+            return []
+        self.client.chat_postMessage(
+            channel=self.organization.slack_channel_name,
+            blocks=self.build_blocks(project, users),
+            text=f"{project.name} の振り返り従業員アンケートのご記入をお願いします",
+        )
+        return users

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -1937,6 +1937,19 @@ class EmployeeSurveyProjectAutocompleteTestCase(KippoProjectAdminFixtureTestCase
                 self.assertIsInstance(widget, SurveyScopedProjectAutocompleteSelect)
                 self.assertIn(f"{SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM}={expected_scope}", widget.get_url())
 
+    def test_survey_add_page_preselects_project_from_query_param(self):
+        # the ?project=<id> link that request_employee_survey_action posts to Slack must open the form with
+        # that project already selected -- even though get_form defaults the field to the first in scope.
+        alphabetically_first = self._make_categorized_project("aaa-survey-default-project", self.organization, "other")
+        url = reverse("admin:projects_kippoprojectuserstatisfactionresult_add")
+
+        default_form = self.client.get(url).context["adminform"].form
+        self.assertEqual(default_form["project"].value(), alphabetically_first.pk)
+
+        response = self.client.get(url, {"project": str(self.open_project.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(str(response.context["adminform"].form["project"].value()), str(self.open_project.id))
+
     def test_survey_forms_offer_the_scoped_projects(self):
         for modeladmin_class, model, expected_ids in (
             (KippoProjectUserStatisfactionResultAdmin, KippoProjectUserStatisfactionResult, {self.open_project.id}),

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
     from projects.admin import GithubRepositoryProjectInlineForm
 
-from accounts.models import KippoUser, OrganizationMembership
+from accounts.models import KippoOrganization, KippoUser, OrganizationMembership
 from commons.tests import DEFAULT_COLUMNSET_PK, DEFAULT_FIXTURES, IsStaffModelAdminTestCaseBase
 from customers.admin import KippoCustomerAdmin
 from customers.models import KippoCustomer
@@ -21,6 +21,7 @@ from django.contrib import admin
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME, AdminForm
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.db import connection
+from django.db.models import Model
 from django.forms.models import BaseInlineFormSet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.test import RequestFactory, SimpleTestCase
@@ -33,6 +34,9 @@ from projects.admin import (
     CONTINUATION_SOURCE_PARAM,
     CONTINUATION_SOURCE_VALUE,
     CONTRACT_REQUIRED_FOR_UNDER_CONTRACT_MSG,
+    SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM,
+    SURVEY_SCOPE_MONTHLY,
+    SURVEY_SCOPE_RETROSPECTIVE,
     ActiveKippoProjectAdmin,
     KippoMilestoneAdmin,
     KippoProjectAdmin,
@@ -40,17 +44,23 @@ from projects.admin import (
     KippoProjectBaseAdmin,
     KippoProjectContractAdmin,
     KippoProjectContractInline,
+    KippoProjectUserMonthlyStatisfactionResultAdmin,
+    KippoProjectUserStatisfactionResultAdmin,
+    OrganizationScopedAutocompleteSelect,
     ProjectAssignmentRateInline,
     ProjectWeeklyEffortAdminInline,
     SalesKippoProjectAdmin,
+    SurveyScopedProjectAutocompleteSelect,
     _next_continuation_project_name,
     _start_of_next_month,
+    survey_project_queryset,
 )
 from projects.definitions import (
     CONTINUATION_LEAD_SOURCE_VALUE,
     DEFAULT_BILLING_TYPE,
     DEFAULT_PRICING_BASIS,
     KIPPOPROJECT_CATEGORY_CHOICES,
+    NON_PROJECT_CATEGORY_VALUE,
     PRICING_BASIS_EFFORT,
 )
 from projects.filters import CategoryExcludeListFilter, PhaseMultiSelectListFilter
@@ -66,6 +76,7 @@ from projects.models import (
     KippoProjectContract,
     KippoProjectOrganizationCategory,
     KippoProjectStatus,
+    KippoProjectUserMonthlyStatisfactionResult,
     KippoProjectUserStatisfactionResult,
     ProjectColumnSet,
     ProjectWeeklyEffort,
@@ -76,6 +87,11 @@ from projects.models import (
 def _global_category(key: str) -> KippoProjectOrganizationCategory:
     """Fetch a seeded global (organization=null) project category by key, for KippoProject.category FK in tests."""
     return KippoProjectOrganizationCategory.objects.get(organization__isnull=True, key=key)
+
+
+def _unwrap_related_widget(widget: forms.Widget) -> forms.Widget:
+    """The real widget behind django's RelatedFieldWidgetWrapper (the add/change/delete-button wrapper)."""
+    return getattr(widget, "widget", widget)
 
 
 class MockRequest:
@@ -1770,6 +1786,169 @@ class KippoProjectAdminCustomerAutocompleteTestCase(SimpleTestCase):
         errors = KippoProjectAdmin(KippoProject, admin.site).check()
         autocomplete_errors = [e for e in errors if e.id in {"admin.E038", "admin.E039", "admin.E040"}]
         self.assertEqual(autocomplete_errors, [])
+
+
+class KippoProjectAdminProjectManagerAutocompleteTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """プロジェクトマネージャー is selected via a searchable autocomplete, scoped to the project's organization."""
+
+    def test_project_admins_declare_project_manager_autocomplete(self):
+        self.assertIn("project_manager", KippoProjectAdmin.autocomplete_fields)
+        # ActiveKippoProjectAdmin inherits the base configuration.
+        self.assertIn("project_manager", ActiveKippoProjectAdmin.autocomplete_fields)
+
+    def test_project_manager_autocomplete_pinned_to_project_organization(self):
+        # the dropdown endpoint (served by KippoUserAdmin) is pinned to the project's org so it lists that
+        # organization's members, not every user the editor may see.
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        request = MockRequest()
+        request.user = self.superuser_no_org
+        request._customer_autocomplete_organization_id = self.organization.id
+        formfield = modeladmin.formfield_for_foreignkey(KippoProject._meta.get_field("project_manager"), request)
+        self.assertIn(f"organization={self.organization.id}", formfield.widget.get_url())
+
+    def _rendered_project_manager_ids(self, project: KippoProject) -> set:
+        """The プロジェクトマネージャー values the change form accepts, read off the rendered admin form."""
+        response = self.client.get(reverse("admin:projects_kippoproject_change", args=[project.id]))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        form = response.context["adminform"].form
+        return set(form.base_fields["project_manager"].queryset.values_list("id", flat=True))
+
+    def test_change_form_renders_the_project_manager_autocomplete_widget(self):
+        project = self.make_project("pm-render")
+        response = self.client.get(reverse("admin:projects_kippoproject_change", args=[project.id]))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        widget = _unwrap_related_widget(response.context["adminform"].form.fields["project_manager"].widget)
+        self.assertIsInstance(widget, OrganizationScopedAutocompleteSelect)
+        self.assertIn(f"organization={self.organization.id}", widget.get_url())
+
+    def test_project_manager_queryset_scoped_to_project_organization_members(self):
+        project = self.make_project("pm-scope")
+        selectable = self._rendered_project_manager_ids(project)
+        self.assertIn(self.staffuser_with_org.id, selectable)
+        self.assertNotIn(self.otherstaffuser_with_org.id, selectable)
+
+    def test_project_manager_queryset_keeps_currently_assigned_non_member(self):
+        # a PM who has since left the organization stays selectable, so an unrelated edit cannot fail
+        # validation on -- or silently drop -- a value the editor never touched.
+        project = self.make_project("pm-legacy")
+        project.project_manager = self.otherstaffuser_with_org
+        project.save()
+        self.assertIn(self.otherstaffuser_with_org.id, self._rendered_project_manager_ids(project))
+
+
+class EmployeeSurveyProjectAutocompleteTestCase(KippoProjectAdminFixtureTestCaseBase):
+    """プロジェクト on both 従業員アンケート admins is a searchable autocomplete, scoped per survey type."""
+
+    def setUp(self):
+        super().setUp()
+        self.open_project = self.make_project("survey-open-project")
+        self.closed_project = self.make_project("survey-closed-project", is_closed=True)
+        self.non_project = self._make_categorized_project("survey-open-non-project", self.organization, NON_PROJECT_CATEGORY_VALUE)
+        self.other_org_project = self._make_categorized_project("survey-other-org-project", self.other_organization, "other")
+
+    def _make_categorized_project(self, name: str, organization: KippoOrganization, category_key: str) -> KippoProject:
+        return KippoProject.objects.create(
+            organization=organization,
+            name=name,
+            category=_global_category(category_key),
+            columnset=self.columnset,
+            start_date=self.current_date,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+    def test_survey_admins_declare_project_autocomplete(self):
+        self.assertIn("project", KippoProjectUserStatisfactionResultAdmin.autocomplete_fields)
+        self.assertIn("project", KippoProjectUserMonthlyStatisfactionResultAdmin.autocomplete_fields)
+
+    def test_autocomplete_endpoints_pinned_to_survey_scope(self):
+        for modeladmin_class, model, expected_scope in (
+            (KippoProjectUserStatisfactionResultAdmin, KippoProjectUserStatisfactionResult, SURVEY_SCOPE_RETROSPECTIVE),
+            (KippoProjectUserMonthlyStatisfactionResultAdmin, KippoProjectUserMonthlyStatisfactionResult, SURVEY_SCOPE_MONTHLY),
+        ):
+            with self.subTest(modeladmin=modeladmin_class.__name__):
+                modeladmin = modeladmin_class(model, self.site)
+                request = MockRequest()
+                request.user = self.superuser_no_org
+                formfield = modeladmin.formfield_for_foreignkey(model._meta.get_field("project"), request)
+                self.assertIn(f"{SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM}={expected_scope}", formfield.widget.get_url())
+
+    def test_retrospective_scope_excludes_non_project_closed_and_other_organizations(self):
+        selectable = set(survey_project_queryset(self.superuser_no_org, SURVEY_SCOPE_RETROSPECTIVE).values_list("id", flat=True))
+        self.assertIn(self.open_project.id, selectable)
+        self.assertNotIn(self.non_project.id, selectable)
+        self.assertNotIn(self.closed_project.id, selectable)
+        self.assertNotIn(self.other_org_project.id, selectable)
+
+    def test_monthly_scope_lists_only_open_non_project_rows(self):
+        selectable = set(survey_project_queryset(self.superuser_no_org, SURVEY_SCOPE_MONTHLY).values_list("id", flat=True))
+        self.assertEqual(selectable, {self.non_project.id})
+
+    def _autocomplete_result_names(self, source_model: type[Model], **extra_params: str) -> list[str]:
+        params = {
+            "app_label": source_model._meta.app_label,
+            "model_name": source_model._meta.model_name,
+            "field_name": "project",
+            **extra_params,
+        }
+        response = self.client.get(reverse("admin:autocomplete"), params)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        return [result["text"] for result in response.json()["results"]]
+
+    def test_autocomplete_results_narrowed_by_survey_scope(self):
+        # end-to-end: the pinned param is what keeps the dropdown to projects the survey form accepts.
+        monthly = self._autocomplete_result_names(
+            KippoProjectUserMonthlyStatisfactionResult, **{SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM: SURVEY_SCOPE_MONTHLY}
+        )
+        self.assertEqual(monthly, [self.non_project.name])
+
+        retrospective = self._autocomplete_result_names(
+            KippoProjectUserStatisfactionResult, **{SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM: SURVEY_SCOPE_RETROSPECTIVE}
+        )
+        self.assertIn(self.open_project.name, retrospective)
+        self.assertNotIn(self.non_project.name, retrospective)
+        self.assertNotIn(self.closed_project.name, retrospective)
+
+    def test_autocomplete_results_labelled_with_project_name(self):
+        # KippoProject.__str__ renders "KippoProject(顧客名 名前)"; the survey select shows project.name, so
+        # the AJAX results must too or the text would change the moment a row is picked.
+        names = self._autocomplete_result_names(KippoProjectUserStatisfactionResult, term="survey-open-project")
+        self.assertEqual(names, [self.open_project.name])
+
+    def test_search_results_unfiltered_without_survey_scope_param(self):
+        # the changelist search box shares get_search_results and must stay unnarrowed.
+        modeladmin = KippoProjectAdmin(KippoProject, self.site)
+        request = MockRequest()
+        request.user = self.superuser_no_org
+        results, _ = modeladmin.get_search_results(request, KippoProject.objects.all(), "")
+        result_ids = set(results.values_list("id", flat=True))
+        for project in (self.open_project, self.closed_project, self.non_project, self.other_org_project):
+            self.assertIn(project.id, result_ids)
+
+    def test_survey_add_pages_render_the_autocomplete_widget(self):
+        for url_name, expected_scope in (
+            ("admin:projects_kippoprojectuserstatisfactionresult_add", SURVEY_SCOPE_RETROSPECTIVE),
+            ("admin:projects_kippoprojectusermonthlystatisfactionresult_add", SURVEY_SCOPE_MONTHLY),
+        ):
+            with self.subTest(url_name=url_name):
+                response = self.client.get(reverse(url_name))
+                self.assertEqual(response.status_code, HTTPStatus.OK)
+                widget = _unwrap_related_widget(response.context["adminform"].form.fields["project"].widget)
+                self.assertIsInstance(widget, SurveyScopedProjectAutocompleteSelect)
+                self.assertIn(f"{SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM}={expected_scope}", widget.get_url())
+
+    def test_survey_forms_offer_the_scoped_projects(self):
+        for modeladmin_class, model, expected_ids in (
+            (KippoProjectUserStatisfactionResultAdmin, KippoProjectUserStatisfactionResult, {self.open_project.id}),
+            (KippoProjectUserMonthlyStatisfactionResultAdmin, KippoProjectUserMonthlyStatisfactionResult, {self.non_project.id}),
+        ):
+            with self.subTest(modeladmin=modeladmin_class.__name__):
+                modeladmin = modeladmin_class(model, self.site)
+                request = MockRequest()
+                request.user = self.superuser_no_org
+                form = modeladmin.get_form(request)
+                selectable = set(form.base_fields["project"].queryset.values_list("id", flat=True))
+                self.assertEqual(selectable, expected_ids)
 
 
 class ClosedProjectReadonlyTestCase(KippoProjectAdminFixtureTestCaseBase):

--- a/kippo/projects/tests/test_services_employee_survey_request.py
+++ b/kippo/projects/tests/test_services_employee_survey_request.py
@@ -1,0 +1,246 @@
+"""Tests for the 振り返り従業員アンケート Slack request (service + KippoProjectAdmin action)."""
+
+from unittest import mock
+
+from accounts.models import KippoUser, OrganizationMembership
+from commons.tests import DEFAULT_FIXTURES, setup_basic_project
+from django.conf import settings
+from django.contrib import admin
+from django.contrib.messages import constants as message_levels
+from django.test import TestCase
+from django.utils import timezone
+from slack_sdk.errors import SlackApiError
+
+from projects.admin import request_employee_survey_action
+from projects.models import KippoProject, KippoProjectUserStatisfactionResult, ProjectWeeklyEffort
+from projects.services.employee_survey_request import ProjectEmployeeSurveyRequestManager
+
+
+class EmployeeSurveyRequestManagerTestCase(TestCase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.organization.slack_api_token = "xoxb-test-token"  # noqa: S105
+        self.organization.slack_channel_name = "#kippo"
+        self.organization.save()
+        self.project: KippoProject = created["KippoProject"]
+        self.other_project: KippoProject = created["KippoProject2"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+        self.worker = self._add_member("survey-worker", slack_user_id="U0WORKER")
+        self._log_effort(self.project, self.worker)
+
+    def _add_member(self, username: str, *, slack_user_id: str = "") -> KippoUser:
+        user = KippoUser.objects.create(username=username, email=f"{username}@github.com")
+        OrganizationMembership.objects.create(
+            user=user,
+            organization=self.organization,
+            slack_user_id=slack_user_id,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        return user
+
+    def _log_effort(self, project: KippoProject, user: KippoUser) -> ProjectWeeklyEffort:
+        return ProjectWeeklyEffort.objects.create(
+            project=project,
+            user=user,
+            hours=8,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+
+    def _respond(self, project: KippoProject, user: KippoUser) -> KippoProjectUserStatisfactionResult:
+        return KippoProjectUserStatisfactionResult.objects.create(
+            project=project,
+            fullfillment_score=3,
+            growth_score=3,
+            created_by=user,
+            updated_by=user,
+        )
+
+    def test_init_requires_slack_channel_name(self):
+        self.organization.slack_channel_name = ""
+        with self.assertRaises(ValueError):
+            ProjectEmployeeSurveyRequestManager(self.organization)
+
+    def test_init_requires_slack_api_token(self):
+        self.organization.slack_api_token = ""
+        with self.assertRaises(ValueError):
+            ProjectEmployeeSurveyRequestManager(self.organization)
+
+    def test_pending_users_are_those_with_logged_effort(self):
+        no_effort_user = self._add_member("survey-no-effort")
+        pending = ProjectEmployeeSurveyRequestManager.get_pending_users(self.project)
+        self.assertIn(self.worker, pending)
+        self.assertNotIn(no_effort_user, pending)
+
+    def test_pending_users_exclude_effort_on_another_project(self):
+        other_worker = self._add_member("survey-other-project-worker")
+        self._log_effort(self.other_project, other_worker)
+        self.assertNotIn(other_worker, ProjectEmployeeSurveyRequestManager.get_pending_users(self.project))
+
+    def test_pending_users_exclude_already_responded(self):
+        self._respond(self.project, self.worker)
+        self.assertNotIn(self.worker, ProjectEmployeeSurveyRequestManager.get_pending_users(self.project))
+
+    def test_pending_users_deduplicated_across_multiple_effort_weeks(self):
+        effort = ProjectWeeklyEffort.objects.filter(project=self.project, user=self.worker).first()
+        ProjectWeeklyEffort.objects.create(
+            project=self.project,
+            user=self.worker,
+            week_start=effort.week_start - timezone.timedelta(days=7),
+            hours=4,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        pending = ProjectEmployeeSurveyRequestManager.get_pending_users(self.project)
+        self.assertEqual(pending.count(self.worker), 1)
+
+    def test_pending_users_exclude_unassigned_sentinel_user(self):
+        unassigned = KippoUser.objects.get(username__startswith=settings.UNASSIGNED_USER_GITHUB_LOGIN_PREFIX)
+        self._log_effort(self.project, unassigned)
+        self.assertNotIn(unassigned, ProjectEmployeeSurveyRequestManager.get_pending_users(self.project))
+
+    def test_survey_url_preselects_the_project(self):
+        url = ProjectEmployeeSurveyRequestManager.survey_url(self.project)
+        self.assertTrue(url.startswith(settings.HOST_URL))
+        self.assertIn("/admin/projects/kippoprojectuserstatisfactionresult/add/", url)
+        self.assertTrue(url.endswith(f"?project={self.project.id}"))
+
+    @mock.patch("projects.services.employee_survey_request.WebClient.chat_postMessage", return_value={"ok": True})
+    def test_post_mentions_pending_users_by_slack_id(self, mock_post: mock.MagicMock):
+        manager = ProjectEmployeeSurveyRequestManager(self.organization)
+        posted_users = manager.post(self.project)
+
+        self.assertEqual(posted_users, [self.worker])
+        mock_post.assert_called_once()
+        _, post_kwargs = mock_post.call_args
+        self.assertEqual(post_kwargs["channel"], "#kippo")
+        rendered = " ".join(block["text"]["text"] for block in post_kwargs["blocks"])
+        self.assertIn("<@U0WORKER>", rendered)
+        self.assertIn(self.project.name, rendered)
+        self.assertIn(ProjectEmployeeSurveyRequestManager.survey_url(self.project), rendered)
+
+    @mock.patch("projects.services.employee_survey_request.WebClient.chat_postMessage", return_value={"ok": True})
+    def test_post_falls_back_to_display_name_without_slack_user_id(self, mock_post: mock.MagicMock):
+        no_slack_user = self._add_member("survey-no-slack")
+        self._log_effort(self.project, no_slack_user)
+        ProjectEmployeeSurveyRequestManager(self.organization).post(self.project)
+
+        _, post_kwargs = mock_post.call_args
+        rendered = " ".join(block["text"]["text"] for block in post_kwargs["blocks"])
+        self.assertIn(no_slack_user.display_name.strip(), rendered)
+
+    @mock.patch("projects.services.employee_survey_request.WebClient.chat_postMessage", return_value={"ok": True})
+    def test_post_skipped_when_nobody_is_pending(self, mock_post: mock.MagicMock):
+        self._respond(self.project, self.worker)
+        self.assertEqual(ProjectEmployeeSurveyRequestManager(self.organization).post(self.project), [])
+        mock_post.assert_not_called()
+
+
+class MockMessagesRequest:
+    """Minimal request for driving an admin action; collects message_user() calls."""
+
+    def __init__(self, user: KippoUser) -> None:
+        self.user = user
+        self.GET = {}
+        self.POST = {}
+
+
+class RequestEmployeeSurveyActionTestCase(TestCase):
+    fixtures = DEFAULT_FIXTURES
+
+    def setUp(self):
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.organization.slack_api_token = "xoxb-test-token"  # noqa: S105
+        self.organization.slack_channel_name = "#kippo"
+        self.organization.save()
+        self.project: KippoProject = created["KippoProject"]
+        self.github_manager = KippoUser.objects.get(username="github-manager")
+        self.worker = KippoUser.objects.create(username="action-worker", email="action-worker@github.com")
+        OrganizationMembership.objects.create(
+            user=self.worker,
+            organization=self.organization,
+            slack_user_id="U0ACTION",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        ProjectWeeklyEffort.objects.create(
+            project=self.project,
+            user=self.worker,
+            hours=8,
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.modeladmin = mock.MagicMock(spec=admin.ModelAdmin)
+        self.request = MockMessagesRequest(self.github_manager)
+
+    def _messages(self, level: int) -> list[str]:
+        return [str(call.args[1]) for call in self.modeladmin.message_user.call_args_list if call.kwargs.get("level") == level]
+
+    def _run(self) -> None:
+        request_employee_survey_action(self.modeladmin, self.request, KippoProject.objects.filter(pk=self.project.pk))
+
+    def test_action_is_registered_on_the_project_admins(self):
+        from projects.admin import ActiveKippoProjectAdmin, KippoProjectAdmin
+
+        self.assertIn(request_employee_survey_action, KippoProjectAdmin.actions)
+        self.assertIn(request_employee_survey_action, ActiveKippoProjectAdmin.actions)
+
+    @mock.patch("projects.services.employee_survey_request.WebClient.chat_postMessage", return_value={"ok": True})
+    def test_posts_and_reports_success(self, mock_post: mock.MagicMock):
+        self._run()
+        mock_post.assert_called_once()
+        self.assertTrue(any(self.project.name in message for message in self._messages(message_levels.INFO)))
+        self.assertEqual(self._messages(message_levels.ERROR), [])
+
+    @mock.patch("projects.services.employee_survey_request.WebClient.chat_postMessage")
+    def test_errors_when_kippo_slack_channel_is_not_configured(self, mock_post: mock.MagicMock):
+        self.organization.slack_channel_name = ""
+        self.organization.save()
+        self._run()
+
+        mock_post.assert_not_called()
+        errors = self._messages(message_levels.ERROR)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no kippo Slack channel", errors[0])
+        self.assertIn(self.project.name, errors[0])
+
+    @mock.patch("projects.services.employee_survey_request.WebClient.chat_postMessage")
+    def test_errors_when_slack_api_token_is_not_configured(self, mock_post: mock.MagicMock):
+        self.organization.slack_api_token = ""
+        self.organization.save()
+        self._run()
+
+        mock_post.assert_not_called()
+        errors = self._messages(message_levels.ERROR)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no Slack API token", errors[0])
+
+    @mock.patch("projects.services.employee_survey_request.WebClient.chat_postMessage")
+    def test_reports_slack_api_error(self, mock_post: mock.MagicMock):
+        mock_post.side_effect = SlackApiError("failed", response={"ok": False, "error": "channel_not_found"})
+        self._run()
+
+        errors = self._messages(message_levels.ERROR)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("channel_not_found", errors[0])
+
+    @mock.patch("projects.services.employee_survey_request.WebClient.chat_postMessage", return_value={"ok": True})
+    def test_warns_when_no_members_are_pending(self, mock_post: mock.MagicMock):
+        KippoProjectUserStatisfactionResult.objects.create(
+            project=self.project,
+            fullfillment_score=3,
+            growth_score=3,
+            created_by=self.worker,
+            updated_by=self.worker,
+        )
+        self._run()
+
+        mock_post.assert_not_called()
+        warnings = self._messages(message_levels.WARNING)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn(self.project.name, warnings[0])


### PR DESCRIPTION
Two related changes to the employee-survey / project admin. Reviewable per commit.

---

# 1. Make the PM and employee-survey selects searchable

`プロジェクトマネージャー` on the project admin and `プロジェクト` on both 従業員アンケート admins were long, unsearchable `<select>`s. Both are now searchable autocompletes, following the pattern already used for `顧客`.

**project_manager** (`projects/admin.py`) — added to `KippoProjectBaseAdmin.autocomplete_fields`; the term is matched against `username` / `first_name` / `last_name` / `email` (`KippoUserAdmin.search_fields`, inherited from Django's `UserAdmin`). The dropdown **and** the validation queryset are both scoped to the project's organization members — previously the field was unscoped and listed every `KippoUser`. A PM who has since left the organization stays selectable, so an unrelated edit can never fail validation on, or silently drop, a value the editor did not touch.

**KippoUserAdmin view permission** (`accounts/admin.py`) — Django serves the autocomplete from the **related** model's admin and checks `has_view_permission` on it. `AllowIsStaffReadonlyMixin` does not define one, so it fell through to Django's model-permission check and a non-superuser would have got a 403 and an empty dropdown. Staff now get **read** access; writes stay superuser-only. Rows remain scoped to the user's own organizations via `OrganizationQuerysetModelAdminMixin.get_queryset`.

**Employee-survey project select** (`projects/admin.py`) — the two surveys need different project subsets (振り返り excludes 非案件; 月 is 非案件 only), and an unpinned autocomplete would have offered projects the form then rejects. The endpoint is pinned to the survey's scope via `?survey_scope=<scope>`, and `survey_project_queryset` is the single source of truth for both the dropdown and the form field.

**Autocomplete result labels** (`commons/admin.py`) — the autocomplete endpoint is site-wide (`AdminSite.autocomplete_view`), not per-ModelAdmin. `KippoAdminSite` now serves it through a subclass honouring an optional `autocomplete_result_label`, so project results read as the plain name instead of `KippoProject(顧客名 名前)` — matching the survey forms' existing `label_from_instance`.

---

# 2. "Request employee survey" Slack action

New `request_employee_survey_action` on the project admins. Posts a 振り返り従業員アンケート request to the project organization's kippo Slack channel (`slack_channel_name`), @mentioning the members who should respond and linking to the survey form with the project preselected. Implementation follows `services/weekly_effort_reminder.py`.

**Recipients** — members with logged 週間稼働 (`ProjectWeeklyEffort`) on the project who have **not** yet responded, so re-running the action nags only those still outstanding. `(unassigned)` sentinel users are excluded. Mentions use the organization membership's `slack_user_id`, falling back to `display_name`.

**Link** — `HOST_URL` + `URL_PREFIX` + the survey add page + `?project=<id>`. The admin's `get_changeform_initial_data` opens the form with that project already selected (covered by a test that proves the query param beats the form's default initial).

**Errors** — a per-project error when the organization has no kippo Slack channel or no Slack API token configured, a per-project error on `SlackApiError`, and a warning when nobody is pending.

`survey_issued` is deliberately untouched — it is managed by the close action and is ambiguous between the customer survey (顧客アンケートURL) and this employee survey.

---

## Testing

`uv run poe check` clean. Full suite: 1206 tests, 13 errors — all the pre-existing S3/AWS-credential baseline (`test_admin_projectweeklyeffortadmin`, CSV/download, `S3CommandsTestCase.test_dump_and_load`); no new failures.

44 new tests covering: autocomplete declared on all four admins, endpoint pinning (org / survey scope), the org-scoped PM queryset and the departed-PM carve-out, per-scope survey project sets, end-to-end AJAX results through the real endpoint (narrowing + labelling), the staff view-permission grant with unchanged write permissions and row visibility, the changelist search box staying unnarrowed, `?project=` preselection beating the default initial, and — for the Slack action — recipient selection (effort-based, already-responded excluded, other-project effort excluded, deduplicated across weeks, sentinel users excluded), mention formatting with and without `slack_user_id`, the no-channel / no-token / `SlackApiError` / nobody-pending paths, and that no message is posted in each of those cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)