### PR TITLE
Display OrganizationMembership admin entries in Japanese

### DIFF
--- a/kippo/accounts/admin.py
+++ b/kippo/accounts/admin.py
@@ -111,7 +111,7 @@ class OrganizationMembershipAdmin(AllowIsStaffReadonlyMixin, UserCreatedBaseMode
         "user",
         "get_user_github_login",
         "slack_username",
-        "committed_days",
+        "get_committed_days",
         "is_project_manager",
         "is_developer",
         "is_admin",
@@ -176,10 +176,13 @@ class OrganizationMembershipAdmin(AllowIsStaffReadonlyMixin, UserCreatedBaseMode
             raise PermissionDenied(f"User({request.user}) is not an organization admin of {obj.organization}")
         super().save_model(request, obj, form, change)
 
+    @admin.display(description=_("GitHubログイン"))
     def get_user_github_login(self, obj: OrganizationMembership) -> str:
         return obj.user.github_login
 
-    get_user_github_login.short_description = _("Github Login")
+    @admin.display(description=_("稼働日数"))
+    def get_committed_days(self, obj: OrganizationMembership) -> int:
+        return obj.committed_days
 
 
 @admin.register(OrganizationInvite)

--- a/kippo/accounts/models.py
+++ b/kippo/accounts/models.py
@@ -314,17 +314,21 @@ class EmailDomain(UserCreatedBaseModel):
 
 
 class OrganizationMembership(UserCreatedBaseModel):
-    user = models.ForeignKey("KippoUser", on_delete=models.DO_NOTHING)
-    organization = models.ForeignKey("KippoOrganization", on_delete=models.DO_NOTHING)
-    email = models.EmailField(blank=True, default="", help_text=_("Email address with Organization"))
-    slack_username = models.CharField(max_length=100, blank=True, default="", help_text=_("Slack username"))
+    user = models.ForeignKey("KippoUser", on_delete=models.DO_NOTHING, verbose_name=_("ユーザー"))
+    organization = models.ForeignKey("KippoOrganization", on_delete=models.DO_NOTHING, verbose_name=_("組織"))
+    email = models.EmailField(blank=True, default="", verbose_name=_("メールアドレス"), help_text=_("Email address with Organization"))
+    slack_username = models.CharField(max_length=100, blank=True, default="", verbose_name=_("Slackユーザー名"), help_text=_("Slack username"))
     slack_user_id = models.CharField(max_length=100, blank=True, default="", help_text=_("Slack user ID"))
     slack_image_url = models.URLField(blank=True, default="", help_text=_("Slack user image URL"))
     # TODO: add OPTIONAL -- contract_start, contract_end
     # in order to define the start/stop of when the user may work
-    is_project_manager = models.BooleanField(default=False)
-    is_developer = models.BooleanField(default=True)
-    is_admin = models.BooleanField(default=False, help_text=_("Organization admin: may invite members to this organization"))
+    is_project_manager = models.BooleanField(default=False, verbose_name=_("プロジェクトマネージャー"))
+    is_developer = models.BooleanField(default=True, verbose_name=_("開発者"))
+    is_admin = models.BooleanField(
+        default=False,
+        verbose_name=_("組織管理者"),
+        help_text=_("Organization admin: may invite members to this organization"),
+    )
     # TODO: Update to allow for fractional days 1.0 - 0.0
     sunday = models.BooleanField(default=False, help_text=_("Works Sunday"))
     monday = models.BooleanField(default=True, help_text=_("Works Monday"))
@@ -341,6 +345,8 @@ class OrganizationMembership(UserCreatedBaseModel):
             "organization",
         )
         indexes = (models.Index(fields=["user_id", "organization_id"]),)
+        verbose_name = _("組織メンバー")
+        verbose_name_plural = _("組織メンバー")
 
     @property
     def committed_days(self) -> int:

--- a/kippo/accounts/tests/test_admin_organizationmembership.py
+++ b/kippo/accounts/tests/test_admin_organizationmembership.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from commons.tests import IsStaffModelAdminTestCaseBase, MockRequest
 from django.contrib.admin.sites import AdminSite
+from django.contrib.admin.templatetags.admin_list import result_headers
 from django.core.exceptions import PermissionDenied
 from django.forms import ModelChoiceField
 from django.urls import reverse
@@ -247,3 +248,49 @@ class OrganizationMembershipAdminHttpTestCase(OrganizationMembershipAdminTestCas
         # get_object() loads through the scoped get_queryset, so the object is unreachable
         self.assertIn(response.status_code, (302, 403, 404))
         self.assertTrue(OrganizationMembership.objects.filter(pk=other_membership.pk).exists())
+
+
+class OrganizationMembershipAdminJapaneseLabelTestCase(OrganizationMembershipAdminTestCaseBase):
+    """Entries are labeled in Japanese -- changelist column headers and change-form field labels."""
+
+    CHANGELIST_HEADERS = (
+        "組織",
+        "ユーザー",
+        "GitHubログイン",
+        "Slackユーザー名",
+        "稼働日数",
+        "プロジェクトマネージャー",
+        "開発者",
+        "組織管理者",
+    )
+
+    def setUp(self):
+        super().setUp()
+        self.membership = self._add_membership(self.target_user, self.organization)
+        self.client.force_login(self.superuser_no_org)
+
+    def test_changelist_column_headers_are_japanese(self):
+        response = self.client.get(reverse("admin:accounts_organizationmembership_changelist"))
+        self.assertEqual(response.status_code, 200)
+        # compare against the per-column header labels, NOT the raw page HTML: several of these
+        # headers are substrings of one another (組織 of 組織メンバー, ユーザー of Slackユーザー名),
+        # so a whole-page containment check passes even with the label dropped.
+        headers = [str(header["text"]) for header in result_headers(response.context["cl"])]
+        for header in self.CHANGELIST_HEADERS:
+            self.assertIn(header, headers)
+
+    def test_change_form_field_labels_are_japanese(self):
+        change_url = reverse("admin:accounts_organizationmembership_change", args=[self.membership.pk])
+        response = self.client.get(change_url)
+        self.assertEqual(response.status_code, 200)
+        labels = {name: str(field.label) for name, field in response.context["adminform"].form.fields.items()}
+        self.assertEqual(labels["organization"], "組織")
+        self.assertEqual(labels["user"], "ユーザー")
+        self.assertEqual(labels["slack_username"], "Slackユーザー名")
+        self.assertEqual(labels["is_project_manager"], "プロジェクトマネージャー")
+        self.assertEqual(labels["is_developer"], "開発者")
+        self.assertEqual(labels["is_admin"], "組織管理者")
+
+    def test_model_verbose_name_is_japanese(self):
+        self.assertEqual(str(OrganizationMembership._meta.verbose_name), "組織メンバー")
+        self.assertEqual(str(OrganizationMembership._meta.verbose_name_plural), "組織メンバー")


### PR DESCRIPTION
## Summary

`OrganizationMembership` renders in Japanese in the Django admin — changelist column headers, change-form field labels, and the admin index entry.

Labels are applied model-side with `verbose_name=_("…")` + `Meta.verbose_name`/`_plural`, matching the existing convention in `customers/models.py` and `projects/models.py` (rather than admin-only `@admin.display` wrappers, which would leave the change form in English).

| field | label |
|---|---|
| `user` | ユーザー |
| `organization` | 組織 |
| `email` | メールアドレス |
| `slack_username` | Slackユーザー名 |
| `is_project_manager` | プロジェクトマネージャー |
| `is_developer` | 開発者 |
| `is_admin` | 組織管理者 |
| `Meta` | 組織メンバー |

`OrganizationMembershipAdmin`: the two computed columns move to the `@admin.display(description=…)` form used elsewhere in `accounts/admin.py` — `get_user_github_login` → GitHubログイン (was the English `Github Login` via a trailing `short_description`), plus a new `get_committed_days` wrapper → 稼働日数. `list_display` swaps the bare `committed_days` property for that wrapper, since a property cannot carry a label. The property itself is untouched and its two non-admin callers (`commons/context_processors.py`, `projects/views.py`) are unaffected.

No `ModelSerializer` targets `OrganizationMembership`, so the OpenAPI schema is unaffected.

## No migration — deliberate

This PR ships **no migration**, though `makemigrations` would generate one (an `AlterModelOptions` + seven `AlterField`). That migration would be pure no-op:

- `verbose_name` is listed in `Field.non_db_attrs` (`django/db/models/fields/__init__.py`), so `BaseDatabaseSchemaEditor._field_should_be_altered()` returns `False` for all seven fields — **zero DDL**.
- `AlterModelOptions.database_forwards` is literally `pass`.
- Nothing at runtime reads migration state: the admin resolves labels through `label_for_field()` → `field.verbose_name` off `_meta`.

Verified with the file absent: `manage.py check` reports no issues and `KIPPO_TESTING=1 poe test accounts` passes 171/171, label assertions included.

**Trade-off:** `makemigrations` will report drift on `accounts` until someone folds these seven `AlterField`s into a later migration. CI does not gate this (`.circleci/config.yml` runs `ruff` + `poe test` only), so nothing fails — it just means the next person to touch an `accounts` model picks them up in their own migration.

## Out of scope

Left in English deliberately: the seven weekday booleans, `slack_user_id` / `slack_image_url`, and all `help_text`. The change form therefore still reads mixed — worth a follow-up if a fully-Japanese form is wanted.

## Test plan

- `uv run poe check` — clean
- `KIPPO_TESTING=1 uv run poe test accounts` — 171 tests OK
- New `OrganizationMembershipAdminJapaneseLabelTestCase` (3 tests) covering the rendered changelist headers, the change-form field labels, and the model `verbose_name`. The header assertions compare against the per-column labels from `result_headers(cl)` rather than the raw page HTML — several labels are substrings of one another (組織 of 組織メンバー, ユーザー of Slackユーザー名), so a whole-page containment check would pass even with a label dropped.