### PR TITLE
Display OrganizationInvite admin entries in Japanese

### DIFF
--- a/kippo/accounts/admin.py
+++ b/kippo/accounts/admin.py
@@ -196,7 +196,7 @@ class OrganizationInviteAdmin(AllowIsStaffReadonlyMixin, UserCreatedBaseModelAdm
     kiconiaworks/kippo#57.
     """
 
-    list_display = ("organization", "email", "expiration_date", "is_complete", "expiration_date", "processed_datetime")
+    list_display = ("organization", "email", "expiration_date", "is_complete", "processed_datetime")
     ordering = ("organization", "email")
     search_fields = ["email"]
 

--- a/kippo/accounts/models.py
+++ b/kippo/accounts/models.py
@@ -513,11 +513,26 @@ class KippoUser(AbstractUser):
 
 
 class OrganizationInvite(UserCreatedBaseModel):
-    organization = models.ForeignKey(KippoOrganization, on_delete=models.CASCADE)
-    email = models.EmailField(db_index=True, help_text=_("Email address to send invite to"))
-    expiration_date = models.DateField(editable=False, help_text=_("Date the invite expires"))
-    is_complete = models.BooleanField(default=False, editable=False, help_text=_("True if the invite has been processed"))
-    processed_datetime = models.DateTimeField(null=True, blank=True, editable=False, help_text=_("Date the invite was processed"))
+    organization = models.ForeignKey(KippoOrganization, on_delete=models.CASCADE, verbose_name=_("組織"))
+    email = models.EmailField(db_index=True, verbose_name=_("メールアドレス"), help_text=_("Email address to send invite to"))
+    expiration_date = models.DateField(editable=False, verbose_name=_("有効期限"), help_text=_("Date the invite expires"))
+    is_complete = models.BooleanField(
+        default=False,
+        editable=False,
+        verbose_name=_("処理済み"),
+        help_text=_("True if the invite has been processed"),
+    )
+    processed_datetime = models.DateTimeField(
+        null=True,
+        blank=True,
+        editable=False,
+        verbose_name=_("処理日時"),
+        help_text=_("Date the invite was processed"),
+    )
+
+    class Meta:
+        verbose_name = _("組織招待")
+        verbose_name_plural = verbose_name
 
     def __str__(self) -> str:
         return f"OrganizationInvite({self.organization.name} -> {self.email})"

--- a/kippo/accounts/tests/test_admin_organizationinvite.py
+++ b/kippo/accounts/tests/test_admin_organizationinvite.py
@@ -5,6 +5,7 @@ from django.contrib import admin as django_admin
 from django.contrib.admin import helpers
 from django.contrib.admin.actions import delete_selected
 from django.contrib.admin.sites import AdminSite
+from django.contrib.admin.templatetags.admin_list import result_headers
 from django.core.exceptions import PermissionDenied
 from django.test import RequestFactory
 from django.urls import reverse
@@ -369,3 +370,48 @@ class OrganizationAdminRoleModelTestCase(IsStaffModelAdminTestCaseBase):
     def test_membership_role_defaults_false(self):
         membership = self.staffuser_with_org.get_membership(self.organization)
         self.assertFalse(membership.is_admin)
+
+
+class OrganizationInviteAdminJapaneseLabelTestCase(IsStaffModelAdminTestCaseBase):
+    """Entries are labeled in Japanese -- changelist column headers and change-form field labels."""
+
+    CHANGELIST_HEADERS = ("組織", "メールアドレス", "有効期限", "処理済み", "処理日時")
+
+    def setUp(self):
+        super().setUp()
+        self.invite = OrganizationInvite.objects.create(
+            organization=self.organization,
+            email=f"invitee@{self.organization_domain}",
+            created_by=self.github_manager,
+            updated_by=self.github_manager,
+        )
+        self.client.force_login(self.superuser_no_org)
+
+    def test_changelist_column_headers_are_japanese(self):
+        response = self.client.get(reverse("admin:accounts_organizationinvite_changelist"))
+        self.assertEqual(response.status_code, 200)
+        # compare against the per-column header labels, NOT the raw page HTML: 組織 is a substring
+        # of the 組織招待 page title, so a whole-page containment check would pass regardless.
+        headers = [str(header["text"]) for header in result_headers(response.context["cl"])]
+        for header in self.CHANGELIST_HEADERS:
+            self.assertIn(header, headers)
+
+    def test_changelist_does_not_repeat_a_column(self):
+        response = self.client.get(reverse("admin:accounts_organizationinvite_changelist"))
+        self.assertEqual(response.status_code, 200)
+        headers = [str(header["text"]) for header in result_headers(response.context["cl"])]
+        self.assertEqual(len(headers), len(set(headers)))
+
+    def test_change_form_field_labels_are_japanese(self):
+        change_url = reverse("admin:accounts_organizationinvite_change", args=[self.invite.pk])
+        response = self.client.get(change_url)
+        self.assertEqual(response.status_code, 200)
+        labels = {name: str(field.label) for name, field in response.context["adminform"].form.fields.items()}
+        # expiration_date/is_complete/processed_datetime are editable=False, so the form carries
+        # only these two; their headers are covered by the changelist test above.
+        self.assertEqual(labels["organization"], "組織")
+        self.assertEqual(labels["email"], "メールアドレス")
+
+    def test_model_verbose_name_is_japanese(self):
+        self.assertEqual(str(OrganizationInvite._meta.verbose_name), "組織招待")
+        self.assertEqual(str(OrganizationInvite._meta.verbose_name_plural), "組織招待")


### PR DESCRIPTION
## Summary

Follows #398, applying the same treatment to `OrganizationInvite`.

| field | label |
|---|---|
| `organization` | 組織 |
| `email` | メールアドレス |
| `expiration_date` | 有効期限 |
| `is_complete` | 処理済み |
| `processed_datetime` | 処理日時 |
| `Meta` (new) | 組織招待 |

The model had no `Meta`, so one was added; `verbose_name_plural` reuses `verbose_name`, matching `PersonalHoliday` two models down. `expiration_date` / `is_complete` / `processed_datetime` are `editable=False`, so they surface as changelist columns only — the change form carries just 組織 and メールアドレス.

## Drive-by fix

`OrganizationInviteAdmin.list_display` listed `expiration_date` **twice**, rendering 有効期限 as two identical columns. Django's system checks do not flag duplicate `list_display` entries (`manage.py check` is clean either way), which is why it went unnoticed. Removed, with `test_changelist_does_not_repeat_a_column` guarding it.

If that second slot was meant to be a different field, say so and I'll restore it under the right name.

## No migration

Consistent with #398. `verbose_name` is in `Field.non_db_attrs` so the `AlterField`s emit no DDL, `AlterModelOptions.database_forwards` is a no-op, and nothing at runtime reads migration state — the admin resolves labels off `_meta`.

**Standing trade-off:** `makemigrations --check --dry-run accounts` now reports **14 no-op operations** of drift (2 × `AlterModelOptions` + 12 × `AlterField`, covering both models). CI does not gate this (`.circleci/config.yml` runs `ruff` + `poe test` only). The next person to touch an `accounts` model picks these up in their own migration — which is what happened historically: `0007_alter_personalholiday_options_and_more.py` carries `AlterModelOptions … 'verbose_name': '個人休日'` bundled in alongside a `RenameField` and `AddField` for an unrelated change. Happy to add a single migration closing all 14 if preferred.

## Test plan

- `uv run poe check` — clean
- `KIPPO_TESTING=1 uv run poe test accounts` — 175 tests OK (was 171)
- New `OrganizationInviteAdminJapaneseLabelTestCase` (4 tests): changelist headers, no-duplicate-column guard, change-form labels, model `verbose_name`. Header assertions compare against `result_headers(cl)` rather than raw page HTML, since 組織 is a substring of the 組織招待 page title.

No `ModelForm` or `ModelSerializer` is bound to `OrganizationInvite` (the only non-admin reference is a query in `accounts/functions.py:27`), so the OpenAPI schema and the kippo-ui client are unaffected.