### PR TITLE
Assert the rendered プロジェクト option carries the 顧客名

### DIFF
--- a/kippo/projects/tests/test_admin.py
+++ b/kippo/projects/tests/test_admin.py
@@ -2009,16 +2009,19 @@ class EmployeeSurveyProjectAutocompleteTestCase(KippoProjectAdminFixtureTestCase
         names = self._autocomplete_result_names(KippoProjectUserStatisfactionResult, term="survey-open-project")
         self.assertEqual(names, [self.open_project.name])
 
-    def test_autocomplete_results_labelled_with_project_name_and_customer_name(self):
+    def _assign_customer_to_open_project(self, name: str = "survey-customer") -> KippoCustomer:
         customer = KippoCustomer.objects.create(
             organization=self.organization,
-            name="survey-customer",
+            name=name,
             created_by=self.github_manager,
             updated_by=self.github_manager,
         )
         self.open_project.customer = customer
         self.open_project.save()
+        return customer
 
+    def test_autocomplete_results_labelled_with_project_name_and_customer_name(self):
+        customer = self._assign_customer_to_open_project()
         expected_label = f"{self.open_project.name} {customer.name}"
         names = self._autocomplete_result_names(KippoProjectUserStatisfactionResult, term="survey-open-project")
         self.assertEqual(names, [expected_label])
@@ -2029,6 +2032,20 @@ class EmployeeSurveyProjectAutocompleteTestCase(KippoProjectAdminFixtureTestCase
         request.user = self.superuser_no_org
         form = modeladmin.get_form(request)
         self.assertEqual(form.base_fields["project"].label_from_instance(self.open_project), expected_label)
+
+    def test_add_page_renders_the_selected_option_with_project_and_customer_names(self):
+        # an autocomplete renders only the *selected* option server-side (the rest arrive over AJAX) -- this
+        # is the text actually shown in the closed select, so assert the rendered markup, not just the label
+        # callable. It must match the AJAX result above or the text changes the moment a row is picked.
+        customer = self._assign_customer_to_open_project()
+        url = reverse("admin:projects_kippoprojectuserstatisfactionresult_add")
+
+        response = self.client.get(url, {"project": str(self.open_project.id)})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertInHTML(
+            f'<option value="{self.open_project.id}" selected>{self.open_project.name} {customer.name}</option>',
+            response.content.decode(),
+        )
 
     def test_search_results_unfiltered_without_survey_scope_param(self):
         # the changelist search box shares get_search_results and must stay unnarrowed.


### PR DESCRIPTION
## What

Test-only follow-up to #393.

#393 asserted the autocomplete AJAX `text` and the `label_from_instance` return value, but nothing asserted the markup the 振り返り従業員アンケート add page actually returns. An autocomplete renders only the **selected** option server-side (the rest arrive over AJAX), and that option is the text shown in the closed select — the thing a user looks at — so it is worth pinning directly.

`test_add_page_renders_the_selected_option_with_project_and_customer_names` GETs the add page with `?project=<id>` and `assertInHTML`s the full option markup:

```html
<option value="…" selected>{プロジェクト名} {顧客名}</option>
```

Verified it fails when `survey_project_display_label` is reverted to the bare project name:

```
AssertionError: Couldn't find '<option value="…" selected>survey-open-project survey-customer</option>'
```

The customer fixture the two label tests share moved to `_assign_customer_to_open_project`.

## Context

This came out of checking a report that the deployed admin still shows the bare project name. The behaviour is correct on `main` — the AJAX endpoint returns `{'id': …, 'text': 'zzz-render-project ACME-CO'}` and the add page renders the matching option. The deployed Lambda is simply not running #393 yet: the CircleCI workflow is `check → test → build-package → generate-python-client → publish-github-release`, with no `zappa update` step, so a merge to main never updates prod. No code change is needed for that — only a deploy.

## Tests

`projects.tests.test_admin` — 205 tests, OK. `poe check` clean on the changed file.
