### PR TITLE
従業員アンケート: show 顧客名 in the プロジェクト select and drop its add/change links

### DIFF
--- a/kippo/projects/admin.py
+++ b/kippo/projects/admin.py
@@ -23,7 +23,7 @@ from customers.models import KippoCustomer
 from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
-from django.contrib.admin.widgets import AutocompleteSelect
+from django.contrib.admin.widgets import AutocompleteSelect, RelatedFieldWidgetWrapper
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import models
 from django.db.models import Case, JSONField, Model, OuterRef, Prefetch, QuerySet, Subquery, Sum, Value, When
@@ -215,7 +215,18 @@ def survey_project_queryset(user: KippoUser, survey_scope: str) -> QuerySet:
         queryset = queryset.filter(category__key=NON_PROJECT_CATEGORY_VALUE)
     else:
         queryset = queryset.exclude(category__key=NON_PROJECT_CATEGORY_VALUE)
-    return queryset.order_by("name")
+    # customer joined in: it is part of the option label (survey_project_display_label).
+    return queryset.select_related("customer").order_by("name")
+
+
+def survey_project_display_label(project: KippoProject) -> str:
+    """プロジェクト option text on the employee-survey selects: "{プロジェクト名} {顧客名}".
+
+    Single source of truth for the dropdown results (KippoProjectBaseAdmin.autocomplete_result_label) and
+    the selected option (label_from_instance on the survey forms), so the text cannot change the moment a
+    row is picked. Projects without a 顧客 show the name alone.
+    """
+    return f"{project.name} {project.customer.name}" if project.customer else project.name
 
 
 def _customer_autocomplete_widget(
@@ -1477,15 +1488,16 @@ class KippoProjectBaseAdmin(AllowIsStaffAdminMixin, nested_admin.NestedModelAdmi
         queryset, may_have_duplicates = super().get_search_results(request, queryset, search_term)
         survey_scope = request.GET.get(SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM)
         if survey_scope:
-            queryset = queryset.filter(pk__in=survey_project_queryset(request.user, survey_scope).values("pk"))
+            # customer joined in: it is part of each result's label (autocomplete_result_label).
+            queryset = queryset.filter(pk__in=survey_project_queryset(request.user, survey_scope).values("pk")).select_related("customer")
         return queryset, may_have_duplicates
 
     @staticmethod
     def autocomplete_result_label(obj: KippoProject) -> str:
         # Read by KippoAutocompleteJsonView. KippoProject.__str__ renders "KippoProject(顧客名 名前)", but the
-        # survey forms label the select with project.name (label_from_instance) -- without this the option
-        # text would change the moment a row is picked from the dropdown.
-        return obj.name
+        # survey forms label the select with "プロジェクト名 顧客名" (label_from_instance) -- without this the
+        # option text would change the moment a row is picked from the dropdown.
+        return survey_project_display_label(obj)
 
     @admin.display(description=_("請求方法"), ordering="contract__billing_type")
     def get_contract_billing_type_display(self, obj: KippoProject) -> str:
@@ -2704,6 +2716,16 @@ class KippoProjectUserStatisfactionResultAdmin(AllowIsStaffAdminMixin, UserCreat
             )
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
+    def formfield_for_dbfield(self, db_field: models.Field, request: DjangoRequest, **kwargs):
+        # The survey form only *selects* a プロジェクト -- drop the ＋ / ✎ (add / change) links the admin puts
+        # beside a related select, so it is not a side door into project maintenance. Wrapping happens in
+        # formfield_for_dbfield (after formfield_for_foreignkey), so the flags have to be cleared here.
+        formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if db_field.name == "project" and isinstance(getattr(formfield, "widget", None), RelatedFieldWidgetWrapper):
+            formfield.widget.can_add_related = False
+            formfield.widget.can_change_related = False
+        return formfield
+
     def get_project_name(self, obj: KippoProjectUserStatisfactionResult | None = None) -> str:
         result = "-"
         if obj and obj.project and obj.project.name:
@@ -2733,14 +2755,11 @@ class KippoProjectUserStatisfactionResultAdmin(AllowIsStaffAdminMixin, UserCreat
         # update user field with logged user as default
         form = super().get_form(request, obj, **kwargs)
 
-        def get_project_display_name(project: KippoProject) -> str:
-            return project.name
-
         if "project" in form.base_fields:
             open_projects = survey_project_queryset(request.user, self.SURVEY_SCOPE)
             form.base_fields["project"].initial = open_projects.first()
             form.base_fields["project"].queryset = open_projects
-            form.base_fields["project"].label_from_instance = get_project_display_name
+            form.base_fields["project"].label_from_instance = survey_project_display_label
         return form
 
     def has_change_permission(self, request: DjangoRequest, obj: KippoProjectUserStatisfactionResult | None = None) -> bool:
@@ -2855,14 +2874,11 @@ class KippoProjectUserMonthlyStatisfactionResultAdmin(AllowIsStaffAdminMixin, Us
         form = super().get_form(request, obj, **kwargs)
         form.request = request
 
-        def get_project_display_name(project: KippoProject) -> str:
-            return project.name
-
         if "project" in form.base_fields:
             open_projects = survey_project_queryset(request.user, self.SURVEY_SCOPE)
             form.base_fields["project"].initial = open_projects.first()
             form.base_fields["project"].queryset = open_projects
-            form.base_fields["project"].label_from_instance = get_project_display_name
+            form.base_fields["project"].label_from_instance = survey_project_display_label
         return form
 
     def save_model(self, request: DjangoRequest, obj: KippoProjectUserMonthlyStatisfactionResult, form: Form, change: bool):

--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -2003,10 +2003,32 @@ class EmployeeSurveyProjectAutocompleteTestCase(KippoProjectAdminFixtureTestCase
         self.assertNotIn(self.closed_project.name, retrospective)
 
     def test_autocomplete_results_labelled_with_project_name(self):
-        # KippoProject.__str__ renders "KippoProject(顧客名 名前)"; the survey select shows project.name, so
-        # the AJAX results must too or the text would change the moment a row is picked.
+        # KippoProject.__str__ renders "KippoProject(顧客名 名前)"; the survey select shows
+        # "プロジェクト名 顧客名", so the AJAX results must too or the text would change the moment a row is
+        # picked. A project without a 顧客 shows the name alone.
         names = self._autocomplete_result_names(KippoProjectUserStatisfactionResult, term="survey-open-project")
         self.assertEqual(names, [self.open_project.name])
+
+    def test_autocomplete_results_labelled_with_project_name_and_customer_name(self):
+        customer = KippoCustomer.objects.create(
+            organization=self.organization,
+            name="survey-customer",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.open_project.customer = customer
+        self.open_project.save()
+
+        expected_label = f"{self.open_project.name} {customer.name}"
+        names = self._autocomplete_result_names(KippoProjectUserStatisfactionResult, term="survey-open-project")
+        self.assertEqual(names, [expected_label])
+
+        # the selected option (label_from_instance) must render identically to the dropdown result
+        modeladmin = KippoProjectUserStatisfactionResultAdmin(KippoProjectUserStatisfactionResult, self.site)
+        request = MockRequest()
+        request.user = self.superuser_no_org
+        form = modeladmin.get_form(request)
+        self.assertEqual(form.base_fields["project"].label_from_instance(self.open_project), expected_label)
 
     def test_search_results_unfiltered_without_survey_scope_param(self):
         # the changelist search box shares get_search_results and must stay unnarrowed.
@@ -2029,6 +2051,18 @@ class EmployeeSurveyProjectAutocompleteTestCase(KippoProjectAdminFixtureTestCase
                 widget = _unwrap_related_widget(response.context["adminform"].form.fields["project"].widget)
                 self.assertIsInstance(widget, SurveyScopedProjectAutocompleteSelect)
                 self.assertIn(f"{SURVEY_PROJECT_AUTOCOMPLETE_SCOPE_PARAM}={expected_scope}", widget.get_url())
+
+    def test_retrospective_survey_project_field_offers_no_add_or_change_links(self):
+        # プロジェクト is select-only on the survey form: the admin's ＋ / ✎ related-object links are dropped.
+        response = self.client.get(reverse("admin:projects_kippoprojectuserstatisfactionresult_add"))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        widget = response.context["adminform"].form.fields["project"].widget
+        self.assertFalse(widget.can_add_related)
+        self.assertFalse(widget.can_change_related)
+
+        content = response.content.decode()
+        self.assertNotIn('id="add_id_project"', content)
+        self.assertNotIn('id="change_id_project"', content)
 
     def test_survey_add_page_preselects_project_from_query_param(self):
         # the ?project=<id> link that request_employee_survey_action posts to Slack must open the form with


### PR DESCRIPTION
## What

Two changes to the 振り返り従業員アンケート (`/admin/projects/kippoprojectuserstatisfactionresult/add/`) プロジェクト field.

### 1. Options read "{プロジェクト名} {顧客名}"

The select showed the bare project name, which is ambiguous when several customers run similarly named projects. Both ends of the widget now use a single helper, `survey_project_display_label`:

- `KippoProjectBaseAdmin.autocomplete_result_label` — the select2 AJAX results.
- `label_from_instance` on the survey forms — the selected option.

Sharing one helper is required, not cosmetic: if the two disagree the option text changes the moment a row is picked from the dropdown. A project without a 顧客 still shows the name alone.

`customer` is `select_related` on the survey queryset and on the scope-filtered autocomplete results, so the 顧客名 does not cost a query per option.

**Scope note:** the AJAX endpoint is served by `KippoProjectAdmin` and shared with the （月）従業員アンケート admin, so that form's label follows the same format. Its dropdown is restricted to 非案件 rows, which carry no 顧客, so it renders unchanged in practice — and keeping the two consistent is required anyway, since one endpoint labels both dropdowns.

### 2. No add / change links on the field

プロジェクト is select-only on this form — the ＋ (add another) and ✎ (change selected) related-object links are dropped so the survey is not a side door into project maintenance. The wrapper is applied by `formfield_for_dbfield` *after* `formfield_for_foreignkey` returns, so the flags are cleared in a `formfield_for_dbfield` override rather than the existing FK hook.

The 🔍 view link stays (read-only navigation). The 🗑 delete link was never rendered — Django suppresses it when the FK is `on_delete=CASCADE`, which this one is. Applies to the 振り返り admin only; the （月）admin is untouched.

## Tests

- `test_autocomplete_results_labelled_with_project_name_and_customer_name` — the AJAX label and the selected-option label are identical, and both carry the 顧客名.
- `test_retrospective_survey_project_field_offers_no_add_or_change_links` — widget flags are off and `add_id_project` / `change_id_project` are absent from the rendered page. Verified it fails without the change.
- The existing no-顧客 label test is unchanged and still passes.

`projects.tests.test_admin` — 204 tests, OK. Full `projects` app — 784 tests, only the 12 documented pre-existing S3/AWS-credential errors (CSV / download / weekly-effort admin). `poe check` clean on both changed files.

Follow-up to #392 (the employee-survey searchable selects).
