### PR TITLE
Bound personal-holiday deduction by duration, not by the window end

### DIFF
--- a/kippo/commons/context_processors.py
+++ b/kippo/commons/context_processors.py
@@ -1,35 +1,65 @@
+import datetime
 import logging
+from collections.abc import Container, Iterable
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.db.models import QuerySet, Sum
+from django.db.models import Sum
 from django.http.request import HttpRequest
 from django.utils import timezone
+
+from commons.definitions import PERSONAL_HOLIDAY_LOOKBACK_DAYS, SATURDAY
 
 if TYPE_CHECKING:
     from accounts.models import PersonalHoliday
 
 
 logger = logging.getLogger(__name__)
-SATURDAY = 5
 
 
-def get_personal_holiday_hours(personal_holidays: QuerySet["PersonalHoliday"], day_workhours: float, end_date: timezone.datetime.date) -> float:
-    total_days = 0
+def get_personal_holiday_workday_fractions(
+    personal_holidays: Iterable["PersonalHoliday"],
+    start_date: datetime.date,
+    end_date: datetime.date,
+) -> dict[datetime.date, float]:
+    """Map each business day covered by `personal_holidays` to the fraction of a day taken.
+
+    `PersonalHoliday.duration` is INCLUSIVE of `day`: a holiday covers
+    `day` ... `day + duration - 1`. Dates outside `[start_date, end_date]` and
+    weekends are dropped; overlapping holidays collapse onto the same date rather
+    than being counted twice.
+    """
+    covered: dict[datetime.date, float] = {}
     for holiday in personal_holidays:
-        if holiday.is_half:
-            assert holiday.duration == 1
-            total_days += 0.5
-        elif holiday.duration > 1:
-            current_date = holiday.day
-            while current_date <= end_date:
-                if current_date.weekday() < SATURDAY:  # Only increment for business days (Monday to Friday)
-                    total_days += 1
-                current_date += timezone.timedelta(days=1)
-        else:
-            total_days += 1
-    personal_holiday_hours = total_days * day_workhours
-    return personal_holiday_hours
+        duration = max(1, holiday.duration)
+        # `is_half` is only meaningful for a single-day holiday (the admin and the API
+        # only ever produce that combination); a multi-day span is always full days.
+        fraction = 0.5 if holiday.is_half and duration == 1 else 1.0
+        for offset in range(duration):
+            target_date = holiday.day + datetime.timedelta(days=offset)
+            if target_date < start_date or target_date > end_date:
+                continue
+            if target_date.weekday() >= SATURDAY:  # business days (Monday to Friday) only
+                continue
+            covered[target_date] = max(covered.get(target_date, 0.0), fraction)
+    return covered
+
+
+def get_personal_holiday_hours(
+    personal_holidays: Iterable["PersonalHoliday"],
+    day_workhours: float,
+    start_date: datetime.date,
+    end_date: datetime.date,
+    exclude_dates: Container[datetime.date] = (),
+) -> float:
+    """Hours to deduct for personal holidays falling within `[start_date, end_date]`.
+
+    Pass the window's public holidays as `exclude_dates` so a personal holiday
+    covering one is not deducted twice by the caller.
+    """
+    covered = get_personal_holiday_workday_fractions(personal_holidays, start_date=start_date, end_date=end_date)
+    total_days = sum(fraction for day, fraction in covered.items() if day not in exclude_dates)
+    return total_days * day_workhours
 
 
 def global_view_additional_context(request: HttpRequest) -> dict:
@@ -67,16 +97,24 @@ def global_view_additional_context(request: HttpRequest) -> dict:
             elif org_membership and org_membership.organization.default_holiday_country:
                 public_holidays = public_holidays.filter(country=org_membership.organization.default_holiday_country)
 
-            public_holiday_days = public_holidays.count()
-            public_holiday_hours = public_holiday_days * user_first_org.day_workhours
+            public_holiday_dates = set(public_holidays.values_list("day", flat=True))
+            public_holiday_hours = len(public_holiday_dates) * user_first_org.day_workhours
             user_weeklyeffort_expected_total -= public_holiday_hours
 
             # remove personal holidays from total
-            personal_holidays = PersonalHoliday.objects.filter(user=request.user, day__gte=week_startdate, day__lte=week_enddate)
+            # NOTE: filtered from a lookback -- the filter matches the holiday's START date, so a
+            # span beginning before the week must be included for its in-week days to be deducted.
+            personal_holidays = PersonalHoliday.objects.filter(
+                user=request.user,
+                day__gte=week_startdate - timezone.timedelta(days=PERSONAL_HOLIDAY_LOOKBACK_DAYS),
+                day__lte=week_enddate,
+            )
             personal_holiday_hours = get_personal_holiday_hours(
                 personal_holidays,
                 day_workhours=user_first_org.day_workhours,
+                start_date=week_startdate,
                 end_date=week_enddate,
+                exclude_dates=public_holiday_dates,
             )
 
             user_weeklyeffort_expected_total -= personal_holiday_hours

--- a/kippo/commons/definitions.py
+++ b/kippo/commons/definitions.py
@@ -5,6 +5,13 @@ SATURDAY = 5
 SUNDAY = 6
 MONDAY = 0
 
+# PersonalHoliday querysets filter on the holiday's START date (`day`), so a span that
+# begins before the window and runs into it is not returned by a naive `day__gte=<window
+# start>` filter. Reach this far back to catch those spans; the covered dates are then
+# clipped to the window. Matches the lookback already used by
+# accounts.viewsets._calc_available_workdays_in_month.
+PERSONAL_HOLIDAY_LOOKBACK_DAYS = 365
+
 
 class StringEnumWithChoices(str, Enum):
     @classmethod

--- a/kippo/projects/tests/test_views_weekly_effort.py
+++ b/kippo/projects/tests/test_views_weekly_effort.py
@@ -171,3 +171,145 @@ class WeeklyEffortMissingWeeksViewTestCase(TestCase):
 
         # First week should NOT be in missing weeks (all committed days are holidays)
         self.assertNotIn("2024-04-01", data["missing_weeks"])
+
+
+class WeeklyEffortExpectedHoursViewTestCase(TestCase):
+    """Tests for WeeklyEffortExpectedHoursView personal-holiday deduction.
+
+    Regression coverage for kiconiaworks/kippo#58: `get_personal_holiday_hours()`
+    bounded its walk by `end_date` instead of `PersonalHoliday.duration`, so a
+    multi-day holiday consumed every business day from its start to the end of the
+    week. `duration` is INCLUSIVE of `day` -- a holiday covers
+    `day` ... `day + duration - 1`.
+
+    The fixture org has day_workhours=8 and the member is committed Mon-Fri, so the
+    unreduced expectation is 40 hours.
+    """
+
+    fixtures = DEFAULT_FIXTURES
+
+    # 2024-04-01 is a Monday.
+    WEEK_START = datetime.date(2024, 4, 1)
+
+    def setUp(self):
+        self.holiday_country = Country(name="japan", alpha_2="jp", alpha_3="jpn", country_code="JPN", region="asia")
+        self.holiday_country.save()
+
+        created = setup_basic_project()
+        self.organization = created["KippoOrganization"]
+        self.organization.default_holiday_country = self.holiday_country
+        self.organization.save()
+
+        self.user = created["KippoUser"]
+        self.user.holiday_country = self.holiday_country
+        self.user.save()
+
+        self.membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        self.membership.monday = True
+        self.membership.tuesday = True
+        self.membership.wednesday = True
+        self.membership.thursday = True
+        self.membership.friday = True
+        self.membership.saturday = False
+        self.membership.sunday = False
+        self.membership.save()
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def _create_personal_holiday(self, day: datetime.date, duration: int = 1, is_half: bool = False) -> PersonalHoliday:
+        return PersonalHoliday.objects.create(
+            user=self.user,
+            day=day,
+            duration=duration,
+            is_half=is_half,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+    def _get_expected_hours(self, week_start: datetime.date | None = None) -> float:
+        response = self.client.get("/api/weekly-effort/expected-hours/", {"week_start": (week_start or self.WEEK_START).isoformat()})
+        self.assertEqual(response.status_code, 200)
+        return response.json()["expected_hours"]
+
+    def test_expected_hours__no_holidays(self):
+        """5 committed days x 8 hours."""
+        self.assertEqual(self._get_expected_hours(), 40)
+
+    def test_expected_hours__multiday_holiday_deducts_only_its_duration(self):
+        """A 2-day holiday deducts 2 days, not every business day through Friday.
+
+        Before the fix this walked Mon->Fri and deducted 40 hours, reporting 0.
+        """
+        self._create_personal_holiday(self.WEEK_START, duration=2)  # Mon + Tue
+
+        self.assertEqual(self._get_expected_hours(), 24)
+
+    def test_expected_hours__multiday_holiday_uses_organization_day_workhours(self):
+        """The per-day rate comes from the organization, not a hardcoded 8."""
+        self.organization.day_workhours = 7
+        self.organization.save()
+        self._create_personal_holiday(self.WEEK_START, duration=2)  # Mon + Tue
+
+        # 5 committed days x 7 = 35, minus 2 days x 7 = 14.
+        self.assertEqual(self._get_expected_hours(), 21)
+
+    def test_expected_hours__single_day_holiday(self):
+        self._create_personal_holiday(self.WEEK_START, duration=1)
+
+        self.assertEqual(self._get_expected_hours(), 32)
+
+    def test_expected_hours__half_day_holiday(self):
+        self._create_personal_holiday(self.WEEK_START, duration=1, is_half=True)
+
+        self.assertEqual(self._get_expected_hours(), 36)
+
+    def test_expected_hours__span_starting_before_the_week_is_deducted(self):
+        """A span opening the previous Friday still consumes this week's Monday.
+
+        The queryset filters on the holiday's START date, so before the fix this
+        holiday was not selected at all and nothing was deducted.
+        """
+        # Fri 2024-03-29 + 4 days -> Fri, Sat, Sun, Mon(04-01).
+        self._create_personal_holiday(datetime.date(2024, 3, 29), duration=4)
+
+        self.assertEqual(self._get_expected_hours(), 32)
+
+    def test_expected_hours__weekend_and_out_of_window_days_are_not_deducted(self):
+        """Only business days inside the Mon-Fri window count."""
+        # Thu 2024-04-04 + 5 days -> Thu, Fri, Sat, Sun, Mon(04-08).
+        # Only Thu + Fri fall in this week's window.
+        self._create_personal_holiday(datetime.date(2024, 4, 4), duration=5)
+
+        self.assertEqual(self._get_expected_hours(), 24)
+
+    def test_expected_hours__overlapping_holidays_counted_once(self):
+        """Two overlapping spans collapse onto the same dates rather than double-deducting."""
+        self._create_personal_holiday(self.WEEK_START, duration=3)  # Mon-Wed
+        self._create_personal_holiday(datetime.date(2024, 4, 3), duration=2)  # Wed-Thu
+
+        # Union is Mon, Tue, Wed, Thu -> 4 days.
+        self.assertEqual(self._get_expected_hours(), 8)
+
+    def test_expected_hours__public_holiday_inside_personal_span_not_double_deducted(self):
+        """A public holiday covered by a personal span is deducted once, not twice."""
+        PublicHoliday.objects.create(
+            country=self.holiday_country,
+            name="Public",
+            day=datetime.date(2024, 4, 3),  # Wednesday
+        )
+        self._create_personal_holiday(self.WEEK_START, duration=3)  # Mon-Wed
+
+        # Union is Mon, Tue, Wed -> 3 days. Before the fix: 40 - 8 - 40 -> clamped to 0.
+        self.assertEqual(self._get_expected_hours(), 16)
+
+    def test_expected_hours__public_holiday_outside_personal_span_still_deducted(self):
+        PublicHoliday.objects.create(
+            country=self.holiday_country,
+            name="Public",
+            day=datetime.date(2024, 4, 5),  # Friday
+        )
+        self._create_personal_holiday(self.WEEK_START, duration=2)  # Mon + Tue
+
+        # Mon, Tue personal + Fri public -> 3 days.
+        self.assertEqual(self._get_expected_hours(), 16)

--- a/kippo/projects/views.py
+++ b/kippo/projects/views.py
@@ -809,6 +809,7 @@ class WeeklyEffortExpectedHoursView(APIView):
 
         from accounts.models import PersonalHoliday, PublicHoliday
         from commons.context_processors import get_personal_holiday_hours
+        from commons.definitions import PERSONAL_HOLIDAY_LOOKBACK_DAYS
 
         week_start_str = request.query_params.get("week_start")
 
@@ -872,20 +873,24 @@ class WeeklyEffortExpectedHoursView(APIView):
         elif org_membership.organization.default_holiday_country:
             public_holidays = public_holidays.filter(country=org_membership.organization.default_holiday_country)
 
-        public_holiday_days = public_holidays.count()
-        public_holiday_hours = public_holiday_days * user_first_org.day_workhours
+        public_holiday_dates = set(public_holidays.values_list("day", flat=True))
+        public_holiday_hours = len(public_holiday_dates) * user_first_org.day_workhours
         expected_hours -= public_holiday_hours
 
-        # Subtract personal holidays
+        # Subtract personal holidays.
+        # NOTE: filtered from a lookback -- the filter matches the holiday's START date, so a
+        # span beginning before the week must be included for its in-week days to be deducted.
         personal_holidays = PersonalHoliday.objects.filter(
             user=user,
-            day__gte=week_start,
+            day__gte=week_start - timezone.timedelta(days=PERSONAL_HOLIDAY_LOOKBACK_DAYS),
             day__lte=week_enddate,
         )
         personal_holiday_hours = get_personal_holiday_hours(
             personal_holidays,
             day_workhours=user_first_org.day_workhours,
+            start_date=week_start,
             end_date=week_enddate,
+            exclude_dates=public_holiday_dates,
         )
         expected_hours -= personal_holiday_hours
 


### PR DESCRIPTION
Refs kiconiaworks/kippo#58

## Problem

`get_personal_holiday_hours()` (`kippo/commons/context_processors.py:17`) read `holiday.duration` **only as a branch predicate**. Nothing inside the loop referenced it:

```python
elif holiday.duration > 1:
    current_date = holiday.day
    while current_date <= end_date:          # ← bound is end_date, not duration
        if current_date.weekday() < SATURDAY:
            total_days += 1
        current_date += timezone.timedelta(days=1)
```

So the walk ran from the holiday's start to the end of the caller's window, counting every Mon–Fri it passed. `PersonalHoliday(day=2024-04-01, duration=2)` with `end_date` = Friday counted Mon, Tue, Wed, Thu, Fri → `total_days = 5`, `5 × 8 = 40h` deducted from a 40h expectation. `/api/weekly-effort/expected-hours/` returned **0** for a week the user actually worked Wed–Fri.

The org's `day_workhours` was applied correctly — it is the final multiplier, and it does come from `user_first_org.day_workhours`. Only the day count was wrong. The error vanished only when a holiday happened to run exactly to the window end, so a Friday holiday was right by coincidence and a Monday one maximally wrong.

## Fix

`duration` is inclusive of `day` — a holiday covers `day` … `day + duration - 1`. The count is now built from `range(duration)` and clipped to the window, the same shape `PersonalHoliday.get_weeklyeffort_hours` (`accounts/models.py:586`) and `_calc_available_workdays_in_month` (`accounts/viewsets.py:46`) already use.

New `get_personal_holiday_workday_fractions()` maps each covered business day to the fraction taken; `get_personal_holiday_hours()` sums it. Working in dates rather than a running total is what makes the two companion defects fall out cleanly.

### Two coupled defects fixed alongside

Both distort the same number, so fixing the loop alone would have left `expected_hours` wrong:

1. **Spans starting before the window deducted nothing.** Both callers filtered `day__gte=<window start>`, which matches the **start** date — a holiday opening the previous Friday and running into Monday was never selected. This is the symmetric under-count. They now filter from `PERSONAL_HOLIDAY_LOOKBACK_DAYS` (365, matching the lookback already used in `accounts/viewsets.py`) back, and the window clipping decides what counts.
2. **A public holiday inside a personal span was deducted twice**, once by each subtraction. Callers now pass their public-holiday dates as `exclude_dates`. Counting those dates as a set also drops a duplicate when neither the user nor the org has a `holiday_country` and the `PublicHoliday` queryset spans countries.

### Behaviour change worth a look

`assert holiday.duration == 1` guarding `is_half` is removed. It was a latent 500 on a record the model does not prevent, and it is stripped entirely under `python -O`. A half day is now honoured for `duration == 1` and treated as full days otherwise.

## Callers updated

- `kippo/projects/views.py:885` — `WeeklyEffortExpectedHoursView`, which feeds kippo-ui's 週の予定時間
- `kippo/commons/context_processors.py:76` — `global_view_additional_context`, the Django admin chrome's expected-hours indicator

## Tests

New `WeeklyEffortExpectedHoursViewTestCase` in `kippo/projects/tests/test_views_weekly_effort.py` — 10 cases: base expectation, multi-day deducting only its duration, per-day rate taken from the org (`day_workhours = 7` → 21h), single day, half day, span starting before the week, weekend + out-of-window days excluded, overlapping spans counted once, and public holiday inside / outside a personal span.

**6 of the 10 fail against pre-fix code** (verified by stashing the source changes and re-running) — the headline one being `AssertionError: 0 != 24`, exactly the reported symptom:

```
FAIL: test_expected_hours__multiday_holiday_deducts_only_its_duration        0 != 24
FAIL: test_expected_hours__multiday_holiday_uses_organization_day_workhours  0 != 21
FAIL: test_expected_hours__overlapping_holidays_counted_once                 0 != 8
FAIL: test_expected_hours__public_holiday_inside_personal_span_...           0 != 16
FAIL: test_expected_hours__public_holiday_outside_personal_span_...          0 != 16
FAIL: test_expected_hours__span_starting_before_the_week_is_deducted        40 != 32
```

`commons projects accounts` — 1014 tests, 13 errors, all the documented pre-existing botocore/S3-credential baseline failures (`S3CommandsTestCase.test_dump_and_load`, the CSV/download/admin-weeklyeffort group). No regressions. `uv run poe check` passes.

## Related

The kippo-ui counterpart is monkut/kippo-ui#135 (monkut/kippo-ui#133) — the weekly-effort calendar rendered only the first day of a multi-day span. The two are independent: the UI under-rendered the span, this one over-charged it.
