### PR TITLE
Add repeatable phase filter and projectsurvey_url to the project API

### DIFF
--- a/kippo/projects/serializers.py
+++ b/kippo/projects/serializers.py
@@ -475,6 +475,10 @@ class KippoProjectSerializer(serializers.ModelSerializer):
     # meeting_calendar_url_field / meeting_description_tag_field display methods.
     meeting_calendar_url = serializers.SerializerMethodField()
     meeting_description_tag = serializers.SerializerMethodField()
+    # 顧客アンケートURL — the org's google-form survey link pre-populated with this project id,
+    # mirroring the admin's get_projectsurvey_display_url column. Blank when the organization has
+    # no survey form configured.
+    projectsurvey_url = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -529,6 +533,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "problem_definition",
             "meeting_calendar_url",
             "meeting_description_tag",
+            "projectsurvey_url",
             "survey_issued",
             "assignment_rates",
             "has_requirements",
@@ -548,6 +553,7 @@ class KippoProjectSerializer(serializers.ModelSerializer):
             "parent_project_name",  # read-only label for the parent_project FK
             "meeting_calendar_url",  # MTG calendar template URL (admin parity)
             "meeting_description_tag",  # dsearch tag for meeting minutes (admin parity)
+            "projectsurvey_url",  # 顧客アンケートURL (admin parity)
             "customer_document_url",  # linked customer's contract-folder URL (kippo#34 / T04)
             "phase_display",  # human-readable status label (kippo#37 / T10)
             "category_label",  # human-readable category label (kippo#39 / T14)
@@ -719,6 +725,15 @@ class KippoProjectSerializer(serializers.ModelSerializer):
     def get_meeting_description_tag(self, obj: KippoProject) -> str:
         """Dsearch sentinel tag embedding the project id, for meeting-minutes discovery (admin parity)."""
         return obj.get_dsearch_tag()
+
+    @extend_schema_field(serializers.CharField())
+    def get_projectsurvey_url(self, obj: KippoProject) -> str:
+        """顧客アンケートURL — org survey form pre-populated with the project id (admin parity).
+
+        Empty string when the organization has no survey form configured, matching
+        KippoProject.get_projectsurvey_url() and the admin column's blank cell.
+        """
+        return obj.get_projectsurvey_url()
 
     @extend_schema_field(serializers.FloatField(allow_null=True))
     def get_allocated_effort_hours(self, obj: KippoProject) -> float | None:

--- a/kippo/projects/tests/test_api_rest.py
+++ b/kippo/projects/tests/test_api_rest.py
@@ -15,6 +15,7 @@ from rest_framework.test import APIClient
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from ..models import (
+    DEFAULT_ACTIVE_PROJECT_PHASES,
     PHASE_CONFIDENCE,
     KippoProject,
     KippoProjectBillingEntry,
@@ -587,6 +588,82 @@ class KippoProjectViewSetTestCase(TestCase):
         self.assertIn(str(self.project.id), all_ids)
         self.assertIn(str(non_project.id), all_ids)
 
+    def test_filter_by_phase(self):
+        """The repeatable `phase` parameter filters to the given phase keys (admin フェーズ filter parity)."""
+        self.project.phase = "under-contract"
+        self.project.save()
+
+        verbal_order_project = KippoProject.objects.create(
+            name="Verbal Order Project",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            phase="verbal-order",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        proposing_project = KippoProject.objects.create(
+            name="Proposing Project",
+            organization=self.organization,
+            columnset=self.project.columnset,
+            phase="proposing-low",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        # Single phase.
+        url = f"{settings.URL_PREFIX}/api/projects/?phase=verbal-order"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        result_ids = [result["id"] for result in response.json()["results"]]
+        self.assertEqual(result_ids, [str(verbal_order_project.id)])
+
+        # Repeated phase params union the phases — this is the set the active-project admin
+        # changelist shows by default, so 口頭受注 is included and 提案(低) is not.
+        query = "&".join(f"phase={phase}" for phase in DEFAULT_ACTIVE_PROJECT_PHASES)
+        url = f"{settings.URL_PREFIX}/api/projects/?{query}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        result_ids = {result["id"] for result in response.json()["results"]}
+        self.assertIn(str(self.project.id), result_ids)
+        self.assertIn(str(verbal_order_project.id), result_ids)
+        self.assertNotIn(str(proposing_project.id), result_ids)
+
+    def test_filter_by_phase_empty_value_is_ignored(self):
+        """`?phase=` (no value) is a no-op rather than a filter matching nothing."""
+        url = f"{settings.URL_PREFIX}/api/projects/?phase="
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        result_ids = [result["id"] for result in response.json()["results"]]
+        self.assertIn(str(self.project.id), result_ids)
+
+    def test_filter_by_phase_unknown_key_matches_nothing(self):
+        """An unrecognized phase key returns an empty result set (not an error)."""
+        url = f"{settings.URL_PREFIX}/api/projects/?phase=not-a-real-phase"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json()["results"], [])
+
+    def test_projectsurvey_url_matches_model(self):
+        """`projectsurvey_url` mirrors KippoProject.get_projectsurvey_url() (admin column parity)."""
+        self.organization.google_forms_project_survey_url = "https://docs.google.com/forms/d/e/TEST/viewform"
+        self.organization.google_forms_project_survey_projectid_entryid = "entry.12345"
+        self.organization.save()
+
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.project.refresh_from_db()
+        expected = self.project.get_projectsurvey_url()
+        self.assertTrue(expected)
+        self.assertEqual(response.json()["projectsurvey_url"], expected)
+
+    def test_projectsurvey_url_blank_when_org_form_unconfigured(self):
+        """Organizations without a survey form serialize an empty string, matching the blank admin cell."""
+        url = f"{settings.URL_PREFIX}/api/projects/{self.project.id}/"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.json()["projectsurvey_url"], "")
+
     def test_search_filters_by_name_substring(self):
         """Test the `search` query parameter filters projects by case-insensitive name substring."""
         match = KippoProject.objects.create(
@@ -760,6 +837,20 @@ class KippoProjectViewSetTestCase(TestCase):
 
         self.assertIn("page_size", param_names)
         self.assertIn("page", param_names)
+
+    def test_openapi_schema_exposes_repeatable_phase_query_param(self):
+        """The `phase` filter is documented as a repeatable (array) query param.
+
+        kippo-ui generates its client from this schema; if `phase` were emitted as a plain
+        string the generated client could only send one phase and the project-status route
+        could not request the admin's DEFAULT_ACTIVE_PROJECT_PHASES set.
+        """
+        schema = SchemaGenerator().get_schema(request=None, public=True)
+        projects_list_op = schema["paths"][f"{settings.URL_PREFIX}/api/projects/"]["get"]
+        phase_params = [p for p in projects_list_op.get("parameters", []) if p["name"] == "phase"]
+
+        self.assertEqual(len(phase_params), 1)
+        self.assertEqual(phase_params[0]["schema"]["type"], "array")
 
 
 class ProjectWeeklyEffortViewSetTestCase(TestCase):

--- a/kippo/projects/viewsets.py
+++ b/kippo/projects/viewsets.py
@@ -156,6 +156,7 @@ class KippoProjectViewSet(OrganizationFilterMixin, viewsets.ModelViewSet):
 
     **Filtering:**
     - is_active: Filter by display_as_active field (true/false)
+    - phase: Include only the given phase key(s); repeatable, e.g. ?phase=verbal-order&phase=under-contract
     - category: Include only the given category key (exact match)
     - exclude_category: Exclude the given category key (exact match), e.g. drop non-project rows
 
@@ -202,6 +203,17 @@ class KippoProjectViewSet(OrganizationFilterMixin, viewsets.ModelViewSet):
                 description="Filter by active status (display_as_active field)",
                 required=False,
                 type=bool,
+            ),
+            OpenApiParameter(
+                name="phase",
+                description=(
+                    "Filter by phase key. Repeatable — pass the parameter once per phase "
+                    "(e.g. ?phase=verbal-order&phase=under-contract) to match the admin's "
+                    "multi-select フェーズ filter. Unknown keys match nothing."
+                ),
+                required=False,
+                many=True,
+                type=str,
             ),
             OpenApiParameter(
                 name="category",
@@ -332,6 +344,14 @@ class KippoProjectViewSet(OrganizationFilterMixin, viewsets.ModelViewSet):
             queryset = queryset.filter(display_as_active=is_active_bool)
             if is_active_bool:
                 queryset = queryset.filter(is_closed=False)
+
+        # Filter by phase — repeatable, mirroring the admin's PhaseMultiSelectListFilter so a client
+        # can request the same in-flight set (DEFAULT_ACTIVE_PROJECT_PHASES) the active-project
+        # changelist shows by default. Empty values are dropped so `?phase=` is a no-op rather than
+        # a filter that matches nothing.
+        phases = [phase for phase in self.request.query_params.getlist("phase") if phase]
+        if phases:
+            queryset = queryset.filter(phase__in=phases)
 
         # Filter by category (exact match on the KippoProject.category key)
         category = self.request.query_params.get("category", None)


### PR DESCRIPTION
`/ui/project-status` shows a different project set than the `ActiveKippoProjectAdmin` changelist. Part of the cause is server-side: the project API cannot express the admin's default フェーズ filter, and it does not serialize the 顧客アンケートURL column at all.

Adds the two backend pieces kippo-ui needs for parity.

## `phase` query param

Repeatable, mirroring `PhaseMultiSelectListFilter`:

```
GET /api/projects/?phase=verbal-order&phase=under-contract&phase=completed
```

That set is `DEFAULT_ACTIVE_PROJECT_PHASES` — what the active-project changelist shows when the フェーズ filter has no query param. Empty values are dropped, so `?phase=` stays a no-op rather than a filter matching nothing.

Documented through `extend_schema` with `many=True` so the generated kippo-ui client can send more than one phase; a test asserts the schema emits it as an `array`, since a plain-string param would silently limit the client to a single phase.

## `projectsurvey_url` serializer field

Read-only, backed by the existing `KippoProject.get_projectsurvey_url()` — the same source as the admin's 顧客アンケートURL column. Empty string when the organization has no survey form configured, matching the blank admin cell. `organization` is already `select_related` on the viewset queryset, so this adds no per-row query.

## Tests

`projects.tests.test_api_rest.KippoProjectViewSetTestCase` — 47 tests, all passing:

- single phase, repeated phases (asserting 口頭受注 is in and 提案(低) is out), empty value ignored, unknown key returns an empty set
- `projectsurvey_url` matches the model, and is blank for an unconfigured org
- schema exposes `phase` as a repeatable array

Full `projects.tests.test_api_rest` module: 135 tests, all passing. `ruff check` clean.

Refs kiconiaworks/kippo#56